### PR TITLE
Two new parameters containerClass and labelClass were added

### DIFF
--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -7,6 +7,7 @@ export declare class Dropdown extends Vue {
     optionValue?: any;
     optionDisabled?: boolean;
     scrollHeight?: string;
+    labelClass?: string;
     filter?: boolean;
     filterPlaceholder?: string;
     filterLocale?: string;
@@ -17,6 +18,7 @@ export declare class Dropdown extends Vue {
     showClear?: boolean;
     tabindex?: string;
     inputId?: string;
+    containerClass?: string;
     ariaLabelledBy?: string;
     appendTo?: string;
     $emit(eventName: 'input', value: string): this;

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -1,12 +1,12 @@
 <template>
-    <div ref="container" :class="containerClass" @click="onClick($event)">
+    <div ref="container" :class="rawContainerClass" @click="onClick($event)">
         <div class="p-hidden-accessible">
             <input ref="focusInput" type="text" :id="inputId" readonly :disabled="disabled" @focus="onFocus" @blur="onBlur" @keydown="onKeyDown" :tabindex="tabindex"
                 aria-haspopup="listbox" :aria-expanded="overlayVisible" :aria-labelledby="ariaLabelledBy"/>
         </div>
         <input v-if="editable" type="text" class="p-dropdown-label p-inputtext" :disabled="disabled" @focus="onFocus" @blur="onBlur" :placeholder="placeholder" :value="editableInputValue" @input="onEditableInput"
             aria-haspopup="listbox" :aria-expanded="overlayVisible">
-        <span v-if="!editable" :class="labelClass">
+        <span v-if="!editable" :class="rawLabelClass">
             <slot name="value" :value="value" :placeholder="placeholder">
                 {{label}}
             </slot>
@@ -53,7 +53,11 @@ export default {
 		scrollHeight: {
 			type: String,
 			default: '200px'
-		},
+        },
+        labelClass: {
+            type: String,
+            default: ''
+        },
 		filter: Boolean,
         filterPlaceholder: String,
         filterLocale: String,
@@ -64,11 +68,16 @@ export default {
         showClear: Boolean,
         inputId: String,
         tabindex: String,
+        containerClass: {
+            type: String,
+            default: ''
+        },
         ariaLabelledBy: null,
         appendTo: {
             type: String,
             default: null
-        }
+        },
+
     },
     data() {
         return {
@@ -419,7 +428,7 @@ export default {
             else
                 return this.options;
         },
-        containerClass() {
+        rawContainerClass() {
             return [
                 'p-dropdown p-component',
                 {
@@ -428,16 +437,18 @@ export default {
                     'p-focus': this.focused,
                     'p-inputwrapper-filled': this.value,
                     'p-inputwrapper-focus': this.focused
-                }
+                },
+                this.containerClass
             ];
         },
-        labelClass() {
+        rawLabelClass() {
             return [
                 'p-dropdown-label p-inputtext',
                 {
                     'p-placeholder': this.label === this.placeholder,
                     'p-dropdown-label-empty': !this.$scopedSlots['value'] && (this.label === 'p-emptylabel' || this.label.length === 0)
-                }
+                },
+                this.labelClass
             ];
         },
         label() {

--- a/src/views/dropdown/DropdownDoc.vue
+++ b/src/views/dropdown/DropdownDoc.vue
@@ -185,7 +185,7 @@ data() {
                                 <td>Id of the element or "body" for document where the overlay should be appended to.</td>
                             </tr>
                             <tr>
-                                <td>labelClass</td>
+                                <td>containerClass</td>
                                 <td>string</td>
                                 <td></td>
                                 <td>Additional class used by the container</td>

--- a/src/views/dropdown/DropdownDoc.vue
+++ b/src/views/dropdown/DropdownDoc.vue
@@ -184,6 +184,18 @@ data() {
                                 <td>null</td>
                                 <td>Id of the element or "body" for document where the overlay should be appended to.</td>
                             </tr>
+                            <tr>
+                                <td>labelClass</td>
+                                <td>string</td>
+                                <td></td>
+                                <td>Additional class used by the container</td>
+                            </tr>
+                            <tr>
+                                <td>labelClass</td>
+                                <td>string</td>
+                                <td></td>
+                                <td>Additional class used by the dropdown label</td>
+                            </tr>
 						</tbody>
 					</table>
 				</div>


### PR DESCRIPTION
I observed that is not possible to customize the Dropdown component with custom classes and it can create an inconsistency when the Dropdown is aligned with other form components like the InputText component when the "p-inputtext-sm" style is used.

Now is possible to pass the class "p-inputtext-sm" to the "labelClass" and to have the Dropdown with the same size of a neighbour InputText component.

I renamed the internal computed properties "containerClass" as "rawContainerClass" and "labelClass" as "rawLabelClass".  