### PR TITLE
Add events emitted by OverlayPanel

### DIFF
--- a/src/components/overlaypanel/OverlayPanel.vue
+++ b/src/components/overlaypanel/OverlayPanel.vue
@@ -51,6 +51,7 @@ export default {
             default: null
         }
     },
+    emits: ['show', 'hide'],
     data() {
         return {
             visible: false


### PR DESCRIPTION
This PR adds the emits: ['show', 'hide'] to OverlayPanel component.
Without these vue will throw warnings in the console
Also in vue js docs, they encourage to add the emits
Also the IDE will benifit us developers when defining 'emits' because that will enable auto complete on the custom events as well