### PR TITLE
Linting fixes in Password.vue

### DIFF
--- a/src/components/password/Password.vue
+++ b/src/components/password/Password.vue
@@ -10,7 +10,7 @@
                         <div class="p-password-meter">
                             <div :class="strengthClass" :style="{'width': meter ? meter.width : ''}"></div>
                         </div>
-                        <div className="p-password-info">{{infoText}}</div>
+                        <div class="p-password-info">{{infoText}}</div>
                     </slot>
                     <slot name="footer"></slot>
                 </div>
@@ -164,7 +164,7 @@ export default {
         },
         onKeyUp(event) {
             if (this.feedback) {
-                let value = event.target.value;
+                const value = event.target.value;
                 let label = null;
                 let meter = null;
 
@@ -330,7 +330,7 @@ export default {
 
 .p-password-strength {
     height: 100%;
-    width: 0%;
+    width: 0;
     transition: width 1s ease-in-out;
 }
 


### PR DESCRIPTION
Three small fixes:
- className where "class" is correct
- a let that should be a const as the variable is never reassigned
- a superfluous % after a "0" CSS value