### PR TITLE
Add appendTo to Dialog to control Teleport

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <Teleport to="body">
+    <Teleport :to="appendTarget" :disabled="appendDisabled">
         <div :ref="maskRef" :class="maskClass" v-if="containerVisible" @click="onMaskClick">
             <transition name="p-dialog" @before-enter="onBeforeEnter" @enter="onEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear>
                 <div :ref="containerRef" :class="dialogClass" v-if="visible" v-bind="$attrs" role="dialog" :aria-labelledby="ariaLabelledById" :aria-modal="modal">
@@ -93,6 +93,10 @@ export default {
         minY: {
             type: Number,
             default: 0
+        },
+        appendTo: {
+            type: String,
+            default: 'body'
         }
     },
     data() {
@@ -399,6 +403,12 @@ export default {
         },
         contentStyleClass() {
             return ['p-dialog-content', this.contentClass];
+        },
+        appendDisabled() {
+            return this.appendTo === 'self';
+        },
+        appendTarget() {
+            return this.appendDisabled ? null : this.appendTo;
         }
     },
     directives: {


### PR DESCRIPTION
It appears `Dialog` was missed in the fixes for https://github.com/primefaces/primevue/issues/1148

We're having trouble with unit tests for components that involve Dialogs, due to the dialog content being teleported outside of the component. The common advice from vue-test-utils is to use another internal component, but that interferes with the ability to use slots in the Dialog.

This should allow us to set `appendTo="self"` during unit tests, to disable the teleporting behaviour.