### PR TITLE
Improve ProgressBar slot

### DIFF
--- a/src/components/progressbar/ProgressBar.vue
+++ b/src/components/progressbar/ProgressBar.vue
@@ -1,11 +1,11 @@
 <template>
     <div role="progressbar" :class="containerClass" aria-valuemin="0" :aria-valuenow="value" aria-valuemax="100">
         <div v-if="determinate" class="p-progressbar-value p-progressbar-value-animate" :style="progressStyle"></div>
-        <div v-if="determinate && value && showValue" class="p-progressbar-label">
-            <slot>{{value + '%'}}</slot>
-        </div>
-        <div v-if="indeterminate" class="p-progressbar-indeterminate-container">
+        <div v-else-if="indeterminate" class="p-progressbar-indeterminate-container">
             <div class="p-progressbar-value p-progressbar-value-animate"></div>
+        </div>
+        <div v-if="hasDefaultSlot || (determinate && value && showValue)" class="p-progressbar-label">
+          <slot>{{determinate ? value + '%' : ''}}</slot>
         </div>
     </div>
 </template>
@@ -44,6 +44,9 @@ export default {
         },
         determinate() {
             return this.mode === 'determinate';
+        },
+        hasDefaultSlot () {
+            return !!this.$slots.default
         }
     }
 }

--- a/src/components/progressbar/ProgressBar.vue
+++ b/src/components/progressbar/ProgressBar.vue
@@ -58,6 +58,14 @@ export default {
     overflow: hidden;
 }
 
+.p-progressbar .p-progressbar-label {
+    text-align: center;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    font-weight: bold;
+}
+
 .p-progressbar-determinate .p-progressbar-value {
     height: 100%;
     width: 0%;
@@ -68,14 +76,6 @@ export default {
 
 .p-progressbar-determinate .p-progressbar-value-animate {
     transition: width 1s ease-in-out;
-}
-
-.p-progressbar-determinate .p-progressbar-label {
-    text-align: center;
-    height: 100%;
-    width: 100%;
-    position: absolute;
-    font-weight: bold;
 }
 
 .p-progressbar-indeterminate .p-progressbar-value::before {


### PR DESCRIPTION
The default slot for `ProgressBar` only applied in `determinate` mode when a value is set.

This PR enables the default slot for both `determinate` and `indeterminate` modes.

`.p-progressbar-label` will now render if a slot is passed, regardless of mode. The CSS selector has been adjusted accordingly.

This does not break any existing functionality.