### PR TITLE
SpeedDial hideOnClickOutside not working

### DIFF
--- a/src/components/speeddial/SpeedDial.vue
+++ b/src/components/speeddial/SpeedDial.vue
@@ -103,6 +103,7 @@ export default {
                 this.list.style.setProperty('--item-diff-y', `${hDiff / 2}px`);
             }
         }
+
         if (this.hideOnClickOutside) {
             this.bindDocumentClickListener();
         }

--- a/src/components/speeddial/SpeedDial.vue
+++ b/src/components/speeddial/SpeedDial.vue
@@ -103,13 +103,11 @@ export default {
                 this.list.style.setProperty('--item-diff-y', `${hDiff / 2}px`);
             }
         }
-
+    },
+    beforeMount() {
         if (this.hideOnClickOutside) {
             this.bindDocumentClickListener();
         }
-    },
-    beforeMount() {
-        this.bindDocumentClickListener();
     },
     methods: {
         onItemClick(e, item) {

--- a/src/components/speeddial/SpeedDial.vue
+++ b/src/components/speeddial/SpeedDial.vue
@@ -103,11 +103,12 @@ export default {
                 this.list.style.setProperty('--item-diff-y', `${hDiff / 2}px`);
             }
         }
-    },
-    beforeMount() {
         if (this.hideOnClickOutside) {
             this.bindDocumentClickListener();
         }
+    },
+    beforeMount() {
+        this.unbindDocumentClickListener();
     },
     methods: {
         onItemClick(e, item) {


### PR DESCRIPTION
this.bindDocumentClickListener() is called in beforeMount without case checking. update code to check props hideOnClickOutside before bind listener.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.