### PR TITLE
Fix import useToast in Composition API example.

### DIFF
--- a/src/views/toast/ToastDoc.vue
+++ b/src/views/toast/ToastDoc.vue
@@ -51,7 +51,7 @@ export default {
 <pre v-code.script>
 <code>
 import { defineComponent } from "vue";
-import { useToast } from "primevue/useToast";
+import { useToast } from "primevue/usetoast";
 
 export default defineComponent({
     setup() {


### PR DESCRIPTION
Importing from `primevue/useToast` causes this error:
`Module not found: Error: [CaseSensitivePathsPlugin] 'C:\...\node_modules\primevue\useToast.js' does not match the corresponding path on disk 'usetoast.js'.`

When I changed to `primevue/usetoast` it started to work 👍.