### PR TITLE
One fix and one improvement, sorry for a single commit

### DIFF
--- a/src/components/togglebutton/ToggleButton.vue
+++ b/src/components/togglebutton/ToggleButton.vue
@@ -1,5 +1,6 @@
 <template>
-    <div :class="buttonClass" @click="onClick($event)" role="checkbox" :aria-labelledby="ariaLabelledBy" :aria-checked="value" :tabindex="$attrs.disabled ? null : '0'" v-ripple>
+<div :class="[buttonClass,value?onClass:offClass]" @click="onClick($event)" role="checkbox"
+     :aria-labelledby="ariaLabelledBy" :aria-checked="value" :tabindex="$attrs.disabled ? null : '0'" v-ripple>
         <span v-if="hasIcon" :class="iconClass"></span>
         <span class="p-button-label">{{label}}</span>
     </div>
@@ -19,6 +20,15 @@ export default {
             type: String,
             default: 'left'
         },
+	offClass: {
+	    type: String,
+	    default: "p-togglebutton"
+	},
+	onClass: {
+	    type: String,
+	    default: "p-togglebutton p-highlight"
+	},
+	
         ariaLabelledBy: String
     },
     methods: {
@@ -33,10 +43,9 @@ export default {
     computed: {
         buttonClass() {
             return {
-                'p-button p-togglebutton p-component': true,
+                'p-button p-component': true,
                 'p-button-icon-only': this.hasIcon && !this.hasLabel,
                 'p-disabled': this.$attrs.disabled,
-                'p-highlight': this.value === true
             }
         },
         iconClass() {
@@ -50,10 +59,16 @@ export default {
             ]
         },
         hasLabel() {
-            return this.onLabel && this.onLabel.length > 0 && this.offLabel && this.offLabel.length > 0;
+	    return (
+		(this.value && this.onLabel && this.onLabel.length > 0) ||
+		    (!this.value && this.offLabel && this.offLabel.length > 0)
+	    );
         },
         hasIcon() {
-            return this.onIcon && this.onIcon.length > 0 && this.offIcon && this.offIcon.length > 0;
+	    return (
+		(this.value && this.onIcon && this.onIcon.length > 0) ||
+		    (!this.value && this.offIcon && this.offIcon.length > 0)
+	    );
         },
         label() {
             return this.hasLabel ? (this.value ? this.onLabel : this.offLabel): '&nbsp;';


### PR DESCRIPTION
1. Added onClass and offClass properties to control button class for on and off state

Now it's possible to specify on and off classes for button. 100% backward compatible

2. Fixed hasLabel() and hasIcon() to provide correct answer if only one of
on/off Label or Icon provided, enabling using label and/or icon only for
one state

If only one icon or label is present, hasLabel and hasIcon returns wrong information and button label is always &amp;nbsp;
