### PR TITLE
Add option to FileUpload to hide Upload/Cancel buttons

### DIFF
--- a/src/components/fileupload/FileUpload.d.ts
+++ b/src/components/fileupload/FileUpload.d.ts
@@ -18,6 +18,8 @@ declare class FileUpload extends Vue {
     uploadLabel?: string;
     cancelLabel?: string;
     customUpload?: boolean;
+    uploadHidden?: boolean;
+    cancelHidden?: boolean;
     $emit(eventName: 'select', e: { originalEvent: Event, files: any }): this;
     $emit(eventName: 'before-upload', e: { xhr: XMLHttpRequest, formData: any }): this;
     $emit(eventName: 'progress', e: { originalEvent: Event, progress: any }): this;

--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -6,8 +6,8 @@
                 <span class="p-button-icon p-button-icon-left pi pi-fw pi-plus"></span>
                 <span class="p-button-label">{{chooseButtonLabel}}</span>
             </span>
-            <FileUploadButton :label="uploadButtonLabel" icon="pi pi-upload" @click="upload" :disabled="uploadDisabled" />
-            <FileUploadButton :label="cancelButtonLabel" icon="pi pi-times" @click="clear" :disabled="cancelDisabled" />
+            <FileUploadButton :label="uploadButtonLabel" icon="pi pi-upload" @click="upload" :disabled="uploadDisabled" v-if="!uploadHidden" />
+            <FileUploadButton :label="cancelButtonLabel" icon="pi pi-times" @click="clear" :disabled="cancelDisabled" v-if="!cancelHidden" />
         </div>
         <div ref="content" class="p-fileupload-content" @dragenter="onDragEnter" @dragover="onDragOver" @dragleave="onDragLeave" @drop="onDrop">
             <FileUploadProgressBar :value="progress" v-if="hasFiles" />
@@ -116,7 +116,15 @@ export default {
         customUpload: {
             type: Boolean,
             default: false
-        }
+        },
+        uploadHidden: {
+            type: Boolean,
+            default: false,
+        },
+        cancelHidden: {
+            type: Boolean,
+            default: false,
+        },
     },
     duplicateIEEvent: false,
     data() {

--- a/src/views/fileupload/FileUploadDemo.vue
+++ b/src/views/fileupload/FileUploadDemo.vue
@@ -15,6 +15,12 @@
                         <p>Drag and drop files to here to upload.</p>
                     </template>
                 </FileUpload>
+                <h5>Advanced with hidden Upload/Cancel buttons</h5>
+                <FileUpload name="demo[]" url="./upload.php" :multiple="true" accept="image/*" :maxFileSize="1000000" :auto="true" :uploadHidden="true" :cancelHidden="false">
+                <template #empty>
+                    <p>Drag and drop files to here to upload.</p>
+                </template>
+                </FileUpload>
 
                 <h5>Basic</h5>
                 <FileUpload mode="basic" name="demo[]" url="./upload.php" accept="image/*" :maxFileSize="1000000" @upload="onUpload" />

--- a/src/views/fileupload/FileUploadDoc.vue
+++ b/src/views/fileupload/FileUploadDoc.vue
@@ -52,7 +52,7 @@ import FileUpload from 'primevue/fileupload';
 
 </code></pre>
 
-				<h5>File Size and File Linit</h5>
+				<h5>File Size and File Limit</h5>
 				<p>Maximium file size can be restricted using <i>maxFileSize</i> property defined in bytes. Similarly <i>fileLimit</i> is available to restrict the number of files to be uploaded.</p>
 <pre v-code>
 <code>
@@ -69,6 +69,18 @@ import FileUpload from 'primevue/fileupload';
 						invalidFileLimitMessage: 'Maximum number of files exceeded, limit is &#123;0&#125; at most.'
 					</li>
 				</ul>
+
+<h5>Hide Upload and/or Cancel buttons</h5>
+        <p>It's possible to hide the Upload button by enabling <i>uploadHidden</i> when it's not needed, for example when <i>auto</i>
+          property is enabled, upload begins as soon as file selection is completed or a file is dropped on the drop
+          area.</p>
+        <p>
+          Similarly, it's possible to hide the Cancel button by enabling <i>cancelHidden</i>.</p>
+        <pre v-code>
+<code>
+&lt;FileUpload name="demo[]" url="./upload" :auto="true" :uploadHidden="true" /&gt;
+
+</code></pre>
 
 				<h5>Request Customization</h5>
 				<p>XHR request to upload the files can be customized using the before-upload callback that passes the xhr instance and FormData object as event parameters.</p>
@@ -319,8 +331,15 @@ myUploader(event) {
 				</a>
 <pre v-code>
 <code><template v-pre>
-&lt;h3&gt;Advanced&lt;/h3&gt;
+&lt;h3&gt;Advanced&lt;/h3&gt;/Users/adil/Sites/laravel/primevue-PR/src/views/fileupload/FileUploadDemo.vue
 &lt;FileUpload name="demo[]" url="./upload.php" @upload="onUpload" :multiple="true" accept="image/*" :maxFileSize="1000000"&gt;
+    &lt;template #empty&gt;
+        &lt;p&gt;Drag and drop files to here to upload.&lt;/p&gt;
+    &lt;/template&gt;
+&lt;/FileUpload&gt;
+
+&lt;h3&gt;Advanced with hidden Upload/Cancel buttons&lt;/h3&gt;
+&lt;FileUpload name="demo[]" url="./upload.php" :auto="true" :uploadHidden="true" :multiple="true" accept="image/*" :maxFileSize="1000000"&gt;
     &lt;template #empty&gt;
         &lt;p&gt;Drag and drop files to here to upload.&lt;/p&gt;
     &lt;/template&gt;

--- a/src/views/fileupload/FileUploadDoc.vue
+++ b/src/views/fileupload/FileUploadDoc.vue
@@ -331,7 +331,7 @@ myUploader(event) {
 				</a>
 <pre v-code>
 <code><template v-pre>
-&lt;h3&gt;Advanced&lt;/h3&gt;/Users/adil/Sites/laravel/primevue-PR/src/views/fileupload/FileUploadDemo.vue
+&lt;h3&gt;Advanced&lt;/h3&gt;
 &lt;FileUpload name="demo[]" url="./upload.php" @upload="onUpload" :multiple="true" accept="image/*" :maxFileSize="1000000"&gt;
     &lt;template #empty&gt;
         &lt;p&gt;Drag and drop files to here to upload.&lt;/p&gt;


### PR DESCRIPTION
For example, when `auto` property is enabled, we don't need the **Upload** button because upload begins as soon as file selected, so we can hide it in this case.
Also if only one file is uploaded, we can hide **Cancel** button because we can remove it by the button in the right. 
