### PR TITLE
[Feature] Added parametrizable PrintTable function to DataTable + Documentation

### DIFF
--- a/src/assets/menu/menu.json
+++ b/src/assets/menu/menu.json
@@ -389,6 +389,10 @@
                             "to": "/datatable/export"
                         },
                         {
+                            "name": "Print",
+                            "to": "/datatable/print"
+                        },
+                        {
                             "name": "State",
                             "to": "/datatable/state"
                         },

--- a/src/components/column/Column.d.ts
+++ b/src/components/column/Column.d.ts
@@ -41,6 +41,7 @@ interface ColumnProps {
     exportable?: boolean;
     filterMatchMode?: string;
     hidden?: boolean;
+    printable?: boolean;
 }
 
 declare class Column {

--- a/src/components/column/Column.vue
+++ b/src/components/column/Column.vue
@@ -169,6 +169,10 @@ export default {
         hidden: {
             type: Boolean,
             default: false
+        },
+        printable: {
+            type: Boolean,
+            default: true
         }
     },
     render() {

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -1070,7 +1070,6 @@ export default {
 
                 if (this.columnProp(column, 'printable') !== false && this.columnProp(column, 'field')) {
                     let text = (this.columnProp(column, 'header') || this.columnProp(column, 'field'));
-                    console.log(text);
                     let textNode = document.createTextNode(text);
                     let th = document.createElement('th');
                     th.appendChild(textNode);

--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -1017,6 +1017,158 @@ export default {
                 document.body.removeChild(link);
             }
         },
+        printTable(options) {
+            let data = this.processedData;
+
+            let container = document.createElement('div');
+            container.classList.add('p-datatable-wrapper');
+
+            if (options && options.pageTitle) {
+                let p = document.createElement('p');
+
+                if (options && options.pageTitleClass) {
+                    let classes = options.pageTitleClass.split(' ');
+                    classes.forEach(clase => {
+                        p.classList.add(clase);
+                    });
+                }
+
+                let text = document.createTextNode(options.pageTitle);
+                p.appendChild(text);
+                container.appendChild(p);
+            }
+
+            let table = document.createElement('table');
+            table.style.width = '100%';
+
+            let header = document.createElement('thead');
+            let headerTr = document.createElement('tr');
+
+
+
+            if (options && options.tableClass) {
+                let classes = options.tableClass.split(' ');
+                classes.forEach(clase => {
+                    table.classList.add(clase);
+                });
+            } else {
+                table.classList.add('p-datatable-table');
+            }
+
+            if (options && options.theaderClass) {
+                let classes = options.theaderClass.split(' ');
+                classes.forEach(clase => {
+                    header.classList.add(clase);
+                });
+            } else {
+                header.classList.add('p-datatable-thead');
+            }
+            
+
+            for (let i = 0; i < this.columns.length; i++) {
+                let column = this.columns[i];
+
+                if (this.columnProp(column, 'printable') !== false && this.columnProp(column, 'field')) {
+                    let text = (this.columnProp(column, 'header') || this.columnProp(column, 'field'));
+                    console.log(text);
+                    let textNode = document.createTextNode(text);
+                    let th = document.createElement('th');
+                    th.appendChild(textNode);
+                    headerTr.appendChild(th);
+                }
+            }
+
+            header.appendChild(headerTr);
+            table.appendChild(header);
+
+            //body
+            if (data) {
+                let body = document.createElement('tbody');
+
+                if (options && options.tbodyClass) {
+                    let classes = options.tbodyClass.split(' ');
+                    classes.forEach(clase => {
+                        body.classList.add(clase);
+                    });
+                } else {
+                    body.classList.add('p-datatable-tbody');
+                }
+
+                data.forEach(record => {
+                let tr = document.createElement('tr');
+
+                if (options && options.trClass) {
+                    let classes = options.trClass.split(' ');
+                    classes.forEach(clase => {
+                        tr.classList.add(clase);
+                    });
+                }
+
+                //   let rowInitiated = false;
+                for (let i = 0; i < this.columns.length; i++) {
+                    let column = this.columns[i];
+                    if (this.columnProp(column, 'printable') !== false && this.columnProp(column, 'field')) {
+                        let td = document.createElement('td');
+
+                        if (options && options.tdClass) {
+                            let classes = options.tdClass.split(' ');
+                            classes.forEach(clase => {
+                                td.classList.add(clase);
+                            });
+                        }
+
+                        let cellData = ObjectUtils.resolveFieldData(
+                            record,
+                            this.columnProp(column, 'field')
+                        );
+
+                        if (cellData != null) {
+                            if (this.exportFunction) {
+                            cellData = this.exportFunction({
+                                data: cellData,
+                                field: this.columnProp(column, 'field')
+                            });
+                            } else cellData = String(cellData).replace(/"/g, '""');
+                        } else cellData = '';
+
+                        let text = document.createTextNode(cellData);
+                        td.appendChild(text);
+                        tr.appendChild(td);
+                    }
+                }
+                body.appendChild(tr);
+                });
+
+                table.appendChild(body);
+            }
+
+            container.appendChild(table);
+
+            let dataTableContainer = document.createElement('div');
+            dataTableContainer.classList.add('p-datatable');
+            
+            dataTableContainer.appendChild(container);
+
+            let newWin = window.open('');
+
+            if (options && options.linkCSSLib) {
+                newWin.document.write(
+                    "<html><head>" +
+                    '<link href="'+ options.linkCSSLib +'" rel="stylesheet" onload="print(); window.close();">' +
+                    "</head><body>" +
+                    dataTableContainer.outerHTML +
+                    "</body></html>"
+                );
+            } else {
+                newWin.document.write(
+                    "<html><head>" +
+                    '<link href="https://cdn.jsdelivr.net/npm/primevue/resources/themes/saga-blue/theme.css" rel="stylesheet" onload="print();">' +
+                    "</head><body>" +
+                    dataTableContainer.outerHTML +
+                    "</body></html>"
+                );
+            }
+        },
         resetPage() {
             this.d_first = 0;
             this.$emit('update:first', this.d_first);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -243,6 +243,11 @@ const routes = [
         component: () => import('../views/datatable/DataTableExportDemo.vue')
     },
     {
+        path: '/datatable/print',
+        name: 'datatableprint',
+        component: () => import('../views/datatable/DataTablePrintDemo.vue')
+    },
+    {
         path: '/datatable/colgroup',
         name: 'datatablecolgroup',
         component: () => import('../views/datatable/DataTableColGroupDemo.vue')

--- a/src/views/datatable/DataTableDoc.vue
+++ b/src/views/datatable/DataTableDoc.vue
@@ -378,6 +378,12 @@ export default {
                             <td>false</td>
                             <td>Whether the column is rendered.</td>
                         </tr>
+                        <tr>
+                            <td>printable</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>Whether the column is printable.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -446,6 +452,70 @@ export default {
                         </tr>
 					</tbody>
 				</table>
+            </div>
+
+            <h5>Print object properties utilized by the DataTable</h5>
+            <div class="doc-tablewrapper">
+                <table class="doc-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Type</th>
+                            <th>Default</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>pageTitle</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Represents the title of the page. It's fully customizable</td>
+                        </tr>
+                        <tr>
+                            <td>linkCSSLib</td>
+                            <td>string</td>
+                            <td>https://cdn.jsdelivr.net/npm/primevue/resources/themes/saga-blue/theme.css</td>
+                            <td>URL of the CSS library that will be appended to printable window.</td>
+                        </tr>
+                        <tr>
+                            <td>pageTitleClass</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>CSS classes of pageTitle, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                        <tr>
+                            <td>tableClass</td>
+                            <td>string</td>
+                            <td>p-datatable-table</td>
+                            <td>CSS classes of table object, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                        <tr>
+                            <td>theaderClass</td>
+                            <td>string</td>
+                            <td>p-datatable-thead</td>
+                            <td>CSS classes of theader object, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                        <tr>
+                            <td>tbodyClass</td>
+                            <td>string</td>
+                            <td>p-datatable-tbody</td>
+                            <td>CSS classes of tbody object, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                        <tr>
+                            <td>trClass</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>CSS classes of tr objects, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                        <tr>
+                            <td>tdClass</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>CSS classes of td objects, can accept more than one class by separate it with an space.</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
 
             <h5>Auto Layout</h5>

--- a/src/views/datatable/DataTablePrintDemo.vue
+++ b/src/views/datatable/DataTablePrintDemo.vue
@@ -1,0 +1,221 @@
+<template>
+	<div>
+		<div class="content-section introduction">
+			<div class="feature-intro">
+				<h1>DataTable <span>Print</span></h1>
+				<p>DataTable can be printed.</p>
+			</div>
+            <AppDemoActions />
+		</div>
+
+		<div class="content-section implementation">
+            <div class="card">
+                <h5>Default parameters</h5>
+                <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                    <template #header>
+                        <div style="text-align: left">
+                            <Button icon="pi pi-print" label="Print" @click="printTable()" />
+                        </div>
+                    </template>
+                    <Column field="code" header="Code"></Column>
+                    <Column field="name" header="Name"></Column>
+                    <Column field="category" header="Category"></Column>
+                    <Column field="quantity" header="Quantity"></Column>
+                </DataTable>
+            </div>
+
+            <div class="card">
+                <h5>Custom parameters</h5>
+                <p>Using <b>pageTitle</b> and <i>Bootstrap</i> as CSS library.</p>
+                <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                    <template #header>
+                        <div style="text-align: left">
+                            <Button icon="pi pi-print" label="Print" @click="printTable2()" />
+                        </div>
+                    </template>
+                    <Column field="code" header="Code"></Column>
+                    <Column field="name" header="Name"></Column>
+                    <Column field="category" header="Category"></Column>
+                    <Column field="quantity" header="Quantity"></Column>
+                </DataTable>
+            </div>
+		</div>
+
+        <AppDoc name="DataTableExportDemo" :sources="sources" :service="['ProductService']" :data="['products-small']" github="datatable/DataTableExportDemo.vue" />
+	</div>
+</template>
+
+<script>
+import ProductService from '../../service/ProductService';
+
+export default {
+    data() {
+        return {
+            products: null,
+            sources: {
+                'options-api': {
+                    tabName: 'Options API Source',
+                    content: `
+<template>
+    <div>
+        <div class="card">
+            <h5>Default parameters</h5>
+            <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                <template #header>
+                    <div style="text-align: left">
+                        <Button icon="pi pi-print" label="Print" @click="printTable()" />
+                    </div>
+                </template>
+                <Column field="code" header="Code"></Column>
+                <Column field="name" header="Name"></Column>
+                <Column field="category" header="Category"></Column>
+                <Column field="quantity" header="Quantity"></Column>
+            </DataTable>
+        </div>
+
+        <div class="card">
+            <h5>Custom parameters</h5>
+            <p>Using <b>pageTitle</b> and <i>Bootstrap</i> as CSS library.</p>
+            <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                <template #header>
+                    <div style="text-align: left">
+                        <Button icon="pi pi-print" label="Print" @click="printTable2()" />
+                    </div>
+                </template>
+                <Column field="code" header="Code"></Column>
+                <Column field="name" header="Name"></Column>
+                <Column field="category" header="Category"></Column>
+                <Column field="quantity" header="Quantity"></Column>
+            </DataTable>
+        </div>
+    </div>
+</template>
+
+<script>
+import ProductService from './service/ProductService';
+
+export default {
+    data() {
+        return {
+            products: null
+        }
+    },
+    productService: null,
+    created() {
+        this.productService = new ProductService();
+    },
+    mounted() {
+        this.productService.getProductsSmall().then(data => this.products = data);
+    },
+    methods: {
+        printTable() {
+            this.$refs.dt.printTable();
+        },
+        printTable2() {
+            this.$refs.dt.printTable({
+                pageTitle: 'Primevue - Printing Page',
+                tableClass: 'table table-striped text-center mt-4',
+                pageTitleClass: 'h2 text-center',
+                linkCSSLib: 'https://cdn.jsdelivr.net/npm/bootstrap/dist/css/bootstrap.min.css'
+            });
+        }
+    }
+}
+<\\/script>
+`
+                },
+                'composition-api': {
+                    tabName: 'Composition API Source',
+                    content: `
+<template>
+    <div>
+        <div class="card">
+            <h5>Default parameters</h5>
+            <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                <template #header>
+                    <div style="text-align: left">
+                        <Button icon="pi pi-print" label="Print" @click="printTable()" />
+                    </div>
+                </template>
+                <Column field="code" header="Code"></Column>
+                <Column field="name" header="Name"></Column>
+                <Column field="category" header="Category"></Column>
+                <Column field="quantity" header="Quantity"></Column>
+            </DataTable>
+        </div>
+
+        <div class="card">
+            <h5>Custom parameters</h5>
+            <p>Using <b>pageTitle</b> and <i>Bootstrap</i> as CSS library.</p>
+            <DataTable :value="products" ref="dt" responsiveLayout="scroll">
+                <template #header>
+                    <div style="text-align: left">
+                        <Button icon="pi pi-print" label="Print" @click="printTable2()" />
+                    </div>
+                </template>
+                <Column field="code" header="Code"></Column>
+                <Column field="name" header="Name"></Column>
+                <Column field="category" header="Category"></Column>
+                <Column field="quantity" header="Quantity"></Column>
+            </DataTable>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import ProductService from './service/ProductService';
+
+export default {
+    setup() {
+        onMounted(() => {
+            productService.value.getProductsSmall().then(data => products.value = data);
+        })
+
+        const dt = ref();
+        const products = ref();
+        const productService = ref(new ProductService());
+        const printTable = () => {
+            dt.value.printTable();
+        };
+
+        const printTable2 = () => {
+            dt.value.printTable({
+                pageTitle: 'Primevue - Printing Page',
+                tableClass: 'table table-striped text-center mt-4',
+                pageTitleClass: 'h2 text-center',
+                linkCSSLib: 'https://cdn.jsdelivr.net/npm/bootstrap/dist/css/bootstrap.min.css'
+            });
+        };
+
+        return { dt, products, printTable, printTable2 }
+    }
+}
+<\\/script>
+`
+                }
+            }
+        }
+    },
+    productService: null,
+    created() {
+        this.productService = new ProductService();
+    },
+    mounted() {
+        this.productService.getProductsSmall().then(data => this.products = data);
+    },
+    methods: {
+        printTable() {
+            this.$refs.dt.printTable();
+        },
+        printTable2() {
+            this.$refs.dt.printTable({
+                pageTitle: 'Primevue - Printing Page',
+                tableClass: 'table table-striped text-center mt-4',
+                pageTitleClass: 'h2 text-center',
+                linkCSSLib: 'https://cdn.jsdelivr.net/npm/bootstrap/dist/css/bootstrap.min.css'
+            });
+        }
+    }
+}
+</script>


### PR DESCRIPTION
## Feature Requests

This is a Feature Request, it adds to Primevue possibility of printing a DataTable. It is fully customizable, the developer can customize it easily by params. I.e., developer can style his table with Bootstrap or Tailwind, default value is, of course, Primevue.

Screen capture of default styles:
![image](https://user-images.githubusercontent.com/2920935/118941554-25595380-b952-11eb-8b44-328118518227.png)

And screen capture of table styled with Bootstrap:
![image](https://user-images.githubusercontent.com/2920935/118941662-3dc96e00-b952-11eb-8925-2d410e201396.png)

Both examples are in docs page: `Datatable > Print`.