### PR TITLE
Class fix for menubar

### DIFF
--- a/src/components/menubar/Menubar.vue
+++ b/src/components/menubar/Menubar.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-menubar p-component'">
+    <div class="p-menubar p-component">
         <MenubarSub :model="model" :root="true" />
         <div class="p-menubar-custom" v-if="$slots.default">
             <slot></slot>


### PR DESCRIPTION
There was an extra single quote in the class name in the Menubar component. This caused the CSS for this component to break.