### PR TITLE
Add stop modifier to RowCheckbox click event

### DIFF
--- a/src/components/datatable/RowCheckbox.vue
+++ b/src/components/datatable/RowCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['p-checkbox p-component', {'p-checkbox-focused': focused}]" @click="onClick">
+    <div :class="['p-checkbox p-component', {'p-checkbox-focused': focused}]" @click.stop.prevent="onClick">
         <div ref="box" :class="['p-checkbox-box p-component', {'p-highlight': checked, 'p-disabled': $attrs.disabled, 'p-focus': focused}]"
             role="checkbox" :aria-checked="checked" :tabindex="$attrs.disabled ? null : '0'" @keydown.space.prevent="onClick" @focus="onFocus($event)" @blur="onBlur($event)">
             <span :class="['p-checkbox-icon', {'pi pi-check': checked}]"></span>


### PR DESCRIPTION
To prevent clicks from propagating through to the row and triggering a row select/unselect event which undoes the effect.

Fixes #2259 