### PR TITLE
Update TabPanel.d.ts

### DIFF
--- a/src/components/tabpanel/TabPanel.d.ts
+++ b/src/components/tabpanel/TabPanel.d.ts
@@ -17,6 +17,10 @@ export interface TabPanelSlots {
      * Custom content template.
      */
     default: () => VNode[];
+    /**
+     * Custom header template.
+     */
+    header: () => VNode[];
 }
 
 export declare type TabPanelEmits = {


### PR DESCRIPTION
Fixed [#1943 ](Type definition for 'header' slot missing in TabPanel component)