### PR TITLE
Fixed #1723 - Clear file list after upload

### DIFF
--- a/src/components/fileupload/FileUpload.vue
+++ b/src/components/fileupload/FileUpload.vue
@@ -191,6 +191,7 @@ export default {
                 }
 
                 this.$emit('uploader', {files: this.files});
+                this.clear()
             }
             else {
                 let xhr = new XMLHttpRequest();


### PR DESCRIPTION
### Defect Fixes

We can't re-select a new file because the file list is not cleared after uploading when using Custom Uploader with basic mode.
ref: https://github.com/primefaces/primevue/issues/1723

#### Implementation to reproduce

```vue
<FileUpload mode="basic" name="demo[]" :customUpload="true" @uploader="myUploader" />
```

```js
myUploader(event) {
    //event.files == files to upload
}
```

#### Reference implementation

In case not using Custom Uploader, it clear file list after upload.

https://github.com/primefaces/primevue/blob/a48fcc34d404c61194b97c0df8f5b8c0273aabb2/src/components/fileupload/FileUpload.vue#L240


How about this patch?
