### PR TITLE
Fix DataTable Element Closure in Datatable Documentation

### DIFF
--- a/src/views/datatable/DataTableDoc.vue
+++ b/src/views/datatable/DataTableDoc.vue
@@ -721,7 +721,7 @@ export default {
             &lt;InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter" :placeholder="`Search by name - ${filterModel.matchMode}`"/&gt;
         &lt;/template&gt;
     &lt;/Column&gt;
-&lt;DataTable&gt;
+&lt;/DataTable&gt;
 
 </template>
 </code></pre>
@@ -737,7 +737,7 @@ export default {
             &lt;InputText type="text" v-model="filterModel.value" @keydown.enter="filterCallback()" class="p-column-filter" :placeholder="`Search by name - ${filterModel.matchMode}`"/&gt;
         &lt;/template&gt;
     &lt;/Column&gt;
-&lt;DataTable&gt;
+&lt;/DataTable&gt;
 
 </template>
 </code></pre>


### PR DESCRIPTION
Two closures are missing on "Filter Row" and "Filter Menu" section on docs

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.