### PR TITLE
Add conditional rendering to Carousel indicators

### DIFF
--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -40,7 +40,7 @@
 					<span :class="['p-carousel-prev-icon pi', {'pi-chevron-right': !isVertical(),'pi-chevron-down': isVertical()}]"></span>
 				</button>
 			</div>
-			<ul :class="indicatorsContentClasses">
+			<ul v-if="totalIndicators >= 0" :class="indicatorsContentClasses">
 				<li v-for="(indicator, i) of totalIndicators" :key="'p-carousel-indicator-' + i.toString()" :class="['p-carousel-indicator', {'p-highlight': d_page === i}]">
 					<button class="p-link" @click="onIndicatorClick($event, i)" type="button" />
 				</li>


### PR DESCRIPTION
When totalIndicators is below 0 (when the value prop is an empty array) and numScroll !== numVisible, a RangeError is thrown.

Fixes #1201.