### PR TITLE
hideIcon and showIcon for Password

### DIFF
--- a/src/components/password/Password.vue
+++ b/src/components/password/Password.vue
@@ -72,6 +72,8 @@ export default {
     },
     data() {
         return {
+            iconHide: 'pi pi-eye-slash',
+            iconShow: 'pi pi-eye',
             overlayVisible: false,
             meter: null,
             infoText: null,
@@ -243,7 +245,7 @@ export default {
             }];
         },
         toggleIconClass() {
-            return this.unmasked ? 'pi pi-eye-slash' : 'pi pi-eye';
+            return this.unmasked ? this.iconHide : this.iconShow;
         },
         strengthClass() {
             return `p-password-strength ${this.meter ? this.meter.strength : ''}`;


### PR DESCRIPTION
Makes the icon classes editable.
Existing "pi" classes are defaults but can be overwritten.