### PR TITLE
bugfix/tooltip_wrong_position: fixed

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -132,6 +132,10 @@ function align(el) {
         alignTop(el);
         if (isOutOfBounds(el)) {
             alignBottom(el);
+
+            if (isOutOfBounds(el)) {
+                alignTop(el);
+            }
         }
     }
     else if (modifiers.left) {
@@ -144,6 +148,10 @@ function align(el) {
 
                 if (isOutOfBounds(el)) {
                     alignBottom(el);
+
+                    if (isOutOfBounds(el)) {
+                        alignLeft(el);
+                    }
                 }
             }
         }
@@ -152,6 +160,10 @@ function align(el) {
         alignBottom(el);
         if (isOutOfBounds(el)) {
             alignTop(el);
+
+            if (isOutOfBounds(el)) {
+                alignBottom(el);
+            }
         }
     }
     else {
@@ -164,6 +176,10 @@ function align(el) {
 
                 if (isOutOfBounds(el)) {
                     alignBottom(el);
+
+                    if (isOutOfBounds(el)) {
+                        alignRight(el);
+                    }
                 }
             }
         }


### PR DESCRIPTION
###Defect Fixes
Corresponding issue: [issue 1976](https://github.com/primefaces/primevue/issues/1976#issuecomment-1013784156)

###Feature Requests
The tooltip will adjust position if the configured position has no enough space, When the adjusted position still has no enough space, just keep it at the configured position.