### PR TITLE
fix message accessibility bug and calendar stay visible after VoiceOver focus out issue

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -1,5 +1,5 @@
 <template>
-    <span ref="container" :class="containerClass" :style="style">
+    <span ref="container" :class="containerClass" :style="style" @focusout="hideOverlay">
         <input :ref="inputRef" v-if="!inline" type="text" :class="['p-inputtext p-component', inputClass]" :style="inputStyle" @input="onInput" v-bind="$attrs"
             @focus="onFocus" @blur="onBlur" @keydown="onKeyDown" :readonly="!manualInput" inputmode="none">
         <CalendarButton v-if="showIcon" :icon="icon" tabindex="-1" class="p-datepicker-trigger" :disabled="$attrs.disabled" @click="onButtonClick" type="button" :aria-label="inputFieldValue"/>
@@ -414,6 +414,10 @@ export default {
         }
     },
     methods: {
+        hideOverlay() {
+            this.overlayVisible = false;
+            this.updateFocus();
+        },
         isComparable() {
             return this.modelValue != null && typeof this.modelValue !== 'string';
         },

--- a/src/components/message/Message.vue
+++ b/src/components/message/Message.vue
@@ -1,6 +1,6 @@
 <template>
     <transition name="p-message" appear>
-        <div :class="containerClass" v-show="visible" role="alert">
+        <div :class="containerClass" v-if="visible" role="alert">
             <div class="p-message-wrapper">
                 <span :class="iconClass"></span>
                 <div class="p-message-text">


### PR DESCRIPTION
###Defect Fixes
Message accessibility bug

I'm submitting a accessibility bug (check one with "x")

MacOS VoiceOver close Message will bring focus to top element of page

Minimal reproduction of the problem with instructions

Visit official document of InputSwitch
https://www.primefaces.org/primevue/#/message
Enable VoiceOver from Mac
Focus any message then close it.
Navigate to next message or element, VO focus go to top element (website header logo).
Please tell us about your environment:
MacOS 10.15.7

PrimeVue version: 3.4.X
3.12.1

Browser:
Safari 15.3 / Chrome 99.0.4844
