### PR TITLE
#923 - Calendar seconds are locked when min/max set (additional fix after testing)

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -1080,7 +1080,7 @@ export default {
             }
             return hours;
         },
-        validateTime(hour, minute, second, pm) {
+        validateTime(hour, minute, second, pm, isMinutes, isSeconds) {
             let value = this.value;
             const convertedHour = this.convertTo24Hour(hour, pm);
             if (!this.isComparable()) {
@@ -1099,11 +1099,16 @@ export default {
                 }
                 if (this.minDate.getHours() === convertedHour) {
                     if (this.minDate.getMinutes() > minute) {
-                        return false;
-                    }
-                    if (this.minDate.getMinutes() === minute) {
-                        if (this.minDate.getSeconds() > second) {
+                        if (isMinutes || isSeconds)
                             return false;
+                        else
+                            this.currentMinute = this.minDate.getMinutes();
+                    } else if (this.minDate.getMinutes() === minute) {
+                        if (this.minDate.getSeconds() > second) {
+                            if (isSeconds)
+                                return false;
+                            else
+                                this.currentSecond = this.minDate.getSeconds();
                         }
                     }
                 }
@@ -1115,11 +1120,16 @@ export default {
                 }
                 if (this.maxDate.getHours() === convertedHour) {
                     if (this.maxDate.getMinutes() < minute) {
-                        return false;
-                    }
-                    if (this.maxDate.getMinutes() === minute) {
+                        if (isMinutes || isSeconds)
+                            return false;
+                        else
+                            this.currentMinute = this.maxDate.getMinutes();
+                    } else if (this.maxDate.getMinutes() === minute) {
                       if (this.maxDate.getSeconds() < second) {
-                          return false;
+                          if (isSeconds)
+                            return false;
+                        else
+                          this.currentSecond = this.maxDate.getSeconds();
                       }
                     }
                 }
@@ -1141,7 +1151,7 @@ export default {
                 newHour = (newHour >= 13) ? (newHour - 12) : newHour;
             }
 
-            if (this.validateTime(newHour, this.currentMinute, this.currentSecond, newPM)) {
+            if (this.validateTime(newHour, this.currentMinute, this.currentSecond, newPM, false, false)) {
                 this.currentHour = newHour;
                 this.pm = newPM;
             }
@@ -1162,7 +1172,7 @@ export default {
                 newHour = (newHour <= 0) ? (12 + newHour) : newHour;
             }
 
-            if (this.validateTime(newHour, this.currentMinute, this.currentSecond, newPM)) {
+            if (this.validateTime(newHour, this.currentMinute, this.currentSecond, newPM, false, false)) {
                 this.currentHour = newHour;
                 this.pm = newPM;
             }
@@ -1171,7 +1181,7 @@ export default {
         },
         incrementMinute(event) {
             let newMinute = this.currentMinute + this.stepMinute;
-            if (this.validateTime(this.currentHour, newMinute, this.currentSecond, true)) {
+            if (this.validateTime(this.currentHour, newMinute, this.currentSecond, true, true, false)) {
                 this.currentMinute = (newMinute > 59) ? newMinute - 60 : newMinute;
             }
 
@@ -1180,7 +1190,7 @@ export default {
         decrementMinute(event) {
             let newMinute = this.currentMinute - this.stepMinute;
             newMinute = (newMinute < 0) ? 60 + newMinute : newMinute;
-            if (this.validateTime(this.currentHour, newMinute, this.currentSecond, true)) {
+            if (this.validateTime(this.currentHour, newMinute, this.currentSecond, true, true, false)) {
                 this.currentMinute = newMinute;
             }
 
@@ -1188,7 +1198,7 @@ export default {
         },
         incrementSecond(event) {
             let newSecond = this.currentSecond + this.stepSecond;
-            if (this.validateTime(this.currentHour, this.currentMinute, newSecond, true)) {
+            if (this.validateTime(this.currentHour, this.currentMinute, newSecond, true, false, true)) {
                 this.currentSecond = (newSecond > 59) ? newSecond - 60 : newSecond;
             }
 
@@ -1197,7 +1207,7 @@ export default {
         decrementSecond(event) {
             let newSecond = this.currentSecond - this.stepSecond;
             newSecond = (newSecond < 0) ? 60 + newSecond : newSecond;
-            if (this.validateTime(this.currentHour, this.currentMinute, newSecond, true)) {
+            if (this.validateTime(this.currentHour, this.currentMinute, newSecond, true, false, true)) {
                 this.currentSecond = newSecond;
             }
 

--- a/src/views/calendar/CalendarDemo.vue
+++ b/src/views/calendar/CalendarDemo.vue
@@ -77,10 +77,14 @@
                         <label for="touchUI">TouchUI</label>
                         <Calendar id="touchUI" v-model="date13" :touchUI="true" />
                     </div>
+                    <div class="p-field p-col-12 p-md-4">
+                        <label for="timeMinMax">Time (Min: {{date14_min.toLocaleTimeString()}}, Max: {{date14_max.toLocaleTimeString()}})</label>
+                        <Calendar id="timeMinMax" v-model="date14" :min-date="date14_min" :max-date="date14_max" :show-time="true" :show-seconds="true" :show-icon="true" />
+                    </div>
                 </div>
 
                 <h5>Inline</h5>
-                <Calendar v-model="date14" :inline="true" :showWeek="true" />
+                <Calendar v-model="date15" :inline="true" :showWeek="true" />
             </div>
         </div>
 
@@ -126,7 +130,10 @@ export default {
             date11: null,
             date12: null,
             date13: null,
-            date14: null,
+            date14: new Date(2021, 2, 1, 5, 18, 28),
+            date14_min: new Date(2021, 2, 1, 5, 18, 28),
+            date14_max: new Date(2021, 2, 1, 5, 19, 7),
+            date15: null,
             dates1: null,
             dates2: null,
             es: {


### PR DESCRIPTION
Please find my additional changes after my review and test of https://github.com/primefaces/primevue/commit/2cfc732d4c689b90dfc368fdeb51a0b22fe26cbe

Related issue: https://github.com/primefaces/primevue/issues/923

Thanks.