### PR TITLE
Fixed broken today button in the Calendar component

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -695,7 +695,10 @@ export default {
             }
 
             DomHandler.find(this.$refs.overlay, '.p-datepicker-calendar td span:not(.p-disabled)').forEach(cell => cell.tabIndex = -1);
-            event.currentTarget.focus();
+
+            if (event) {
+                event.currentTarget.focus();
+            }
 
             if (this.isMultipleSelection() && this.isSelected(dateMeta)) {
                 let newValue = this.value.filter(date => !this.isDateEquals(date, dateMeta));


### PR DESCRIPTION
When clicking the today button in the calendar there was a broken reference to the event.