### PR TITLE
[Fix] Prevent overlay from closing when clicking on a label inside

### DIFF
--- a/src/components/overlaypanel/OverlayPanel.vue
+++ b/src/components/overlaypanel/OverlayPanel.vue
@@ -2,7 +2,7 @@
     <Teleport :to="appendTo">
         <transition name="p-overlaypanel" @enter="onEnter" @leave="onLeave" @after-leave="onAfterLeave">
             <div :class="containerClass" v-if="visible" :ref="containerRef" v-bind="$attrs" @click="onOverlayClick">
-                <div class="p-overlaypanel-content" @mousedown="onContentClick">
+                <div class="p-overlaypanel-content" @click="onContentClick" @mousedown="onContentClick">
                     <slot></slot>
                 </div>
                 <button class="p-overlaypanel-close p-link" @click="hide" v-if="showCloseIcon" :aria-label="ariaCloseLabel" type="button" v-ripple>


### PR DESCRIPTION
Hi,
On this PR https://github.com/primefaces/primevue/pull/1361 the event used for checking if the click is inside the overlay was changed from @click to @mousedown
This caused the overlay to hide when clicking on a <label> tag within the overlay

In this PR, i'm adding a listener for the click event that calls onContentClick function

I tested this change locally and now both clicking on a label or trying to select text work both fine

###Defect Fixes
Fixes https://github.com/primefaces/primevue/issues/1528
Re production of the bug https://codesandbox.io/s/wonderful-agnesi-020nn