### PR TITLE
[Minor][Fix] fullcalendar watchers + data method

### DIFF
--- a/src/components/fullcalendar/FullCalendar.vue
+++ b/src/components/fullcalendar/FullCalendar.vue
@@ -11,18 +11,28 @@ export default {
         events: Array,
         options: null
     },
-    calendar: null,
+    data() {
+        return {
+            calendar: null
+        }
+    },
     watch: {
-        events(value) {
-            if (value && this.calendar) {
-                this.calendar.removeAllEventSources();
-                this.calendar.addEventSource(value);
+        events: {
+            deep: true,
+            handler(newEvents, oldEvents) {
+                if (newEvents && this.calendar) {
+                    this.calendar.removeAllEventSources();
+                    this.calendar.addEventSource(newEvents);
+                }
             }
         },
-        options(value) {
-            if (value && this.calendar) {
-                for (let prop in value) {
-                    this.calendar.setOption(prop, value[prop]);
+        options: {
+            deep: true,
+            handler(newOptions, oldOptions) {
+                if (newOptions && this.calendar) {
+                    for (const prop in newOptions) {
+                        this.calendar.setOption(prop, newOptions[prop]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
fullcalendar props are objects: watchers on objects need to be set to deep to work;
standardized calendar instance by putting it into the data method;

###Defect Fixes
When submitting a PR, please also create an issue documenting the error: ISSUE >>> https://github.com/primefaces/primevue/issues/1316 <<<