### PR TITLE
Issue #2808 Bug fix: ColorPicker Hue does not change to violet unexpectedly

### DIFF
--- a/src/components/colorpicker/ColorPicker.vue
+++ b/src/components/colorpicker/ColorPicker.vue
@@ -72,23 +72,26 @@ export default {
     },
     data() {
         return {
-            overlayVisible: false
+            overlayVisible: false,
+            hsbValue: {
+                h: 0,
+                s: 100,
+                b: 100
+            },
+            outsideClickListener: null,
+            documentMouseMoveListener: null,
+            documentMouseUpListener: null,
+            scrollHandler: null,
+            resizeListener: null,
+            hueDragging: false,
+            colorDragging: false,
+            picker: null,
+            colorSelector: null,
+            colorHandle: null,
+            hueView: null,
+            hueHandle: null,
         };
     },
-    hsbValue: null,
-    outsideClickListener: null,
-    documentMouseMoveListener: null,
-    documentMouseUpListener: null,
-    scrollHandler: null,
-    resizeListener: null,
-    hueDragging: null,
-    colorDragging: null,
-    selfUpdate: null,
-    picker: null,
-    colorSelector: null,
-    colorHandle: null,
-    hueView: null,
-    hueHandle: null,
     beforeUnmount() {
         this.unbindOutsideClickListener();
         this.unbindDragListeners();
@@ -107,19 +110,7 @@ export default {
     },
     mounted() {
         this.updateUI();
-    },
-    watch: {
-        modelValue: {
-            immediate: true,
-            handler(newValue) {
-                this.hsbValue = this.toHSB(newValue);
-
-                if (this.selfUpdate)
-                    this.selfUpdate = false;
-                else
-                    this.updateUI();
-            }
-        }
+        this.updateModel();
     },
     methods: {
         pickColor(event) {
@@ -134,7 +125,6 @@ export default {
                 b: brightness
             });
 
-            this.selfUpdate = true;
             this.updateColorHandle();
             this.updateInput();
             this.updateModel();
@@ -142,13 +132,9 @@ export default {
         },
         pickHue(event) {
             let top = this.hueView.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0);
-            this.hsbValue = this.validateHSB({
-                h: Math.floor(360 * (150 - Math.max(0, Math.min(150, ((event.pageY || event.changedTouches[0].pageY) - top)))) / 150),
-                s: 100,
-                b: 100
-            });
+            const hueInput = Math.floor(360 * (150 - Math.max(0, Math.min(150, ((event.pageY || event.changedTouches[0].pageY) - top)))) / 150);
+            this.hsbValue.h = Math.min(360, Math.max(0, hueInput));
 
-            this.selfUpdate = true;
             this.updateColorSelector();
             this.updateHue();
             this.updateModel();
@@ -176,12 +162,12 @@ export default {
         },
         updateColorSelector() {
             if (this.colorSelector) {
-                let hsbValue = this.validateHSB({
+                this.hsbValue = this.validateHSB(this.hsbValue);
+                this.colorSelector.style.backgroundColor = '#' + this.HSBtoHEX({
                     h: this.hsbValue.h,
                     s: 100,
                     b: 100
                 });
-                this.colorSelector.style.backgroundColor = '#' + this.HSBtoHEX(hsbValue);
             }
         },
         updateColorHandle() {
@@ -221,10 +207,10 @@ export default {
             };
         },
         validateHEX(hex) {
-            var len = 6 - hex.length;
+            const len = 6 - hex.length;
             if (len > 0) {
-                var o = [];
-                for (var i=0; i<len; i++) {
+                let o = [];
+                for (let i=0; i<len; i++) {
                     o.push('0');
                 }
                 o.push(hex);
@@ -232,50 +218,13 @@ export default {
             }
             return hex;
         },
-        HEXtoRGB(hex) {
-            let hexValue = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
-            return {r: hexValue >> 16, g: (hexValue & 0x00FF00) >> 8, b: (hexValue & 0x0000FF)};
-        },
-        HEXtoHSB(hex) {
-            return this.RGBtoHSB(this.HEXtoRGB(hex));
-        },
-        RGBtoHSB(rgb) {
-            var hsb = {
-                h: 0,
-                s: 0,
-                b: 0
-            };
-            var min = Math.min(rgb.r, rgb.g, rgb.b);
-            var max = Math.max(rgb.r, rgb.g, rgb.b);
-            var delta = max - min;
-            hsb.b = max;
-            hsb.s = max !== 0 ? 255 * delta / max : 0;
-            if (hsb.s !== 0) {
-                if (rgb.r === max) {
-                    hsb.h = (rgb.g - rgb.b) / delta;
-                } else if (rgb.g === max) {
-                    hsb.h = 2 + (rgb.b - rgb.r) / delta;
-                } else {
-                    hsb.h = 4 + (rgb.r - rgb.g) / delta;
-                }
-            } else {
-                hsb.h = -1;
-            }
-            hsb.h *= 60;
-            if (hsb.h < 0) {
-                hsb.h += 360;
-            }
-            hsb.s *= 100/255;
-            hsb.b *= 100/255;
-            return hsb;
-        },
         HSBtoRGB(hsb) {
-            var rgb = {
+            let rgb = {
                 r: null, g: null, b: null
             };
-            var h = Math.round(hsb.h);
-            var s = Math.round(hsb.s*255/100);
-            var v = Math.round(hsb.b*255/100);
+            let h = Math.round(hsb.h);
+            const s = Math.round(hsb.s*255/100);
+            const v = Math.round(hsb.b*255/100);
             if (s === 0) {
                 rgb = {
                     r: v,
@@ -284,28 +233,28 @@ export default {
                 }
             }
             else {
-                var t1 = v;
-                var t2 = (255-s)*v/255;
-                var t3 = (t1-t2)*(h%60)/60;
+                let t1 = v;
+                let t2 = (255-s)*v/255;
+                let t3 = (t1-t2)*(h%60)/60;
                 if (h===360) h = 0;
-                if (h<60) {rgb.r=t1;	rgb.b=t2; rgb.g=t2+t3}
-                else if (h<120) {rgb.g=t1; rgb.b=t2;	rgb.r=t1-t3}
-                else if (h<180) {rgb.g=t1; rgb.r=t2;	rgb.b=t2+t3}
-                else if (h<240) {rgb.b=t1; rgb.r=t2;	rgb.g=t1-t3}
-                else if (h<300) {rgb.b=t1; rgb.g=t2;	rgb.r=t2+t3}
-                else if (h<360) {rgb.r=t1; rgb.g=t2;	rgb.b=t1-t3}
+                if (h<60) {rgb.r=t1; rgb.b=t2; rgb.g=t2+t3}
+                else if (h<120) {rgb.g=t1; rgb.b=t2; rgb.r=t1-t3}
+                else if (h<180) {rgb.g=t1; rgb.r=t2; rgb.b=t2+t3}
+                else if (h<240) {rgb.b=t1; rgb.r=t2; rgb.g=t1-t3}
+                else if (h<300) {rgb.b=t1; rgb.g=t2; rgb.r=t2+t3}
+                else if (h<360) {rgb.r=t1; rgb.g=t2; rgb.b=t1-t3}
                 else {rgb.r=0; rgb.g=0;	rgb.b=0}
             }
             return {r:Math.round(rgb.r), g:Math.round(rgb.g), b:Math.round(rgb.b)};
         },
         RGBtoHEX(rgb) {
-            var hex = [
+            let hex = [
                 rgb.r.toString(16),
                 rgb.g.toString(16),
                 rgb.b.toString(16)
             ];
 
-            for (var key in hex) {
+            for (let key in hex) {
                 if (hex[key].length === 1) {
                     hex[key] = '0' + hex[key];
                 }
@@ -315,33 +264,6 @@ export default {
         },
         HSBtoHEX(hsb) {
             return this.RGBtoHEX(this.HSBtoRGB(hsb));
-        },
-        toHSB(value) {
-            let hsb;
-
-            if (value) {
-                switch (this.format) {
-                    case 'hex':
-                        hsb = this.HEXtoHSB(value);
-                    break;
-
-                    case 'rgb':
-                        hsb = this.RGBtoHSB(value);
-                    break;
-
-                    case 'hsb':
-                        hsb = value;
-                    break;
-
-                    default:
-                        break;
-                }
-            }
-            else {
-                hsb = this.HEXtoHSB(this.defaultColor);
-            }
-
-            return hsb;
         },
         onOverlayEnter(el) {
             this.updateUI();


### PR DESCRIPTION
Fix for issue #2808 

The ColorPicker component was unexpectedly changing to a pure violet hue when the color picker circle was dragged to the bottom or left side. This PR contains changes that fix that bug.

While investigating the bug, I found a lot of unnecessary code that was converting HSB format colors to Hex and back, causing strange behavior that constantly changed the hue value while dragging the color picker. I've removed the unnecessary code.

I've also taken the liberty to do some light housekeeping, like moving local variables into the data return block, changing all vars to let or const, and removing some extra whitespace.

Changes:
- Moves variables into data return block
- Sets default values for hsbValue
- Removes unnecessary Watch function
- Removes unnecessary variable that was used in the Watch function
- Removes unnecessary conversion to HSB format functions (the component doesn't need to convert to HSB because it has a variable holding those values)
- Necessary refactors for desired functionality
- Some code cleanup

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.