### PR TITLE
Fixed dismissableMask for Dialog

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -117,7 +117,7 @@ export default {
             this.unbindDocumentState();
         },
         onMaskClick(event) {
-            if (this.dismissableMask && this.closable && this.modal && this.mask === event.target) {
+            if (this.dismissableMask && this.closable && this.modal && this.$refs.mask === event.target) {
                 this.close();
             }
         },


### PR DESCRIPTION
`onMaskClick` did nothing because `this.mask` is undefined, it requires `this.$refs.mask`