### PR TITLE
Allow custom display callbacks in resolving fields

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -93,16 +93,16 @@ export default {
     },
     methods: {
         getOptionLabel(option) {
-            return this.optionLabel ? ObjectUtils.resolveFieldData(option, this.optionLabel) : option;
+            return this.optionLabel ? ObjectUtils.resolveGetter(option, this.optionLabel) : option;
         },
         getOptionValue(option) {
-            return this.optionValue ? ObjectUtils.resolveFieldData(option, this.optionValue) : option;
+            return this.optionValue ? ObjectUtils.resolveGetter(option, this.optionValue) : option;
         },
         getOptionRenderKey(option) {
-            return this.dataKey ? ObjectUtils.resolveFieldData(option, this.dataKey) : this.getOptionLabel(option);
+            return this.dataKey ? ObjectUtils.resolveGetter(option, this.dataKey) : this.getOptionLabel(option);
         },
         isOptionDisabled(option) {
-            return this.optionDisabled ? ObjectUtils.resolveFieldData(option, this.optionDisabled) : false;
+            return this.optionDisabled ? ObjectUtils.resolveGetter(option, this.optionDisabled) : false;
         },
         getSelectedOption() {
             let selectedOption;

--- a/src/components/multiselect/MultiSelect.vue
+++ b/src/components/multiselect/MultiSelect.vue
@@ -103,16 +103,16 @@ export default {
     },
     methods: {
         getOptionLabel(option) {
-            return this.optionLabel ? ObjectUtils.resolveFieldData(option, this.optionLabel) : option;
+            return this.optionLabel ? ObjectUtils.resolveGetter(option, this.optionLabel) : option;
         },
         getOptionValue(option) {
-            return this.optionValue ? ObjectUtils.resolveFieldData(option, this.optionValue) : option;
+            return this.optionValue ? ObjectUtils.resolveGetter(option, this.optionValue) : option;
         },
         getOptionRenderKey(option) {
-            return this.dataKey ? ObjectUtils.resolveFieldData(option, this.dataKey) : this.getOptionLabel(option);
+            return this.dataKey ? ObjectUtils.resolveGetter(option, this.dataKey) : this.getOptionLabel(option);
         },
         isOptionDisabled(option) {
-            return this.optionDisabled ? ObjectUtils.resolveFieldData(option, this.optionDisabled) : false;
+            return this.optionDisabled ? ObjectUtils.resolveGetter(option, this.optionDisabled) : false;
         },
         isSelected(option) {
             let selected = false;

--- a/src/components/utils/ObjectUtils.js
+++ b/src/components/utils/ObjectUtils.js
@@ -57,6 +57,14 @@ export default class ObjectUtils {
         return a !== a && b !== b;
     }
 
+    static resolveGetter(data, getter) {
+        if (typeof getter === 'function') {
+            return getter(data);
+        } else {
+            return this.resolveFieldData(data, getter);
+        }
+    }
+
     static resolveFieldData(data, field) {
         if (data && field) {
             if (field.indexOf('.') === -1) {


### PR DESCRIPTION
I am working on a project in which I need to use a custom callback as the display value of Dropdown and MultiSelect components.

To get this done, I added a new method in ObjectUtils called "resolveGetter", which is similar to existing "resolveFieldData", but allows to pass a callback as its second parameter (and also a string - in that case, it calls "resolveFieldData"). Then I modify Dropdown and MultiSelect components to use "resolveGetter" instead of "resolveFieldData".

I think this is a very flexible feature that doesn't break any existing behavior. I've been using it for a month before creating this PR.

Suggestions for a better name or anything else are welcome :)