### PR TITLE
Button slot

### DIFF
--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,8 +1,10 @@
 <template>
     <button :class="buttonClass" v-on="$listeners" type="button" v-ripple>
-        <span v-if="icon" :class="iconClass"></span>
-        <span class="p-button-label">{{label||'&nbsp;'}}</span>
-        <span class="p-badge" v-if="badge" :class="badgeClass">{{badge}}</span>
+        <slot>
+            <span v-if="icon" :class="iconClass"></span>
+            <span class="p-button-label">{{label||'&nbsp;'}}</span>
+            <span class="p-badge" v-if="badge" :class="badgeClass">{{badge}}</span>
+        </slot>
     </button>
 </template>
 


### PR DESCRIPTION
I've added a default `<slot>` inside `Button`, this enables us to pass in custom components. For example, if we'd like to use font-awesome icons instead of the built in primeicons:

```html
<Button>
  <font-awesome icon="check" />
</Button>
```

Let me know if you'd like an example added to the documentation.