### PR TITLE
Fixed #1596 :  Typescript `Plugin` issue of `ConfirmationService.d.ts` and `ToastService.d.ts`

### DIFF
--- a/src/components/confirmationservice/ConfirmationService.d.ts
+++ b/src/components/confirmationservice/ConfirmationService.d.ts
@@ -1,6 +1,7 @@
-import Vue, { PluginFunction } from 'vue';
+import Vue, { Plugin } from 'vue';
 
-export const install: PluginFunction<{}>;
+declare const plugin: Plugin;
+export default plugin;
 
 interface ConfirmationServiceMethods {
     require(options: any): any;

--- a/src/components/toastservice/ToastService.d.ts
+++ b/src/components/toastservice/ToastService.d.ts
@@ -1,6 +1,7 @@
-import Vue, { PluginFunction } from 'vue';
+import Vue, { Plugin } from 'vue';
 
-export const install: PluginFunction<{}>;
+declare const plugin: Plugin;
+export default plugin;
 
 interface ToastServiceMethods {
     add(message: any): any;


### PR DESCRIPTION
### The issue ( https://github.com/primefaces/primevue/issues/1596 ) when using typescript in `vue-tsc --noEmit && vite build`

#### package version:

* `"vue": "^3.2.6"`
* `"vite": "^2.5.2"`
* `"vue-tsc": "^0.2.2"`

if using `vue-tsc --noEmit`, it not working with these error. 

### Error message

```bash
node_modules/primevue/confirmationservice/ConfirmationService.d.ts:1:15 - error TS2305: Module '"vue"' has no exported member 'PluginFunction'.

import Vue, { PluginFunction } from 'vue';
                ~~~~~~~~~~~~~~

node_modules/primevue/toastservice/ToastService.d.ts:1:15 - error TS2305: Module '"vue"' has no exported member 'PluginFunction'.

import Vue, { PluginFunction } from 'vue';
                ~~~~~~~~~~~~~~
```