### PR TITLE
Added selected filter key to emit when filtering in datatable

### DIFF
--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -377,7 +377,8 @@ export default {
             d_selectionKeys: null,
             d_expandedRowKeys: null,
             d_columnOrder: null,
-            d_editingRowKeys: null
+            d_editingRowKeys: null,
+            d_selectedFilterKey:null
         };
     },
     rowTouched: false,
@@ -427,6 +428,13 @@ export default {
         editingRows(newValue) {
             if (this.dataKey) {
                 this.updateEditingRowKeys(newValue);
+            }
+        },
+        filters(newValue, oldValue){
+            for(const key of Object.keys(oldValue)) {
+                if (newValue[key] !== oldValue[key]) {
+                    this.data.d_selectedFilterKey = key;
+                }
             }
         }
     },
@@ -628,6 +636,7 @@ export default {
 
             let filterEvent = this.createLazyLoadEvent();
             filterEvent.filteredValue = filteredValue;
+            filterEvent.selectedFilterKey = this.data.d_selectedFilterKey;
             this.$emit('filter', filterEvent);
 
             return filteredValue;


### PR DESCRIPTION
Currently there is no good way of knowing which filter was triggered when the user filters the datatable. This PR adds a watcher to the filters prop that caches the selected filter key when the user filters and emits the selected filter key when the user filters the data in the filterEvent.