### PR TITLE
#1013 Add remove event to FileUpload

### DIFF
--- a/src/components/fileupload/FileUpload.d.ts
+++ b/src/components/fileupload/FileUpload.d.ts
@@ -29,6 +29,7 @@ declare class FileUpload {
     $emit(eventName: 'error', e: { originalEvent: Event, files: any }): this;
     $emit(eventName: 'before-send', e: { xhr: XMLHttpRequest, formData: any }): this;
     $emit(eventName: 'clear'): this;
+    $emit(eventName: 'remove', e: { originalEvent: Event, file: any }): this;
 }
 
 export default FileUpload;

--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -47,7 +47,7 @@ import {DomHandler} from 'primevue/utils';
 import Ripple from 'primevue/ripple';
 
 export default {
-    emits: ['select', 'uploader', 'before-upload', 'progress', 'upload', 'error', 'before-send', 'clear'],
+    emits: ['select', 'uploader', 'before-upload', 'progress', 'upload', 'error', 'before-send', 'clear', 'remove'],
     props: {
         name: {
             type: String,
@@ -322,7 +322,7 @@ export default {
         },
         remove(index) {
             this.clearInputElement();
-            this.files.splice(index, 1);
+            this.$emit('remove', {originalEvent: event, file: this.files[index]});
             this.files = [...this.files];
         },
         isImage(file) {

--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -323,6 +323,7 @@ export default {
         remove(index) {
             this.clearInputElement();
             this.$emit('remove', {originalEvent: event, file: this.files[index]});
+            this.files.splice(index, 1);
             this.files = [...this.files];
         },
         isImage(file) {

--- a/src/views/fileupload/FileUploadDoc.vue
+++ b/src/views/fileupload/FileUploadDoc.vue
@@ -275,10 +275,16 @@ myUploader(event) {
 								event.progress: Calculated progress value.</td>
 							<td>Callback to invoke when files are selected.</td>
 						</tr>
-                        <tr>
+            <tr>
 							<td>uploader</td>
 							<td>event.files: List of selected files.</td>
 							<td>Callback to invoke to implement a custom upload.</td>
+						</tr>
+						<tr>
+							<td>remove</td>
+							<td>event.originalEvent: Original browser event. <br />
+								event.file: Selected file.</td>
+							<td>Callback to invoke when a file is removed without uploading using clear button of a file.</td>
 						</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
Add an remove event to FileUpload like in PrimeNg and PrimeReact.

An 'remove' Event with the original Browser Event and the removed File ist emitted when a file is removed with the corresponding 'X' Button

Is this how do adjust the Doku?

#1013 