### PR TITLE
Fixed "dataKey" prop type in all components that use it

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -2,7 +2,7 @@ import Vue, { VNode } from 'vue';
 
 declare class DataTable extends Vue {
     value?: any[];
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     rows?: number;
     first?: number;
     totalRecords?: number;

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -146,7 +146,7 @@ export default {
             default: null
         },
         dataKey: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         rows: {

--- a/src/components/datatable/TableBody.vue
+++ b/src/components/datatable/TableBody.vue
@@ -121,7 +121,7 @@ export default {
             default: null
         },
         dataKey: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         expandedRowIcon: {

--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -13,7 +13,7 @@ declare class Dropdown extends Vue {
     editable?: boolean;
     placeholder?: string;
     disabled?: boolean;
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     showClear?: boolean;
     tabindex?: string;
     inputId?: string;

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -62,7 +62,10 @@ export default {
 		editable: Boolean,
 		placeholder: String,
 		disabled: Boolean,
-        dataKey: null,
+        dataKey: {
+            type: [String, Function],
+            default: null
+        },
         showClear: Boolean,
         inputId: String,
         tabindex: String,

--- a/src/components/listbox/Listbox.d.ts
+++ b/src/components/listbox/Listbox.d.ts
@@ -8,7 +8,7 @@ declare class Listbox extends Vue {
     optionDisabled?: boolean;
     listStyle?: string;
     disabled?: boolean;
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     multiple?: boolean;
     metaKeySelection?: boolean;
     filter?: boolean;

--- a/src/components/listbox/Listbox.vue
+++ b/src/components/listbox/Listbox.vue
@@ -34,7 +34,10 @@ export default {
         optionDisabled: null,
 		listStyle: null,
         disabled: Boolean,
-        dataKey: null,
+        dataKey: {
+            type: [String, Function],
+            default: null
+        },
         multiple: Boolean,
         metaKeySelection: Boolean,
         filter: Boolean,

--- a/src/components/multiselect/MultiSelect.d.ts
+++ b/src/components/multiselect/MultiSelect.d.ts
@@ -12,7 +12,7 @@ declare class MultiSelect extends Vue {
     filter?: boolean;
     tabindex?: string;
     inputId?: string;
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     filterPlaceholder?: string;
     filterLocale?: string;
     ariaLabelledBy?: string;

--- a/src/components/multiselect/MultiSelect.vue
+++ b/src/components/multiselect/MultiSelect.vue
@@ -85,7 +85,10 @@ export default {
 		filter: Boolean,
         tabindex: String,
         inputId: String,
-        dataKey: null,
+        dataKey: {
+            type: [String, Function],
+            default: null
+        },
         filterPlaceholder: String,
         filterLocale: String,
         ariaLabelledBy: null,

--- a/src/components/orderlist/OrderList.d.ts
+++ b/src/components/orderlist/OrderList.d.ts
@@ -2,7 +2,7 @@ import Vue, {VNode} from 'vue';
 
 declare class OrderList extends Vue {
     value?: any[];
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     selection?: any[];
     metaKeySelection?: boolean;
     listStyle?: any;

--- a/src/components/orderlist/OrderList.vue
+++ b/src/components/orderlist/OrderList.vue
@@ -40,7 +40,7 @@ export default {
             default: null
         },
         dataKey: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         listStyle: {

--- a/src/components/picklist/PickList.d.ts
+++ b/src/components/picklist/PickList.d.ts
@@ -3,7 +3,7 @@ import Vue, {VNode} from 'vue';
 declare class PickList extends Vue {
     value?: any[][];
     selection?: any[][];
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     metaKeySelection?: boolean;
     listStyle?: any;
     $emit(eventName: 'reorder', e: { originalEvent: Event, value: any[]; direction: string}): this;

--- a/src/components/picklist/PickList.vue
+++ b/src/components/picklist/PickList.vue
@@ -64,7 +64,7 @@ export default {
             default: () => [[],[]]
         },
         dataKey: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         listStyle: {

--- a/src/components/selectbutton/SelectButton.d.ts
+++ b/src/components/selectbutton/SelectButton.d.ts
@@ -8,7 +8,7 @@ declare class SelectButton extends Vue {
     optionDisabled?: boolean;
     multiple?: boolean;
     disabled?: boolean;
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     ariaLabelledBy?: string;
     $emit(eventName: 'input', value: any): this;
     $emit(eventName: 'focus', event: Event): this;

--- a/src/components/selectbutton/SelectButton.vue
+++ b/src/components/selectbutton/SelectButton.vue
@@ -24,7 +24,10 @@ export default {
         optionDisabled: null,
 		multiple: Boolean,
         disabled: Boolean,
-        dataKey: null,
+        dataKey: {
+            type: [String, Function],
+            default: null
+        },
         ariaLabelledBy: null
     },
     methods: {

--- a/src/components/timeline/Timeline.d.ts
+++ b/src/components/timeline/Timeline.d.ts
@@ -4,7 +4,7 @@ declare class Timeline extends Vue {
     value?: any[];
     align?: string;
     layout?: string;
-    dataKey?: string;
+    dataKey?: string | ((item: any) => any);
     $slots: {
         content: VNode[];
         opposite: VNode[];

--- a/src/components/timeline/Timeline.vue
+++ b/src/components/timeline/Timeline.vue
@@ -31,7 +31,10 @@ export default {
             mode: String,
             default: 'vertical'
         },
-        dataKey: null
+        dataKey: {
+            type: [String, Function],
+            default: null
+        }
     },
     methods: {
         getKey(item, index) {


### PR DESCRIPTION
As done with "sortField" property in #743, this PR fixes the "dataKey" property type in the following components and its corresponding type definition files:
* DataTable
* TableBody
* Dropdown
* Listbox
* MultiSelect
* OrderList
* PickList
* SelectButton
* Timeline