### PR TITLE
use type name instead of HTML tag to determine if child is column

### DIFF
--- a/src/components/datatable/TableFooter.vue
+++ b/src/components/datatable/TableFooter.vue
@@ -41,7 +41,7 @@ export default {
                 row.child.$scopedSlots.default().forEach(child => {
                     if (child.child && child.child.children && child.child.children instanceof Array)
                         cols = [...cols, ...child.child.children];
-                    else if (child.componentOptions.tag === 'Column')
+                    else if (child.type.name === 'Column')
                         cols.push(child);
                 });
 

--- a/src/components/datatable/TableHeader.vue
+++ b/src/components/datatable/TableHeader.vue
@@ -136,7 +136,7 @@ export default {
                 row.child.$scopedSlots.default().forEach(child => {
                     if (child.child && child.child.children && child.child.children instanceof Array)
                         cols = [...cols, ...child.child.children];
-                    else if (child.componentOptions.tag === 'Column')
+                    else if (child.type.name === 'Column')
                         cols.push(child);
                 });
 


### PR DESCRIPTION
###Defect Fixes
Fixes #1927  

This allows users to customize `Column` tags to something other than `Column`, such as `PrimeColumn`.

Follows examples like: https://github.com/primefaces/primevue/blob/2.x/src/components/datatable/DataTable.vue#L1773