### PR TITLE
Adds custom target for OverlayPanel #942

### DIFF
--- a/src/components/overlaypanel/OverlayPanel.vue
+++ b/src/components/overlaypanel/OverlayPanel.vue
@@ -100,9 +100,9 @@ export default {
             else
                 this.show(event);
         },
-        show(event) {
+        show(event, target) {
             this.visible = true;
-            this.target = event.currentTarget;
+            this.target = target || event.currentTarget;
         },
         hide() {
             this.visible = false;


### PR DESCRIPTION
Fixes #942

Adds the second parameter `target` to `OverlayPanel.show` which is already documented in https://primefaces.org/primevue/showcase/#/overlaypanel and addressed by issue #942.

Citing the documentation:
target: Optional target if event.target should not be used

Here is probably still an issue, because the code uses `event.currentTarget` and not `event.target` as stated in the documentation.
