### PR TITLE
Add "multiple" support to simple FileUpload button

### DIFF
--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -34,7 +34,7 @@
         <span :class="basicChooseButtonClass" @mouseup="onBasicUploaderClick"  @keydown.enter="choose" @focus="onFocus" @blur="onBlur" v-ripple tabindex="0" >
             <span :class="basicChooseButtonIconClass"></span>
             <span class="p-button-label">{{basicChooseButtonLabel}}</span>
-            <input ref="fileInput" type="file" :accept="accept" :disabled="disabled" @change="onFileSelect" @focus="onFocus" @blur="onBlur" v-if="!hasFiles" />
+            <input ref="fileInput" type="file" :accept="accept" :disabled="disabled" :multiple="multiple" @change="onFileSelect" @focus="onFocus" @blur="onBlur" v-if="!hasFiles" />
         </span>
     </div>
 </template>


### PR DESCRIPTION
### Defect Fixes
In my eyes this is a defect - I don't think it makes sense that the "simple" mode should not support multiple files being processed. The documentation only mentions a simpler UI, not a more simplistic behaviour.