### PR TITLE
FileUpload fileLimit warns

### DIFF
--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -119,11 +119,11 @@ export default {
         }
     },
     duplicateIEEvent: false,
-    uploadedFileCount: 0,
     data() {
         return {
-            files: null,
-            messages: null,
+            uploadedFileCount: 0,
+            files: [],
+            messages: [],
             focused: false,
             progress: null
         }
@@ -239,7 +239,7 @@ export default {
             }
         },
         clear() {
-            this.files = null;
+            this.files = [];
             this.messages = null;
             this.$emit('clear');
 
@@ -349,11 +349,7 @@ export default {
         },
         checkFileLimit() {
             if (this.isFileLimitExceeded()) {
-                this.msgs.push({
-                    severity: 'error',
-                    summary: this.invalidFileLimitMessageSummary.replace('{0}', this.fileLimit.toString()),
-                    detail: this.invalidFileLimitMessageDetail.replace('{0}', this.fileLimit.toString())
-                });
+                this.messages.push(this.invalidFileLimitMessage.replace('{0}', this.fileLimit.toString()))
             }
         }
     },


### PR DESCRIPTION
Using `:fileLimit` causes these errors [#610 ](https://github.com/primefaces/primevue/issues/610) and 
![error](https://user-images.githubusercontent.com/32294991/98362460-50c3c300-203e-11eb-9fc2-fbbcddd9ae0b.png)

According to `Message` component, also `checkFileLimit()` fixed.