### PR TITLE
Vue 3 + TS: fix for config.globalProperties services

### DIFF
--- a/src/components/confirmationservice/ConfirmationService.d.ts
+++ b/src/components/confirmationservice/ConfirmationService.d.ts
@@ -12,3 +12,9 @@ declare module 'vue/types/vue' {
         $confirm: ConfirmationServiceMethods;
     }
 }
+
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $confirm: ConfirmationServiceMethods;
+    }
+}

--- a/src/components/toastservice/ToastService.d.ts
+++ b/src/components/toastservice/ToastService.d.ts
@@ -14,3 +14,8 @@ declare module 'vue/types/vue' {
     }
 }
 
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $toast: ToastServiceMethods;
+    }
+}


### PR DESCRIPTION
Without this fix typescript throws this errors:
`Property '$confirm' does not exist on type 'App'.`
`Property '$toast' does not exist on type 'App'.`