### PR TITLE
Toast: add missing 'top-right' ToastPositionType causing Typescript compilation errors

### DIFF
--- a/src/components/toast/Toast.d.ts
+++ b/src/components/toast/Toast.d.ts
@@ -1,7 +1,7 @@
 import { VNode } from 'vue';
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers';
 
-type ToastPositionType = 'top-left' | 'top-center' | 'bottom-left' | 'bottom-center' | 'bottom-right' | 'center' | undefined;
+type ToastPositionType = 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right' | 'center' | undefined;
 
 type ToastMessageSeverityType = 'success' | 'info' | 'warn' | 'error' | undefined;
 


### PR DESCRIPTION
**Toast**: add missing `'top-right'` `ToastPositionType` causing Typescript compilation errors