### PR TITLE
VirtualScroller: add missing method typings

### DIFF
--- a/src/components/virtualscroller/VirtualScroller.d.ts
+++ b/src/components/virtualscroller/VirtualScroller.d.ts
@@ -15,8 +15,21 @@ interface VirtualScrollerProps {
     class?: string;
 }
 
+interface Range {
+    first: number;
+    last: number;
+    viewport: {
+        first: number;
+        last: number;
+    }
+}
+
 declare class VirtualScroller {
     $props: VirtualScrollerProps;
+    scrollTo(options?: ScrollToOptions): void;
+    scrollToIndex(index: number, behavior: ScrollBehavior): void;
+    scrollInView(index: number, to: "to-start" | "to-end", behavior: ScrollBehavior): void;
+    getRenderedRange(): Range
     $emit(eventName: 'update:numToleratedItems', value: number): this;
     $emit(eventName: 'scroll-index-change', value: { first: number, last: number }): this;
     $emit(eventName: 'lazy-load', value: { first: number, last: number }): this;


### PR DESCRIPTION
Added missing method typings for VirtualScroller

These allow to invoke methods in a type-safe way, such as:

```typescript

const scroller = ref<InstanceType<typeof VirtualScroller>>();

// ....

function onClick {
    scroller.value.scrollTo({left: 100, top: 50, behavior: "smooth"});
}

```