### PR TITLE
Fix incorrect type on inputClass

### DIFF
--- a/src/components/password/Password.vue
+++ b/src/components/password/Password.vue
@@ -65,7 +65,7 @@ export default {
             type: Boolean,
             default: false
         },
-        inputClass: toString,
+        inputClass: String,
         inputStyle: null,
         style: null,
         class: String,


### PR DESCRIPTION
This was added as "toString" instead of "String", this this component breaks during development as it's typechecked