### PR TITLE
Reflect actual casing of filename

### DIFF
--- a/src/components/terminalservice/package.json
+++ b/src/components/terminalservice/package.json
@@ -2,5 +2,5 @@
   "main": "./terminalservice.cjs.js",
   "module": "./terminalservice.esm.js",
   "unpkg": "./terminalservice.min.js",
-  "types": "./Terminalservice.d.ts"
+  "types": "./TerminalService.d.ts"
 }


### PR DESCRIPTION
Trivial fix for casing on typescript type definitions