### PR TITLE
Fix #465 dropdown click issue

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -326,7 +326,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.$refs.overlay && !this.$refs.container.contains(event.target)) {
+                    if (this.overlayVisible && this.$refs.overlay && !this.$refs.container.contains(event.target)
+                        && !(this.appendTo && this.$refs.overlay.contains(event.target))) {
                         this.hide();
                     }
                 };


### PR DESCRIPTION
When dropdown used with `appendTo` option, clicking inside the container triggers the `outsideClick`. Because dropdown panel has a chance to be appended outside of the container.