### PR TITLE
TabView changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Editor directories and files
+.vs
 .idea
 .vscode
 *.suo

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #FFB300;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #FFA000;
 }
-body a:active {
+body .p-component a:active {
   color: #FF8F00;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #1f7ed0;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #1b71bb;
 }
-body a:active {
+body .p-component a:active {
   color: #1864a6;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #1ea04c;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #1b9044;
 }
-body a:active {
+body .p-component a:active {
   color: #18803c;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #cc285c;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #b72452;
 }
-body a:active {
+body .p-component a:active {
   color: #a32049;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/nova-colored/theme.css
+++ b/public/themes/nova-colored/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #007ad9;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #116fbf;
 }
-body a:active {
+body .p-component a:active {
   color: #005b9f;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/nova-dark/theme.css
+++ b/public/themes/nova-dark/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #007ad9;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #116fbf;
 }
-body a:active {
+body .p-component a:active {
   color: #005b9f;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/nova-light/theme.css
+++ b/public/themes/nova-light/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #007ad9;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #116fbf;
 }
-body a:active {
+body .p-component a:active {
   color: #005b9f;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/nova-vue/theme.css
+++ b/public/themes/nova-vue/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #41b883;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #318c63;
 }
-body a:active {
+body .p-component a:active {
   color: #246749;
 }
 body .p-disabled, body .p-component:disabled {

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -29,25 +29,23 @@
   src: local("Open Sans Bold"), local("OpenSans-Bold"), url("./fonts/open-sans-v15-latin-700.eot?#iefix") format("embedded-opentype"), url("./fonts/open-sans-v15-latin-700.woff2") format("woff2"), url("./fonts/open-sans-v15-latin-700.woff") format("woff"), url("./fonts/open-sans-v15-latin-700.ttf") format("truetype"), url("./fonts/open-sans-v15-latin-700.svg#OpenSans") format("svg");
   /* Legacy iOS */
 }
-* {
+
+body .p-component {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-body .p-component {
   font-family: "Open Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
   text-decoration: none;
 }
-body a {
+body .p-component a {
   color: #7B95A3;
   text-decoration: none;
 }
-body a:hover {
+body .p-component a:hover {
   color: #6c8999;
 }
-body a:active {
+body .p-component a:active {
   color: #617c8a;
 }
 body .p-disabled, body .p-component:disabled {

--- a/src/components/tabpanel/TabPanel.vue
+++ b/src/components/tabpanel/TabPanel.vue
@@ -26,6 +26,7 @@ export default {
     watch: {
         active(newValue) {
             this.d_active = newValue;
+            if (newValue) this.$emit("activated", this);
         }
     }
 }

--- a/src/components/tabpanel/TabPanel.vue
+++ b/src/components/tabpanel/TabPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-tabview-panel" role="tabpanel" v-show="d_active">
+    <div class="p-tabview-panel" role="tabpanel" v-show="d_visible">
         <slot></slot>
     </div>
 </template>
@@ -10,16 +10,20 @@ export default {
     props: {
         header: null,
         active: Boolean,
-        disabled: Boolean
+        disabled: Boolean,
+        hidden: Boolean
     },
     data() {
         return {
-            d_active: this.active
+            d_visible: this.active && !this.hidden
         }
     },
     watch: {
         active(newValue) {
-            this.d_active = newValue;
+            this.d_visible = newValue && this.hidden;
+        },
+        hidden(newValue) {
+            this.d_visible = this.active && newValue;
         }
     }
 }

--- a/src/components/tabpanel/TabPanel.vue
+++ b/src/components/tabpanel/TabPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-tabview-panel" role="tabpanel" v-show="d_visible">
+    <div class="p-tabview-panel" role="tabpanel" v-show="c_visible">
         <slot></slot>
     </div>
 </template>
@@ -15,15 +15,17 @@ export default {
     },
     data() {
         return {
-            d_visible: this.active && !this.hidden
+            d_active: false
+        };
+    },
+    computed: {
+        c_visible: function() {
+            return this.d_active && !this.hidden;
         }
     },
     watch: {
         active(newValue) {
-            this.d_visible = newValue && this.hidden;
-        },
-        hidden(newValue) {
-            this.d_visible = this.active && newValue;
+            this.d_active = newValue;
         }
     }
 }

--- a/src/components/tabview/TabView.vue
+++ b/src/components/tabview/TabView.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="p-tabview p-component p-tabview-top">
         <ul class="p-tabview-nav p-reset" role="tablist">
-            <li role="presentation" v-for="(tab, i) of tabs" :key="tab.header || i" :class="['p-unselectable-text', {'p-highlight': (tab.d_visible), 'p-disabled': tab.disabled, 'p-hidden': tab.hidden}]">
-                <a role="tab" @click="onTabClick($event, tab)" @keydown="onTabKeydown($event, tab)" :tabindex="tab.disabled ? null : '0'" :aria-selected="tab.d_visible">
+            <li role="presentation" v-for="(tab, i) of tabs" :key="tab.header || i" :class="['p-unselectable-text', {'p-highlight': (tab.c_visible), 'p-disabled': tab.disabled, 'p-hidden': tab.hidden}]">
+                <a role="tab" @click="onTabClick($event, tab)" @keydown="onTabKeydown($event, tab)" :tabindex="tab.disabled ? null : '0'" :aria-selected="tab.c_visible">
                     <span class="p-tabview-title" v-if="tab.header">{{tab.header}}</span>
                     <TabPanelHeaderSlot :tab="tab" v-if="tab.$scopedSlots.header" />
                 </a>
@@ -39,7 +39,7 @@ export default {
     },
     methods: {
         onTabClick(event, tab) {
-            if (!tab.disabled && !tab.d_visible) {
+            if (!tab.disabled && !tab.c_visible) {
                 this.activateTab(tab);
 
                 this.$emit('tab-change', {
@@ -51,7 +51,7 @@ export default {
         activateTab(tab) {
             for (let i = 0; i < this.tabs.length; i++) {
                 let active = this.tabs[i] === tab;
-                this.tabs[i].d_visible = active;
+                this.tabs[i].d_active = active;
                 this.tabs[i].$emit('update:active', active);
             }
         },
@@ -60,23 +60,25 @@ export default {
                 this.onTabClick(event, tab);
             }
         },
-        findActiveTab() {
-            let activeTab;
+        findVisibleTabs() {
+            var visibleTabs = new Array();
             for (let i = 0; i < this.tabs.length; i++) {
                 let tab = this.tabs[i];
-                if (tab.d_visible) {
-                    activeTab = tab;
-                    break;
+                if (tab.c_visible) {
+                    visibleTabs[visibleTabs.length] = tab;
                 }
             }
-
-            return activeTab;
+            return visibleTabs;
         }
     },
     updated() {
-        let activeTab = this.findActiveTab();
-        if (!activeTab && this.tabs.length) {
-            this.tabs[0].d_visible = true;
+        let visibleTabs = this.findVisibleTabs();
+        if (this.tabs.length) {
+            if (visibleTabs.length == 0) {
+                this.activateTab(this.tabs[0]);
+            } else if (visibleTabs.length > 1) {
+                this.activateTab(visibleTabs[0]);
+            }
         }
     },
     computed: {

--- a/src/components/tabview/TabView.vue
+++ b/src/components/tabview/TabView.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="p-tabview p-component p-tabview-top">
         <ul class="p-tabview-nav p-reset" role="tablist">
-            <li role="presentation" v-for="(tab, i) of tabs" :key="tab.header || i" :class="['p-unselectable-text', {'p-highlight': (tab.d_active), 'p-disabled': tab.disabled}]">
-                <a role="tab" @click="onTabClick($event, tab)" @keydown="onTabKeydown($event, tab)" :tabindex="tab.disabled ? null : '0'" :aria-selected="tab.d_active">
+            <li role="presentation" v-for="(tab, i) of tabs" :key="tab.header || i" :class="['p-unselectable-text', {'p-highlight': (tab.d_visible), 'p-disabled': tab.disabled, 'p-hidden': tab.hidden}]">
+                <a role="tab" @click="onTabClick($event, tab)" @keydown="onTabKeydown($event, tab)" :tabindex="tab.disabled ? null : '0'" :aria-selected="tab.d_visible">
                     <span class="p-tabview-title" v-if="tab.header">{{tab.header}}</span>
                     <TabPanelHeaderSlot :tab="tab" v-if="tab.$scopedSlots.header" />
                 </a>
@@ -39,7 +39,7 @@ export default {
     },
     methods: {
         onTabClick(event, tab) {
-            if (!tab.disabled && !tab.d_active) {
+            if (!tab.disabled && !tab.d_visible) {
                 this.activateTab(tab);
 
                 this.$emit('tab-change', {
@@ -51,7 +51,7 @@ export default {
         activateTab(tab) {
             for (let i = 0; i < this.tabs.length; i++) {
                 let active = this.tabs[i] === tab;
-                this.tabs[i].d_active = active;
+                this.tabs[i].d_visible = active;
                 this.tabs[i].$emit('update:active', active);
             }
         },
@@ -64,7 +64,7 @@ export default {
             let activeTab;
             for (let i = 0; i < this.tabs.length; i++) {
                 let tab = this.tabs[i];
-                if (tab.d_active) {
+                if (tab.d_visible) {
                     activeTab = tab;
                     break;
                 }
@@ -76,7 +76,7 @@ export default {
     updated() {
         let activeTab = this.findActiveTab();
         if (!activeTab && this.tabs.length) {
-            this.tabs[0].d_active = true;
+            this.tabs[0].d_visible = true;
         }
     },
     computed: {
@@ -112,6 +112,10 @@ export default {
     margin: 0 .125em 1px 0;
     padding: 0;
     white-space: nowrap;
+}
+
+.p-tabview .p-tabview-nav li.p-hidden {
+    display: none;
 }
 
 .p-tabview .p-tabview-nav li a {

--- a/src/components/tabview/TabView.vue
+++ b/src/components/tabview/TabView.vue
@@ -36,6 +36,9 @@ export default {
     },
     mounted() {
         this.d_children = this.$children;
+        for (let i = 0; i < this.tabs.length; i++) {
+            this.tabs[i].$on("activated", this.onTabActivatedByProp);
+        }
     },
     methods: {
         onTabClick(event, tab) {
@@ -47,6 +50,9 @@ export default {
                     tab: tab
                 });
             }
+        },
+        onTabActivatedByProp(tab) {
+            this.activateTab(tab);
         },
         activateTab(tab) {
             for (let i = 0; i < this.tabs.length; i++) {
@@ -73,18 +79,14 @@ export default {
     },
     updated() {
         let visibleTabs = this.findVisibleTabs();
-        if (this.tabs.length) {
-            if (visibleTabs.length == 0) {
-                this.activateTab(this.tabs[0]);
-            } else if (visibleTabs.length > 1) {
-                this.activateTab(visibleTabs[0]);
-            }
+        if (visibleTabs.length == 0 && this.tabs.length) {
+            this.activateTab(this.tabs[0]);
         }
     },
     computed: {
         tabs() {
             return this.d_children.filter(child => child.$vnode.tag.indexOf('tabpanel') !== -1);
-        }
+        },
     },
     components: {
         'TabPanelHeaderSlot': TabPanelHeaderSlot


### PR DESCRIPTION
**UI component framework must not change styles of page elements not belongs to this framework.**
After including any theme of primevue the styles of links and behaviour of all div elements (it is very important!) was changed becouse of style `* { -webkit-box-sizing: border-box; }`. This style brokes any div elements that works with default box-sizing behaviour (content-box) like said in specification.

**Added 'hidden' option for tabpanel. Its allows to hide tab caption.**
Added additional commit about 'hidden' option for tabpanel. 

**Currently active page is not deactivating when another page is activated from ':active.sync="prop"'**
So multiple pages can be activated in the same time.
