### PR TITLE
Fixed class binding quotation mark typo on Menubar Docs

### DIFF
--- a/src/views/menubar/MenubarDoc.vue
+++ b/src/views/menubar/MenubarDoc.vue
@@ -183,7 +183,7 @@ export default {
 &lt;Menubar :model="items"&gt;
     &lt;template #item="{item}"&gt;
         &lt;router-link :to="item.to" custom v-slot="{href, route, navigate, isActive, isExactActive}"&gt;
-            &lt;a :href="href" @click="navigate" :class="{'active-link': isActive, 'active-link-exact": isExactActive}&gt;{{route.fullPath}}&lt;/a&gt;
+            &lt;a :href="href" @click="navigate" :class="{'active-link': isActive, 'active-link-exact': isExactActive}"&gt;{{route.fullPath}}&lt;/a&gt;
         &lt;/router-link&gt;
     &lt;/template&gt;
 &lt;/Menubar&gt;


### PR DESCRIPTION
On line 186 there is a class binding quotation mark typo inside the <a> tag on the router configuration example that leads to an error when used. Simply changed
:class="{'active-link': isActive, 'active-link-exact": isExactActive}
to
:class="{'active-link': isActive, 'active-link-exact': isExactActive}"
in the <a> tag.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.