### PR TITLE
Fix show method when it is called from outside

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -419,9 +419,9 @@ export default {
             else if (!this.overlay || !this.overlay.contains(event.target)) {
                 if (this.overlayVisible)
                     this.hide();
-                else 
+                else
                     this.show();
-                
+
                 this.$refs.focusInput.focus();
             }
         },

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -239,7 +239,10 @@ export default {
         },
         show() {
             this.$emit('before-show');
-            this.overlayVisible = true;
+            setTimeout(() => {
+                this.overlayVisible = true;
+                this.$refs.focusInput.focus();
+            });
         },
         hide() {
             this.$emit('before-hide');
@@ -416,9 +419,9 @@ export default {
             else if (!this.overlay || !this.overlay.contains(event.target)) {
                 if (this.overlayVisible)
                     this.hide();
-                else
+                else 
                     this.show();
-
+                
                 this.$refs.focusInput.focus();
             }
         },


### PR DESCRIPTION
### Defect Fixes

This PR fixes #1771. When we were calling the `show()` method it wasn't showing the overlay to select items. It was happening in a special case where I implemented a click event to a button to open the dropdown items.

The `show()` method was being called correctly, but right after this the `hide()` method was also being called. The `hide()` method is being called in this scenario because of `bindOutsideClickListener()` that adds a listener to `document` and when the clicked comes from outside the `hide()` method is fired.

I tried to solve it without making aggressive changes, I just put it inside of a `setTimeout()` and it worked as expected. It [queues the instruction `this.overlayVisible` to be executed after the listener](https://johnresig.com/blog/how-javascript-timers-work/).
