### PR TITLE
Fixed use of MenuModel's "class" property in PanelMenuSub

### DIFF
--- a/src/components/panelmenu/PanelMenuSub.vue
+++ b/src/components/panelmenu/PanelMenuSub.vue
@@ -62,7 +62,7 @@ export default {
                 this.activeItem = item;
         },
         getItemClass(item) {
-            return ['p-menuitem', item.className];
+            return ['p-menuitem', item.class];
         },
         getLinkClass(item) {
             return ['p-menuitem-link', {'p-disabled': item.disabled}];


### PR DESCRIPTION
`PanelMenu` component was ignoring `class` property of its model's items because of a typo. This PR solves that issue.