### PR TITLE
Fix: Prevent overlay closing if click start inside

### DIFF
--- a/src/components/overlaypanel/OverlayPanel.vue
+++ b/src/components/overlaypanel/OverlayPanel.vue
@@ -2,7 +2,7 @@
     <Teleport :to="appendTo">
         <transition name="p-overlaypanel" @enter="onEnter" @leave="onLeave" @after-leave="onAfterLeave">
             <div :class="containerClass" v-if="visible" :ref="containerRef" v-bind="$attrs" @click="onOverlayClick">
-                <div class="p-overlaypanel-content" @click="onContentClick">
+                <div class="p-overlaypanel-content" @mousedown="onContentClick">
                     <slot></slot>
                 </div>
                 <button class="p-overlaypanel-close p-link" @click="hide" v-if="showCloseIcon" :aria-label="ariaCloseLabel" type="button" v-ripple>


### PR DESCRIPTION
### Defect Fixes
When I try to highlight some text inside the overlay, if the cursor ends its run outside, the panel will be close.
I checked the code, and I found that "selfClick" property is used to avoid that, but I think It's attached to the wrong event.

I changed "click" event with "mousedown".
