### PR TITLE
Datatable - selection performance issue

### DIFF
--- a/src/components/datatable/DataTable.vue
+++ b/src/components/datatable/DataTable.vue
@@ -880,8 +880,8 @@ export default {
                 this.$emit('row-unselect', { originalEvent: event.originalEvent, data: rowData, index: event.index, type: 'checkbox' });
             }
             else {
-                let _selection = this.selection ? [...this.selection] : [];
-                _selection = [..._selection, rowData];
+                let _selection = this.selection ? [...this.selection, rowData] : [rowData];
+
                 this.$emit('update:selection', _selection);
                 this.$emit('row-select', { originalEvent: event.originalEvent, data: rowData, index: event.index, type: 'checkbox' });
             }
@@ -903,7 +903,6 @@ export default {
                 }
 
                 this.$emit('update:selection', _selection);
-
             }
         },
         isSingleSelectionMode() {
@@ -1890,7 +1889,16 @@ export default {
             }
             else {
                 const val = this.frozenValue ? [...this.frozenValue, ...this.processedData] : this.processedData;
-                return val && this.selection && Array.isArray(this.selection) && val.every(v => this.selection.some(s => this.equals(s, v)));
+
+                const partialResult = val && this.selection && Array.isArray(this.selection) ;
+                if (!partialResult) { return false }
+
+                if (this.compareSelectionBy === 'equals') {
+                    const s = new Set(this.selection);
+                    return val.every(v => s.has(v));
+                } else {
+                    return val.every(v => this.selection.some(s => this.equals(s, v)));
+                }
             }
         },
         attributeSelector() {


### PR DESCRIPTION
###Defect Fixes
"Selecting all" with checkbox in the header in a table with more than hundred rows it's really slow.

Row: 883
I found spread operator two times. In my opinion, one time is enough. 

Rows: 1892 / 1898 
If the user specified “compareSelectionBy” as “equals” we can take advantage from Set collection’s method “has” and reduce operation time from almost *3s* to some *ms.*

I tested it with a collection of 1 thousand elements, in a non lazy table and multiple selection.