### PR TITLE
Updated Quill import so it works with current module standards

### DIFF
--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script>
-import * as Quill from "quill";
+import Quill from "quill";
 
 export default {
     props: {


### PR DESCRIPTION
Replaced 'import * as Quill' with 'import Quill' since Quill is expected
to be a constructor not an object.

Using, for example, Parceljs to bundle a project importing primevue/editor gave me the error `e is not a constructor`, after examining this in the debugger I found that `e` (the temporary name returned by the import) was actually some kind of module object instead of the expected function constructor, additionally the expected function constructor was store as `e.default` instead.