### PR TITLE
#2546 - fix issue where Calendar.vue was always using the first date …

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -2246,7 +2246,11 @@ export default {
             }
 
             if (propValue && Array.isArray(propValue)) {
-                propValue = propValue[0];
+                if (this.isRangeSelection()) {
+                    propValue = propValue[1] || propValue[0];
+                } else if (this.isMultipleSelection()) {
+                    propValue = propValue[propValue.length - 1];
+                }
             }
 
             return propValue || new Date();


### PR DESCRIPTION
…when using multiple or range selection.

###Defect Fixes
Fixes: #2546
Fixed the issue allowing time selection on the end date, as well as editting the time in the multiple selection mode.