### PR TITLE
Add focus helper method

### DIFF
--- a/src/components/inputtext/InputText.vue
+++ b/src/components/inputtext/InputText.vue
@@ -1,5 +1,5 @@
 <template>
-    <input :class="['p-inputtext p-component', {'p-filled': filled}]" :value="modelValue" @input="onInput" />
+    <input :class="['p-inputtext p-component', {'p-filled': filled}]" :value="modelValue" @input="onInput" ref="input"/>
 </template>
 
 <script>
@@ -11,6 +11,9 @@ export default {
     methods: {
         onInput(event) {
             this.$emit('update:modelValue', event.target.value);
+        },
+        focus() {
+          this.$refs.input.focus();
         }
     },
     computed: {


### PR DESCRIPTION
I propose adding a focus helper method, so that the input can be directly focused from parent component. 

e.g. in parent component:

```
<template>
...
  <InputText ref="userInput" />
...
</template>

<script>
export default {
  methods: {
    focus() {
      this.$refs.userInput.focus()
    }
  }
}
</script>
```