### PR TITLE
Added default slot to ProgressBar

### DIFF
--- a/src/components/progressbar/ProgressBar.vue
+++ b/src/components/progressbar/ProgressBar.vue
@@ -1,7 +1,9 @@
 <template>
     <div role="progressbar" :class="containerClass" aria-valuemin="0" :aria-valuenow="value" aria-valuemax="100">
         <div v-if="determinate" class="p-progressbar-value p-progressbar-value-animate" :style="progressStyle"></div>
-        <div v-if="determinate && value && showValue" class="p-progressbar-label">{{value + '%'}}</div>
+        <div v-if="determinate && value && showValue" class="p-progressbar-label">
+            <slot>{{value + '%'}}</slot>
+        </div>
         <div v-if="indeterminate" class="p-progressbar-indeterminate-container">
             <div class="p-progressbar-value p-progressbar-value-animate"></div>
         </div>

--- a/src/views/progressbar/ProgressBarDoc.vue
+++ b/src/views/progressbar/ProgressBarDoc.vue
@@ -25,6 +25,14 @@ data() {
 &lt;ProgressBar mode="indeterminate"/&gt;
 </CodeHighlight>
 
+                <h5>Slot</h5>
+                <p>A custom label can be placed inside the progress bar via the default slot.</p>
+<CodeHighlight>
+&lt;ProgressBar :value="value"&gt;
+    Percent Complete
+&lt;/ProgressBar&gt;
+</CodeHighlight>
+
 				<h5>Properties</h5>
 				<div class="doc-tablewrapper">
 					<table class="doc-table">


### PR DESCRIPTION
I've added a default slot to the ProgressBar component. This gives us more flexibility with the label.

Example usage:

```vue
<progress-bar :value="value">
  Percent Complete: {{ value }}%
</progress-bar>
```