### PR TITLE
fixed typo in AutoComplete.d.ts: AutoCompletenOptionLabelType -> AutoCompleteOptionLabelType with no extra "n"

### DIFF
--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -92,7 +92,7 @@ export interface AutoCompleteProps {
      * Property name or getter function to use as the label of an option group.
      * @see AutoCompletenOptionLabelType
      */
-    optionGroupLabel?: AutoCompletenOptionLabelType;
+    optionGroupLabel?: AutoCompleteOptionLabelType;
     /**
      * Property name or getter function that refers to the children options of option group.
      * @see AutoCompleteOptionChildrenType


### PR DESCRIPTION
typo: changed "AutoCompletenOptionLabelType" to "AutoCompleteOptionLabelType" (removed extra "n")

Current compilation error: 

    node_modules/primevue/autocomplete/AutoComplete.d.ts:95:24 - error TS2552: Cannot find name 'AutoCompletenOptionLabelType'. Did you mean 'AutoCompleteOptionLabelType'?
    95     optionGroupLabel?: AutoCompletenOptionLabelType;
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    Found 1 error in node_modules/primevue/autocomplete/AutoComplete.d.ts:95

Fixes #2866