### PR TITLE
Improved the mobile responsiveness for toasts

### DIFF
--- a/src/components/toast/Toast.vue
+++ b/src/components/toast/Toast.vue
@@ -97,6 +97,7 @@ export default {
 .p-toast {
     position: fixed;
     width: 25rem;
+    max-width: calc(100% - 40px);
 }
 
 .p-toast-message-content {


### PR DESCRIPTION
The toast component extends beyond the page view on small screens.
This PR set max-width for toasts.

Why '- 40px'? 
Because, we have `margin-right: 20px` or `margin-left: 20px` (depending on the 'position' attribute). So this adds 20px of margin for the opposite side, 20px + 20px = 40px. Toast is centred.

Effect:
![improveToast](https://user-images.githubusercontent.com/60690037/100393238-4b540a00-3039-11eb-8da7-1a7b4a941130.png)
