### PR TITLE
feature: supply remove method for toast, to close one message instead of close all

### DIFF
--- a/src/components/toast/ToastMessage.vue
+++ b/src/components/toast/ToastMessage.vue
@@ -18,6 +18,7 @@
 
 <script>
 import Ripple from 'primevue/ripple';
+import ToastEventBus from 'primevue/toasteventbus';
 
 export default {
     name: 'ToastMessage',
@@ -28,11 +29,15 @@ export default {
     },
     closeTimeout: null,
     mounted() {
+        ToastEventBus.on('remove', this.onRemove);
         if (this.message.life) {
             this.closeTimeout = setTimeout(() => {
                 this.close();
             }, this.message.life)
         }
+    },
+    beforeUnmount() {
+        ToastEventBus.off('remove', this.onRemove);
     },
     methods: {
         close() {
@@ -44,7 +49,12 @@ export default {
             }
 
             this.close();
-        }
+        },
+        onRemove(message) {
+            if (this.message === message || this.message.id === message.id) {
+                this.onCloseClick();
+            }
+        },
     },
     computed: {
         containerClass() {

--- a/src/components/toastservice/ToastService.d.ts
+++ b/src/components/toastservice/ToastService.d.ts
@@ -4,7 +4,7 @@ export const install: PluginFunction<{}>;
 
 interface ToastServiceMethods {
     add(message: any): any;
-    remove(message: any): any;
+    remove(message: any): void;
     removeGroup(group: any): void;
     removeAllGroups(): void;
 }

--- a/src/components/toastservice/ToastService.d.ts
+++ b/src/components/toastservice/ToastService.d.ts
@@ -4,6 +4,7 @@ export const install: PluginFunction<{}>;
 
 interface ToastServiceMethods {
     add(message: any): any;
+    remove(message: any): any;
     removeGroup(group: any): void;
     removeAllGroups(): void;
 }

--- a/src/components/toastservice/ToastService.js
+++ b/src/components/toastservice/ToastService.js
@@ -7,6 +7,9 @@ export default {
             add: (message) => {
                 ToastEventBus.emit('add', message);
             },
+            remove: (message) => {
+                ToastEventBus.emit('remove', message);
+            },
             removeGroup: (group) => {
                 ToastEventBus.emit('remove-group', group);
             },

--- a/src/components/usetoast/UseToast.d.ts
+++ b/src/components/usetoast/UseToast.d.ts
@@ -1,5 +1,6 @@
 export declare function useToast(): {
     add(args:{ severity?: string, summary?: string, detail?: string, life?: number, closable?: boolean, group?: string }): void;
+    remove(args:{ severity?: string, summary?: string, detail?: string, life?: number, closable?: boolean, group?: string }): void;
     removeGroup(group: string): void;
     removeAllGroups(): void;
 }

--- a/src/views/toast/ToastDemo.vue
+++ b/src/views/toast/ToastDemo.vue
@@ -19,10 +19,10 @@
                         </div>
                         <div class="p-grid p-fluid">
                             <div class="p-col-6">
-                                <Button class="p-button-success" label="Yes" @click="onConfirm"></Button>
+                                <Button class="p-button-success" label="Yes" @click="onConfirm(slotProps.message)"></Button>
                             </div>
                             <div class="p-col-6">
-                                <Button class="p-button-secondary" label="No" @click="onReject"></Button>
+                                <Button class="p-button-secondary" label="No" @click="onReject(slotProps.message)"></Button>
                             </div>
                         </div>
                     </div>
@@ -100,11 +100,11 @@ export default {
         showTemplate() {
             this.$toast.add({severity: 'warn', summary: 'Are you sure?', detail: 'Proceed to confirm', group: 'bc'});
         },
-        onConfirm() {
-            this.$toast.removeGroup('bc');
+        onConfirm(message) {
+            this.$toast.remove(message);
         },
-        onReject() {
-            this.$toast.removeGroup('bc');
+        onReject(message) {
+            this.$toast.remove(message);
         },
         clear() {
             this.$toast.removeAllGroups();

--- a/src/views/toast/ToastDoc.vue
+++ b/src/views/toast/ToastDoc.vue
@@ -117,6 +117,11 @@ export default defineComponent({
                         <td>Displays the message in a suitable Toast component.</td>
                     </tr>
                     <tr>
+                        <td>remove</td>
+                        <td>message: Message instance</td>
+                        <td>Clears the message in a suitable Toast component.</td>
+                    </tr>
+                    <tr>
                         <td>removeGroup</td>
                         <td>group: Name of the message group</td>
                         <td>Clears the messages that belongs to the group.</td>
@@ -189,10 +194,10 @@ this.$toast.add({severity:'success', summary: 'Specific Message', group: 'mykey'
             &lt;/div&gt;
             &lt;div class="p-grid p-fluid"&gt;
                 &lt;div class="p-col-6"&gt;
-                    &lt;Button class="p-button-success" label="Yes" @click="onConfirm" /&gt;
+                    &lt;Button class="p-button-success" label="Yes" @click="onConfirm(slotProps.message)" /&gt;
                 &lt;/div&gt;
                 &lt;div class="p-col-6"&gt;
-                    &lt;Button class="p-button-secondary" label="No" @click="onReject" /&gt;
+                    &lt;Button class="p-button-secondary" label="No" @click="onReject(slotProps.message)" /&gt;
                 &lt;/div&gt;
             &lt;/div&gt;
         &lt;/div&gt;
@@ -328,10 +333,10 @@ export default {
                     </div>
                     <div class="p-grid p-fluid">
                         <div class="p-col-6">
-                            <Button class="p-button-success" label="Yes" @click="onConfirm"></Button>
+                            <Button class="p-button-success" label="Yes" @click="onConfirm(slotProps.message)"></Button>
                         </div>
                         <div class="p-col-6">
-                            <Button class="p-button-secondary" label="No" @click="onReject"></Button>
+                            <Button class="p-button-secondary" label="No" @click="onReject(slotProps.message)"></Button>
                         </div>
                     </div>
                 </div>
@@ -403,11 +408,11 @@ export default {
         showTemplate() {
             this.$toast.add({severity: 'warn', summary: 'Are you sure?', detail: 'Proceed to confirm', group: 'bc'});
         },
-        onConfirm() {
-            this.$toast.removeGroup('bc');
+        onConfirm(message) {
+            this.$toast.remove(message);
         },
-        onReject() {
-            this.$toast.removeGroup('bc');
+        onReject(message) {
+            this.$toast.remove(message);
         },
         clear() {
             this.$toast.removeAllGroups();
@@ -450,10 +455,10 @@ button {
                     </div>
                     <div class="p-grid p-fluid">
                         <div class="p-col-6">
-                            <Button class="p-button-success" label="Yes" @click="onConfirm"></Button>
+                            <Button class="p-button-success" label="Yes" @click="onConfirm(slotProps.message)"></Button>
                         </div>
                         <div class="p-col-6">
-                            <Button class="p-button-secondary" label="No" @click="onReject"></Button>
+                            <Button class="p-button-secondary" label="No" @click="onReject(slotProps.message)"></Button>
                         </div>
                     </div>
                 </div>
@@ -525,12 +530,12 @@ export default defineComponent({
         const showTemplate = () => {
             toast.add({severity: 'warn', summary: 'Are you sure?', detail: 'Proceed to confirm', group: 'bc'});
         }
-        const onConfirm = () => {
-            toast.removeGroup('bc');
-        }
-        const onReject = () => {
-            toast.removeGroup('bc');
-        }
+        const onConfirm = (message) => {
+            toast.remove(message);
+        },
+        const onReject = (message) => {
+            toast.remove(message);
+        },
         const clear = () => {
             toast.removeAllGroups();
         }


### PR DESCRIPTION
###Feature Requests
The Toast message component can close a group message or close all groups messages, but can't close one message by calling a method, so in the slot, we can't close the current toast message, just as the demo showed, we must close all by call `removeGroup`. This pull request is just added the `remove` method to close one message, the usage is shown in ToastDoc.vue.