### PR TITLE
Fixed #1389 - Dropdown search dont work with gboard And Colspan Datatables

### DIFF
--- a/src/components/datatable/TableBody.vue
+++ b/src/components/datatable/TableBody.vue
@@ -505,7 +505,18 @@ export default {
     },
     computed: {
         columnsLength() {
-            return this.columns ? this.columns.length : 0;
+
+            let lengthHidden = 0;
+            //For Colspan
+            this.columns.forEach(column => {
+                if(column.props.hidden !== undefined){
+                    if(column.props.hidden){
+                        lengthHidden = lengthHidden+1;
+                    }
+                }    
+            });
+                 
+            return this.columns ? this.columns.length - lengthHidden : 0;
         },
         rowGroupHeaderStyle() {
             if (this.scrollable) {

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -21,7 +21,7 @@
                     <slot name="header" :value="modelValue" :options="visibleOptions"></slot>
                     <div class="p-dropdown-header" v-if="filter">
                         <div  class="p-dropdown-filter-container">
-                            <input type="text" ref="filterInput" v-model="filterValue" @vnode-updated="onFilterUpdated" autoComplete="off" class="p-dropdown-filter p-inputtext p-component" :placeholder="filterPlaceholder" @keydown="onFilterKeyDown"  @input="onFilterChange"/>
+                            <input type="text" ref="filterInput" :value="filterValue" @vnode-updated="onFilterUpdated" autoComplete="off" class="p-dropdown-filter p-inputtext p-component" :placeholder="filterPlaceholder" @keydown="filterValue = $event.target.value" @input="filterValue = $event.target.value"/>
                             <span class="p-dropdown-filter-icon pi pi-search"></span>
                         </div>
                     </div>


### PR DESCRIPTION
###Defect Fixes
IME composition fixed in all keyboards, broadcast filter not firing when using gboard

Fix incorrect colspan when using property hidden=”true”
The number of columns is incorrect 

![image](https://user-images.githubusercontent.com/22731770/154872790-15294337-cf66-44c5-9ca4-0bfdc5039049.png)

Correct 

![image](https://user-images.githubusercontent.com/22731770/154872814-e9e76576-de7b-453c-adfb-b4be67d7c87b.png)

 
