### PR TITLE
Fix plugin type in config/PrimeVue.d.ts

### DIFF
--- a/src/components/config/PrimeVue.d.ts
+++ b/src/components/config/PrimeVue.d.ts
@@ -1,4 +1,4 @@
-import Vue, { PluginFunction } from 'vue';
+import Vue, { Plugin } from 'vue';
 
 interface PrimeVueConfiguration {
     ripple?: boolean;
@@ -51,7 +51,8 @@ interface PrimeVueLocaleOptions {
 
 export declare function usePrimeVue(): PrimeVueConfiguration;
 
-export const install: PluginFunction<{}>;
+declare const plugin: Plugin;
+export default plugin;
 
 declare module 'vue/types/vue' {
     interface Vue {


### PR DESCRIPTION
vue 3 does not export a `PluginFunction` type. The `install` function should be of type `PluginInstallFunction`, but even that isn't exported. Instead we declare the type of the default export as `Plugin`.

See
https://github.com/vuejs/vue-next/blob/f0cf14bcc56c387372932e7d730f838ece17fe5f/packages/runtime-core/src/apiCreateApp.ts#L90-L96.

Fixes #1164.