### PR TITLE
Fix closable dialog focus

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -122,9 +122,9 @@ export default {
             }
         },
         focus() {
-            let focusable = DomHandler.findSingle(this.$refs.dialog, 'input,button');
-            if (focusable) {
-                focusable.focus();
+            let focusableElements = DomHandler.getFocusableElements(this.$refs.dialog);
+            if (focusableElements && focusableElements.length > 0) {
+                focusableElements[0].focus();
             }
         },
         maximize() {

--- a/src/components/utils/DomHandler.js
+++ b/src/components/utils/DomHandler.js
@@ -401,10 +401,10 @@ export default class DomHandler {
     }
 
     static getFocusableElements(element) {
-        let focusableElements = DomHandler.find(element, `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), 
-                [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), 
-                input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), select:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), 
-                textarea:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), [tabIndex]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), 
+        let focusableElements = DomHandler.find(element, `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]),
+                [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]):not([aria-label = "close"]),
+                input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), select:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]),
+                textarea:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]), [tabIndex]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden]),
                 [contenteditable]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])`
             );
 


### PR DESCRIPTION
When opening a closable dialog, the focus goes to the close button.

```html
<button aria-label="close" type="button"
    class="p-dialog-titlebar-icon p-dialog-titlebar-close p-link">...</button>
```

This button should not be focused

**Note** : this is an attempt to fix this problem, may be there is a better way to do so ?