### PR TITLE
Expanded datatable header is hide

### DIFF
--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -2049,8 +2049,4 @@ export default {
     width: auto;
 }
 
-/* Responsive */
-.p-datatable .p-datatable-tbody .p-column-title {
-    display: none;
-}
 </style>


### PR DESCRIPTION
###Defect Fixes
Expanded datatable header is hide.

###Feature Requests
i have removed the class to show it. I don't know if that's enough to risolve all the problems but in the responsive works.