### PR TITLE
Add Function to Column prop field types

### DIFF
--- a/src/components/column/Column.vue
+++ b/src/components/column/Column.vue
@@ -7,7 +7,7 @@ export default {
             default: null
         },
         field: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         sortField: {
@@ -15,7 +15,7 @@ export default {
             default: null
         },
         filterField: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         dataType: {


### PR DESCRIPTION
Fix for #2097

To match the Typescript types added in #1078 and not trigger Vue's "Invalid prop" warnings.