### PR TITLE
Add missing 'expansion' slot TypeScript definition to DataTable.d.ts

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -114,6 +114,7 @@ declare class DataTable {
         groupheader: VNode[];
         groupfooter: VNode[];
         loading: VNode[];
+        expansion: VNode[];
     };
 }
 


### PR DESCRIPTION
The DataTable.d.ts file is missing the 'expansion' field in the $slots class field.
This PR adds the missing field.
This PR resolves Issue #1629 

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.