### PR TITLE
Fixed a bug in the locale demo.

### DIFF
--- a/src/views/locale/LocaleDemo.vue
+++ b/src/views/locale/LocaleDemo.vue
@@ -45,15 +45,20 @@ export default {
 
             <h6>Composition API</h6>
 <pre v-code.script><code>
-import { defineComponent, reactive } from "vue";
+
 import { usePrimeVue } from "primevue/config";
+import { onMounted } from "vue";
 
 export default defineComponent({
     setup() {
         const changeToSpanish = () => {
             const primevue = usePrimeVue();
-            primevue.config.locale.accept: 'Aceptar';
-            primevue.config.locale.reject: 'Rechazar';
+            primevue.config.locale.accept = 'Aceptar';
+            primevue.config.locale.reject = 'Rechazar';
+        }
+
+        onMounted(async () => {
+            changeToSpanish()
         }
     }
 });


### PR DESCRIPTION
- In the locale demo for the composition API, where a ':' was used instead
of an '='
- Completed the example to show, how the created function
should be called in order to change the locale
- Removed unnecessary imports from the example

Signed-off-by: Benedikt Bergenthal <benedikt@kdrennert.de>