### PR TITLE
Fix #2516: Carousel less items than allocated slots

### DIFF
--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -477,7 +477,7 @@ export default {
 	},
 	computed: {
 		totalIndicators() {
-			return this.value ? Math.ceil((this.value.length - this.d_numVisible) / this.d_numScroll) + 1 : 0;
+			return this.value ? Math.max(Math.ceil((this.value.length - this.d_numVisible) / this.d_numScroll) + 1, 0) : 0;
 		},
 		backwardIsDisabled() {
 			return (this.value && (!this.circular || this.value.length < this.d_numVisible) && this.d_page === 0);


### PR DESCRIPTION
###Defect Fixes
Fix #2516: Carousel less items than allocated slots

see https://github.com/primefaces/primefaces/issues/8265 for original bug and issue