### PR TITLE
Fixed autoLayout not working

### DIFF
--- a/src/components/treetable/TreeTable.vue
+++ b/src/components/treetable/TreeTable.vue
@@ -888,7 +888,7 @@ export default {
 }
 
 .p-treetable-auto-layout > .p-treetable-wrapper > table {
-    table-layout: auto;
+    table-layout: auto !important;
 }
 
 .p-treetable-hoverable-rows .p-treetable-tbody > tr.p-highlight {


### PR DESCRIPTION
Property autoLayout of TreeTable was not working because of missing !important.