### PR TITLE
FIX #1390 - Search method triggers from onkeypress instead of onkeydown

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -1,7 +1,7 @@
 <template>
     <div ref="container" :class="containerClass" @click="onClick($event)">
         <div class="p-hidden-accessible">
-            <input ref="focusInput" type="text" :id="inputId" readonly :disabled="disabled" @focus="onFocus" @blur="onBlur" @keydown="onKeyDown" :tabindex="tabindex"
+            <input ref="focusInput" type="text" :id="inputId" readonly :disabled="disabled" @focus="onFocus" @blur="onBlur" @keydown="onKeyDown" @keypress="onKeyPress" :tabindex="tabindex"
                 aria-haspopup="true" :aria-expanded="overlayVisible" :aria-labelledby="ariaLabelledBy"/>
         </div>
         <input v-if="editable" type="text" class="p-dropdown-label p-inputtext" :disabled="disabled" @focus="onFocus" @blur="onBlur" :placeholder="placeholder" :value="editableInputValue" @input="onEditableInput"
@@ -255,11 +255,11 @@ export default {
                 case 9:
                     this.hide();
                 break;
-
-                default:
-                    this.search(event);
-                break;
             }
+        },
+        // Accepts values from numpad
+        onKeyPress(event) {
+            this.search(event);
         },
         onFilterKeyDown(event) {
             switch (event.which) {


### PR DESCRIPTION
###Defect Fixes
#1390 

This PR try to fix a behavior where the function `String.fromCharCode()` returns a letter instead of number when the numpad keys are pressed to search an item in the dropdown component.

I propose call the search method  from the onKeyPress event, where the function mentioned above works as expected.