### PR TITLE
fix global prop type definition in Vue 3

### DIFF
--- a/src/components/config/PrimeVue.d.ts
+++ b/src/components/config/PrimeVue.d.ts
@@ -62,3 +62,11 @@ declare module 'vue/types/vue' {
         }
     }
 }
+
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $primevue: {
+            config: PrimeVueConfiguration;
+        }
+    }
+}


### PR DESCRIPTION
fix #2315