### PR TITLE
TerminalDoc update

### DIFF
--- a/src/views/terminal/TerminalDoc.vue
+++ b/src/views/terminal/TerminalDoc.vue
@@ -176,14 +176,14 @@ export default {
                     response = "Unknown command: " + command;
             }
 
-            TerminalService.$emit('response', response);
+            TerminalService.emit('response', response);
         }
     },
     mounted() {
-        TerminalService.$on('command', this.commandHandler);
+        TerminalService.on('command', this.commandHandler);
     },
     beforeUnmount() {
-        TerminalService.$off('command', this.commandHandler);
+        TerminalService.off('command', this.commandHandler);
     }
 }
 


### PR DESCRIPTION
The TerminalService does not have $on, $off, and $emit properties. I believe this comes from the ts declaration, but in plain js, this produces an error. Even in the TerminalDemo.vue, the TerminalService uses the event listeners without the $ sign. This should be fixed, because its misleading.