### PR TITLE
Correct check MenuItem is disabled 

### DIFF
--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -85,7 +85,7 @@ export default {
     methods: {
         itemClick(event) {
             const item = event.item;
-            if (item.disabled) {
+            if (this.disabled(item)) {
                 return;
             }
 
@@ -196,6 +196,9 @@ export default {
         },
         label(item) {
             return (typeof item.label === 'function' ? item.label() : item.label);
+        },
+        disabled(item) {
+            return (typeof item.disabled === 'function' ? item.disabled() : item.disabled);
         },
         containerRef(el) {
             this.container = el;


### PR DESCRIPTION
If the "disabled" property of MenuItem is defined as a function, then when you try to execute a command by pressing MenuItem, the command is not executed, because **item.disabled** is always true.
Behavior is reproduced: https://codesandbox.io/s/menu-item-disabled-function-579mm