### PR TITLE
api-generator inputswitch wrong false value

### DIFF
--- a/api-generator/components/inputswitch.js
+++ b/api-generator/components/inputswitch.js
@@ -26,7 +26,7 @@ const InputSwitchProps = [
     {
         name: "falseValue",
         type: "any",
-        default: "true",
+        default: "false",
         description: "Value in unchecked state."
     }
 ];


### PR DESCRIPTION
Fix the default value for falseValue otherwise the inputswitch is stuck in a true state

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.