### PR TITLE
Dropdown: add function type to optionLabel

### DIFF
--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -4,7 +4,7 @@ import VirtualScrollerProps from '../virtualscroller';
 interface DropdownProps {
     modelValue?: any;
     options?: any[];
-    optionLabel?: string;
+    optionLabel?: string | ((option: any) => string);
     optionValue?: any;
     optionDisabled?: boolean;
     optionGroupLabel?: string;


### PR DESCRIPTION
[Issue here](https://github.com/primefaces/primevue/issues/1710#issue-1038496613)
I'd like to add the function type to the `optionLabel` in the Dropdown to get rid of the Volar error when using a function.

```ts
    <Dropdown
      :options="options"
      :optionLabel="(option) => option.foo" // <--- Type '(option: any) => any' is not assignable to type 'string'.ts(2322)
    ></Dropdown>
```