### PR TITLE
Fixed bug that prevent to raise the OutsideClickListener when click event is not propagated

### DIFF
--- a/src/components/multiselect/MultiSelect.vue
+++ b/src/components/multiselect/MultiSelect.vue
@@ -313,12 +313,12 @@ export default {
                         this.hide();
                     }
                 };
-                document.addEventListener('click', this.outsideClickListener);
+                document.addEventListener('click', this.outsideClickListener, true);
             }
         },
         unbindOutsideClickListener() {
             if (this.outsideClickListener) {
-                document.removeEventListener('click', this.outsideClickListener);
+                document.removeEventListener('click', this.outsideClickListener, true);
                 this.outsideClickListener = null;
             }
         },


### PR DESCRIPTION
I observed that in some situations the MultiSelect component is unable to listen the click event on the bindOutsideClickListener. This happen because the click propagation was stopped, however if the click action is outside of the Dialog area the outsideClickListener is successfully executed as expected.

Steps to reproduce:
1. Multiselect component is added into a Dialog component
2. Multiselect is opened
3. Click action is done inside the Dialog but outside the multiselect overlay area.

Expected behavior:
The outsideClickListener is triggered.

Reproduced behavior:
The outsideClickListener is not triggered hereby the overlay is not hidden.

I come with the solution of use useCapture option of the addEventListener, so the event is capture by the dispatched listener before than propagation is stopped. Another possible solution it could be to change "document" by "window" (I didn't test this possibility).


