### PR TITLE
SelectButton click always makes an option is selected

### DIFF
--- a/src/components/selectbutton/SelectButton.vue
+++ b/src/components/selectbutton/SelectButton.vue
@@ -57,7 +57,7 @@ export default {
                     newValue = this.modelValue ? [...this.modelValue, optionValue]: [optionValue];
             }
             else {
-                newValue = selected ? null : optionValue;
+                newValue = optionValue;
             }
 
             this.$emit('update:modelValue', newValue);


### PR DESCRIPTION
In non multiple SelectButton, when an option is clicked, the value never will be null.
Related to the issue [#494 ](https://github.com/primefaces/primevue/issues/494)