### PR TITLE
#194 - DataTable rowSelect event triggers rowClick

### DIFF
--- a/src/components/datatable/RowCheckbox.vue
+++ b/src/components/datatable/RowCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-checkbox p-component" @click="onClick">
+    <div class="p-checkbox p-component" @click.stop="onClick">
         <div class="p-hidden-accessible">
            <input ref="input" type="checkbox" :checked="checked" @focus="onFocus($event)" @blur="onBlur($event)" :disabled="disabled">
         </div>

--- a/src/components/datatable/RowRadioButton.vue
+++ b/src/components/datatable/RowRadioButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-radiobutton p-component" @click="onClick">
+    <div class="p-radiobutton p-component" @click.stop="onClick">
         <div class="p-hidden-accessible">
            <input ref="input" type="radio" :checked="checked" @focus="onFocus($event)" @blur="onBlur($event)" :disabled="disabled">
         </div>

--- a/src/views/datatable/DataTableSelectionDemo.vue
+++ b/src/views/datatable/DataTableSelectionDemo.vue
@@ -61,7 +61,6 @@
                 <Column field="brand" header="Brand"></Column>
                 <Column field="color" header="Color"></Column>
             </DataTable>
-			<p>Selected car: {{selectedCar3}}</p>
 
             <h3>Checkbox</h3>
             <p>Multiple selection can also be handled using checkboxes by enabling the selectionMode property of column as "multiple".</p>
@@ -72,7 +71,6 @@
                 <Column field="brand" header="Brand"></Column>
                 <Column field="color" header="Color"></Column>
             </DataTable>
-			<p>Selected cars: {{selectedCars3}}</p>
 		</div>
 
         <div class="content-section documentation">

--- a/src/views/datatable/DataTableSelectionDemo.vue
+++ b/src/views/datatable/DataTableSelectionDemo.vue
@@ -61,6 +61,7 @@
                 <Column field="brand" header="Brand"></Column>
                 <Column field="color" header="Color"></Column>
             </DataTable>
+			<p>Selected car: {{selectedCar3}}</p>
 
             <h3>Checkbox</h3>
             <p>Multiple selection can also be handled using checkboxes by enabling the selectionMode property of column as "multiple".</p>
@@ -71,6 +72,7 @@
                 <Column field="brand" header="Brand"></Column>
                 <Column field="color" header="Color"></Column>
             </DataTable>
+			<p>Selected cars: {{selectedCars3}}</p>
 		</div>
 
         <div class="content-section documentation">

--- a/src/views/datatable/DataTableSelectionDemo.vue
+++ b/src/views/datatable/DataTableSelectionDemo.vue
@@ -54,7 +54,7 @@
 
             <h3>RadioButton</h3>
             <p>Single selection can also be handled using radio buttons by enabling the selectionMode property of column as "single".</p>
-			<DataTable :value="cars" :selection.sync="selectedCar3" dataKey="vin">
+			<DataTable :value="cars" :selection.sync="selectedCar3" dataKey="vin" :row-hover="true" @row-select="onRowSelect" @row-unselect="onRowUnselect" @row-click="onRowClick">
                 <Column selectionMode="single" headerStyle="width: 3em"></Column>
                 <Column field="vin" header="Vin"></Column>
                 <Column field="year" header="Year"></Column>
@@ -64,7 +64,7 @@
 
             <h3>Checkbox</h3>
             <p>Multiple selection can also be handled using checkboxes by enabling the selectionMode property of column as "multiple".</p>
-			<DataTable :value="cars" :selection.sync="selectedCars3" dataKey="vin">
+			<DataTable :value="cars" :selection.sync="selectedCars3" dataKey="vin" :row-hover="true" @row-select="onRowSelect" @row-unselect="onRowUnselect" @row-click="onRowClick">
                 <Column selectionMode="multiple" headerStyle="width: 3em"></Column>
                 <Column field="vin" header="Vin"></Column>
                 <Column field="year" header="Year"></Column>
@@ -209,7 +209,10 @@ export default {
         },
         onRowUnselect(event) {
             this.$toast.add({severity: 'warn', summary: 'Car Unselected', detail: 'Vin: ' + event.data.vin, life: 3000});
-        }
+        },
+		onRowClick(event) {
+			this.$toast.add({severity: "info", summary: "Car Clicked", detail: "Vin: " + event.data.vin, life: 3000});
+		}
     },
     components: {
         'DataTableSubMenu': DataTableSubMenu

--- a/src/views/splitbutton/SplitButtonDoc.vue
+++ b/src/views/splitbutton/SplitButtonDoc.vue
@@ -53,7 +53,7 @@ export default {
 </CodeHighlight>
 
                 <h3>MenuModel</h3>
-                <p>SplitButton uses the common MenuModel API to define the items, visit <router-link to="/theming">MenuModel API</router-link> for details.
+                <p>SplitButton uses the common MenuModel API to define the items, visit <router-link to="/menumodel">MenuModel API</router-link> for details.
 
 				<h3>Severity</h3>
 				<p>Different color options are available as severity levels.</p>


### PR DESCRIPTION
Fixing `row-select` propagation to prevent from firing `row-click`.
Related to the issue #194 