### PR TITLE
Fixes #2651 RadioButton deprecated v-bind use on non-boolean attributes

### DIFF
--- a/src/components/radiobutton/RadioButton.vue
+++ b/src/components/radiobutton/RadioButton.vue
@@ -48,7 +48,7 @@ export default {
     },
     computed: {
         checked() {
-            return this.modelValue != null && ObjectUtils.equals(this.modelValue, this.value);
+            return (this.modelValue != null && ObjectUtils.equals(this.modelValue, this.value)) || null;
         },
         containerClass() {
             return ['p-radiobutton p-component', this.class, {'p-radiobutton-checked': this.checked, 'p-radiobutton-disabled': this.$attrs.disabled, 'p-radiobutton-focused': this.focused}];

--- a/src/components/radiobutton/RadioButton.vue
+++ b/src/components/radiobutton/RadioButton.vue
@@ -3,7 +3,7 @@
         <div class="p-hidden-accessible">
             <input ref="input" type="radio" :checked="checked" :value="value" v-bind="$attrs" @focus="onFocus" @blur="onBlur">
         </div>
-        <div ref="box" :class="['p-radiobutton-box', {'p-highlight': checked, 'p-disabled': $attrs.disabled, 'p-focus': focused}]" role="radio" :aria-checked="checked">
+        <div ref="box" :class="['p-radiobutton-box', {'p-highlight': checked, 'p-disabled': $attrs.disabled, 'p-focus': focused}]" role="radio" :aria-checked="checked || null">
             <div class="p-radiobutton-icon"></div>
         </div>
     </div>
@@ -48,7 +48,7 @@ export default {
     },
     computed: {
         checked() {
-            return (this.modelValue != null && ObjectUtils.equals(this.modelValue, this.value)) || null;
+            return this.modelValue != null && ObjectUtils.equals(this.modelValue, this.value);
         },
         containerClass() {
             return ['p-radiobutton p-component', this.class, {'p-radiobutton-checked': this.checked, 'p-radiobutton-disabled': this.$attrs.disabled, 'p-radiobutton-focused': this.focused}];

--- a/src/components/radiobutton/RadioButton.vue
+++ b/src/components/radiobutton/RadioButton.vue
@@ -3,7 +3,7 @@
         <div class="p-hidden-accessible">
             <input ref="input" type="radio" :checked="checked" :value="value" v-bind="$attrs" @focus="onFocus" @blur="onBlur">
         </div>
-        <div ref="box" :class="['p-radiobutton-box', {'p-highlight': checked, 'p-disabled': $attrs.disabled, 'p-focus': focused}]" role="radio" :aria-checked="checked || null">
+        <div ref="box" :class="['p-radiobutton-box', {'p-highlight': checked, 'p-disabled': $attrs.disabled, 'p-focus': focused}]" role="radio" :aria-checked="'' + checked">
             <div class="p-radiobutton-icon"></div>
         </div>
     </div>


### PR DESCRIPTION
The following warning results in Vue 3 with Sakai and the latest Primevue

https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html
```
[Vue warn]: (deprecation ATTR_FALSE_VALUE) Attribute "aria-checked" with v-bind value `false` will render aria-checked="false" instead of removing it in Vue 3. To remove the attribute, use `null` or `undefined` instead. If the usage is intended, you can disable the compat behavior and suppress this warning with:

  configureCompat({ ATTR_FALSE_VALUE: false })

  Details: https://v3-migration.vuejs.org/breaking-changes/attribute-coercion.html 
  at <RadioButton id="input_outlined" name="inputstyle" value="outlined"  ... > 
  at <AppConfig layoutMode="static" onLayoutChange=fn<bound onLayoutChange> > 
  at <App onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< undefined > > 
  at <RouterView> 
  at <AppWrapper>
```

## Defect Fixes
When submitting a PR, please also create an issue documenting the error.
