### PR TITLE
Fixed DialogProps type error issue: "Component: Dynamic Dialog #2699"

### DIFF
--- a/src/components/dialog/Dialog.d.ts
+++ b/src/components/dialog/Dialog.d.ts
@@ -42,6 +42,10 @@ export interface DialogProps {
      */
     modal?: boolean | undefined;
     /**
+     * Style of the dialog.
+     */
+    style?: any;
+    /**
      * Style of the content section.
      */
     contentStyle?: any;


### PR DESCRIPTION
type DialogProps was missing the style property, causing typescript to raise irrelevant errors when styling dynamic dialogs.
Fixed by adding style as optional property to type DialogProps

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.