### PR TITLE
Documentation quickfix: filterMatchModeOptions: Use valid object

### DIFF
--- a/src/views/datatable/DataTableDoc.vue
+++ b/src/views/datatable/DataTableDoc.vue
@@ -840,8 +840,8 @@ app.use(PrimeVue, {
 
                 <pre v-code.script><code>
 matchModes: [
-    {label: 'Starts With', FilterMatchMode.STARTS_WITH},
-    {label: 'Contains', FilterMatchMode.CONTAINS},
+    {label: 'Starts With', value: FilterMatchMode.STARTS_WITH},
+    {label: 'Contains', value: FilterMatchMode.CONTAINS},
 ]
 </code></pre>
 
@@ -856,8 +856,8 @@ FilterService.register('myfilter', (a,b) => a === b);
 <pre v-code.script><code>
 matchModes: [
     {label: 'My Filter', "myfilter"},
-    {label: 'Starts With', FilterMatchMode.STARTS_WITH},
-    {label: 'Contains', FilterMatchMode.CONTAINS},
+    {label: 'Starts With', value: FilterMatchMode.STARTS_WITH},
+    {label: 'Contains', value: FilterMatchMode.CONTAINS},
 ]
 </code></pre>
 


### PR DESCRIPTION
With label and value as described

###Defect Fixes
Simple fix for invalid config object