### PR TITLE
Made month-chage event consistent

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -689,7 +689,7 @@ export default {
                     this.currentMonth++;
                 }
 
-                this.$emit('month-change', {month: this.currentMonth , year: this.currentYear});
+                this.$emit('month-change', {month: this.currentMonth + 1, year: this.currentYear});
             }
         },
         decrementYear() {

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -664,7 +664,7 @@ export default {
                     this.currentMonth--;
                 }
 
-                this.$emit('month-change', {month: this.currentMonth, year: this.currentYear});
+                this.$emit('month-change', {month: this.currentMonth + 1, year: this.currentYear});
             }
         },
         navForward(event) {


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
a fix for issue #2696
changed all month-change emits to emit in the 1-12 range rather than a mix of 0-11 and 1-12. 
it was changed this way as it is easier to forget a +1 then accidentally add a +1, so it is safer to assume this is the intended behavior and the 2 returning 0-11 was a mistake

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.