### PR TITLE
Fix Password component when get prop "inputClass" with Object type

### DIFF
--- a/src/components/inputtext/InputText.spec.js
+++ b/src/components/inputtext/InputText.spec.js
@@ -1,5 +1,5 @@
 import { mount } from  '@vue/test-utils';
-import InputText from '@/components/inputText/InputText.vue';
+import InputText from './InputText.vue';
 
 describe('InputText.vue', () => {
     it('is InputText component exists', async () => {

--- a/src/components/password/Password.vue
+++ b/src/components/password/Password.vue
@@ -74,7 +74,7 @@ export default {
             type: String,
             default: 'pi pi-eye'
         },
-        inputClass: String,
+        inputClass: null,
         inputStyle: null,
         style: null,
         class: String,


### PR DESCRIPTION
When using a component including an "inputClass" parameter with type Object in the browser console, you may see an error with  types mismatch in component. TypeScript accept to the type of any, while the component points to String