### PR TITLE
Add block style for buttons

### DIFF
--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -14,6 +14,20 @@
     flex: 1 1 auto;
 }
 
+.p-button-block {
+    display: flex;
+    flex: 1 0 auto;
+    min-width: 100% !important;
+}
+
+.p-button-compact {
+    justify-content: center;
+}
+
+.p-button-compact .p-button-label {
+    flex-grow: 0;
+}
+
 .p-button-icon-right {
     order: 1;
 }

--- a/src/views/button/ButtonDemo.vue
+++ b/src/views/button/ButtonDemo.vue
@@ -120,6 +120,15 @@
                     <Button label="Normal" icon="pi pi-check" class="p-button"  />
                     <Button label="Large" icon="pi pi-check" class="p-button-lg" />
                 </div>
+                <h5>Block Buttons</h5>
+                <div class="p-grid">
+                    <div class="p-col-12 p-md-3 p-xl-2">
+                        <Button class="p-button-block" label="Submit Form" />
+                    </div>
+                    <div class="p-col-12 p-md-3 p-xl-2">
+                        <Button class="p-button-block p-button-secondary p-button-outlined" label="Reset" />
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/src/views/button/ButtonDemo.vue
+++ b/src/views/button/ButtonDemo.vue
@@ -19,6 +19,10 @@
                 <Button label="Submit" icon="pi pi-check" />
                 <Button label="Submit" icon="pi pi-check" iconPos="right" />
 
+                <h5>Compact Icon Buttons</h5>
+                <Button class="p-button-compact" label="Submit" icon="pi pi-check" />
+                <Button class="p-button-compact" label="Submit" icon="pi pi-check" iconPos="right" />
+
                 <h5>Severities</h5>
                 <Button label="Primary" />
                 <Button label="Secondary" class="p-button-secondary" />

--- a/src/views/button/ButtonDoc.vue
+++ b/src/views/button/ButtonDoc.vue
@@ -33,6 +33,15 @@ import Button from 'primevue/button';
 
 </code></pre>
 
+                <h5>Compact Icon Buttons</h5>
+				<p>For more compact, apply <i>.p-button-compact</i> to align an icon's position to place next to the text. (Resize your desktop to tablet or mobile size see the changes)</p>
+<pre v-code>
+<code>
+&lt;Button class=&quot;p-button-compact&quot; label=&quot;Submit&quot; icon=&quot;pi pi-check&quot; /&gt;
+&lt;Button class=&quot;p-button-compact&quot; label=&quot;Submit&quot; icon=&quot;pi pi-check&quot; iconPos=&quot;right&quot; /&gt;
+
+</code></pre>
+
 				<h5>Events</h5>
 				<p>Events are defined with the standard notation.</p>
 <pre v-code>
@@ -263,6 +272,10 @@ import Button from 'primevue/button';
 &lt;Button label="Submit" icon="pi pi-check" /&gt;
 &lt;Button label="Submit" icon="pi pi-check" iconPos="right" /&gt;
 
+&lt;h5&gt;Compact Icon Buttons&lt;/h5&gt;
+&lt;Button class=&quot;p-button-compact&quot; label=&quot;Submit&quot; icon=&quot;pi pi-check&quot; /&gt;
+&lt;Button class=&quot;p-button-compact&quot; label=&quot;Submit&quot; icon=&quot;pi pi-check&quot; iconPos=&quot;right&quot; /&gt;
+
 &lt;h5&gt;Severities&lt;/h5&gt;
 &lt;Button label="Primary" /&gt;
 &lt;Button label="Secondary" class="p-button-secondary" /&gt;
@@ -409,6 +422,10 @@ export default {
                 <Button icon="pi pi-check" />
                 <Button label="Submit" icon="pi pi-check" />
                 <Button label="Submit" icon="pi pi-check" iconPos="right" />
+
+                <h5>Compact Icon Buttons</h5>
+                <Button class="p-button-compact" label="Submit" icon="pi pi-check" />
+                <Button class="p-button-compact" label="Submit" icon="pi pi-check" iconPos="right" />
 
                 <h5>Severities</h5>
                 <Button label="Primary" />

--- a/src/views/button/ButtonDoc.vue
+++ b/src/views/button/ButtonDoc.vue
@@ -134,6 +134,20 @@ import Button from 'primevue/button';
 
 </code></pre>
 
+                <h5>Block Buttons</h5>
+                <p>Apply <i>.p-button-block</i> to make a button to be a full-width button, button will grow width as its parent's width. Useful when you want to make your desire button width or an equal-width button based on <router-link to="/grid">Grid System</router-link>.</p>
+<pre v-code>
+<code>
+&lt;div class=&quot;p-grid&quot;&gt;
+    &lt;div class=&quot;p-col-12 p-md-3 p-xl-2&quot;&gt;
+        &lt;Button class=&quot;p-button-block&quot; label=&quot;Submit Form&quot; /&gt;
+    &lt;/div&gt;
+    &lt;div class=&quot;p-col-12 p-md-3 p-xl-2&quot;&gt;
+        &lt;Button class=&quot;p-button-block p-button-secondary p-button-outlined&quot; label=&quot;Reset&quot; /&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+
+</code></pre>
                 <h5>Slot</h5>
                 <p>Custom content can be placed inside the button via the default slot. Note that when slot is used, label, icon and badge properties are not included.</p>
 <pre v-code>
@@ -350,6 +364,16 @@ import Button from 'primevue/button';
     &lt;Button label="Normal" icon="pi pi-check" class="p-button"  /&gt;
     &lt;Button label="Large" icon="pi pi-check" class="p-button-lg" /&gt;
 &lt;/div&gt;
+
+&lt;h5&gt;Block Buttons&lt;/h5&gt;
+&lt;div class=&quot;p-grid&quot;&gt;
+    &lt;div class=&quot;p-col-12 p-md-3 p-xl-2&quot;&gt;
+        &lt;Button class=&quot;p-button-block&quot; label=&quot;Submit Form&quot; /&gt;
+    &lt;/div&gt;
+    &lt;div class=&quot;p-col-12 p-md-3 p-xl-2&quot;&gt;
+        &lt;Button class=&quot;p-button-block p-button-secondary p-button-outlined&quot; label=&quot;Reset&quot; /&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
 </template>
 </code></pre>
 
@@ -486,6 +510,16 @@ export default {
                     <Button label="Small" icon="pi pi-check" class="p-button-sm"  />
                     <Button label="Normal" icon="pi pi-check" class="p-button"  />
                     <Button label="Large" icon="pi pi-check" class="p-button-lg" />
+                </div>
+
+                <h5>Block Buttons</h5>
+                <div class="p-grid">
+                    <div class="p-col-12 p-md-3 p-xl-2">
+                        <Button class="p-button-block" label="Submit Form" />
+                    </div>
+                    <div class="p-col-12 p-md-3 p-xl-2">
+                        <Button class="p-button-block p-button-secondary p-button-outlined" label="Reset" />
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Make a button able to be a full-width button, button will grow width as its parent's width.
  - **Screenshot:**
![Screen Shot 2564-01-09 at 21 02 10](https://user-images.githubusercontent.com/8948091/104093593-03720500-52be-11eb-8152-1f2d13267ecd.png)

- for more compact, apply `.p-button-compact` to align an icon's position to place next to the text.
  - **Screenshot:**
![Screen Shot 2564-01-09 at 22 02 48](https://user-images.githubusercontent.com/8948091/104094947-a3339100-52c6-11eb-8b20-9d994d4eb2cf.png)
