### PR TITLE
Implemented custom password level check based on regular expressions

### DIFF
--- a/src/components/password/Password.d.ts
+++ b/src/components/password/Password.d.ts
@@ -3,6 +3,8 @@ import Vue from 'vue';
 export declare class Password extends Vue {
     value?: string;
     promptLabel?: string;
+    mediumCheckExpr?: string;
+    strongCheckExpr?: string;
     weakLabel?: string;
     mediumLabel?: string;
     strongLabel?: string;

--- a/src/components/password/Password.vue
+++ b/src/components/password/Password.vue
@@ -12,6 +12,14 @@ export default {
             type: String,
             default: 'Enter a password'
         },
+        mediumCheckExpr: {
+            type: String,
+            default: '^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})' // eslint-disable-line
+        },
+        strongCheckExpr: {
+            type: String,
+            default: '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})' // eslint-disable-line
+        },
         weakLabel: {
             type: String,
             default: 'Weak'
@@ -32,34 +40,24 @@ export default {
     panel: null,
     meter: null,
     info: null,
+    mediumCheckRegExp: null,
+    strongCheckRegExp: null,
+    mounted() {
+        this.mediumCheckRegExp = new RegExp(this.mediumCheckExpr);
+        this.strongCheckRegExp = new RegExp(this.strongCheckExpr);
+    },
     methods: {
         testStrength(str) {
-            let grade = 0;
-            let val;
+            let level = 0;
 
-            val = str.match('[0-9]');
-            grade += this.normalize(val ? val.length : 1/4, 1) * 25;
+            if (this.strongCheckRegExp.test(str))
+                level = 3;
+            else if (this.mediumCheckRegExp.test(str))
+                level = 2;
+            else if (str.length)
+                level = 1;
 
-            val = str.match('[a-zA-Z]');
-            grade += this.normalize(val ? val.length : 1/2, 3) * 10;
-
-            val = str.match('[!@#$%^&*?_~.,;=]');
-            grade += this.normalize(val ? val.length : 1/6, 1) * 35;
-
-            val = str.match('[A-Z]');
-            grade += this.normalize(val ? val.length : 1/6, 1) * 30;
-
-            grade *= str.length / 8;
-
-            return grade > 100 ? 100 : grade;
-        },
-        normalize(x, y) {
-            let diff = x - y;
-
-            if(diff <= 0)
-                return x / y;
-            else
-                return 1 + 0.5 * (x / (x + y/4));
+            return level;
         },
         createPanel() {
             this.panel = document.createElement('div');
@@ -119,25 +117,26 @@ export default {
                         let label = null;
                         let meterPos = null;
 
-                        if (value.length === 0) {
-                            label = this.promptLabel;
-                            meterPos = '0px 0px';
-                        }
-                        else {
-                            let score = this.testStrength(value);
-
-                            if (score < 30) {
+                        switch (this.testStrength(value)) {
+                            case 1:
                                 label = this.weakLabel;
                                 meterPos = '0px -10px';
-                            }
-                            else if (score >= 30 && score < 80) {
+                                break;
+
+                            case 2:
                                 label = this.mediumLabel;
                                 meterPos = '0px -20px';
-                            }
-                            else if (score >= 80) {
+                                break;
+
+                            case 3:
                                 label = this.strongLabel;
                                 meterPos = '0px -30px';
-                            }
+                                break;
+
+                            default:
+                                label = this.promptLabel;
+                                meterPos = '0px 0px';
+                                break;
                         }
 
                         vm.meter.style.backgroundPosition = meterPos;


### PR DESCRIPTION
The password weak level cannot be customized, so implemented a way that allow a customization using regular expressions.

Two new parameters are now accepted:
mediumCheckExpr (medium-check-expr) and strongCheckExpr (strong-check-expr).

The mediumCheckExpr has the following default value as string:
`"^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})"`

It means that medium level passwords are those that match with the following format:
- At least one lowercase
- At least one uppercase or one number
- Minimum 6 characters

The strongCheckExpr has the following default value as string:
`^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})`

It means that strong level passwords are those that match with the following format:
- At least one lowercase
- At least one uppercase
- At least one numeric
- Minimum 8 characters

Now the it's possible to customize the password level.

I think that is feature is very important because different organizations has different policies for the password.

This improvement also bring some code optimisations.