### PR TITLE
feat: bind event item to timeline custom connector slot

### DIFF
--- a/src/components/timeline/Timeline.vue
+++ b/src/components/timeline/Timeline.vue
@@ -8,7 +8,7 @@
                 <slot name="marker" :item="item" :index="index">
                     <div class="p-timeline-event-marker"></div>
                 </slot>
-                <slot name="connector" v-if="index !== (value.length - 1)">
+                <slot name="connector" v-if="index !== (value.length - 1)" :item="item" :index="index">
                     <div class="p-timeline-event-connector"></div>
                 </slot>
             </div>


### PR DESCRIPTION
Currently, style overrides to the timeline connector component happen globally at the timeline component level.  It is not an uncommon use case to require dynamic style overrides across multiple connectors for a given timeline instance. This can be achieved (as is being done with the `marker` and `content` named slot) by binding the `item` property to the `connector` named slot. This enables the following type of customization to connectors for a given timeline.

```vue
<template #connector="slotProps">
            <div
              class="p-timeline-event-connector"
              :style="{ width: '4px', backgroundColor: slotProps.item.color }"
            ></div>
</template>
```

![image](https://user-images.githubusercontent.com/28514482/178623384-7f5b448a-f59c-460d-9e91-a0e661590c76.png)

Unless there is a strong reason to not support this (can't see what that reason would be) I think this would be a really useful addition to the component!