### PR TITLE
Fix Bug Colspan - Error in datatables when using hidden

### DIFF
--- a/src/components/datatable/TableBody.vue
+++ b/src/components/datatable/TableBody.vue
@@ -505,7 +505,18 @@ export default {
     },
     computed: {
         columnsLength() {
-            return this.columns ? this.columns.length : 0;
+
+            let lengthHidden = 0;
+            //For Colspan
+            this.columns.forEach(column => {
+                if(column.props.hidden !== undefined){
+                    if(column.props.hidden){
+                        lengthHidden = lengthHidden+1;
+                    }
+                }    
+            });
+                 
+            return this.columns ? this.columns.length - lengthHidden : 0;
         },
         rowGroupHeaderStyle() {
             if (this.scrollable) {


### PR DESCRIPTION
Fix incorrect colspan when using property hidden=”true”
The number of columns in the colspan is incorrect since when using the property, the column does not really exist, this modification does not affect any existing functionality and leaves the table structure correctly.

Incorrect

![image](https://user-images.githubusercontent.com/22731770/154984589-c3ac934f-097e-4aa6-babe-666a163ff9d5.png)


Correct

![image](https://user-images.githubusercontent.com/22731770/154984623-899c0f87-8c13-4f93-87bb-d868aad977ed.png)
