### PR TITLE
fix: remove white background on tooltip

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -118,6 +118,7 @@ function create(el) {
     document.body.appendChild(container);
 
     container.style.display = 'inline-block';
+    container.style.backgroundColor = 'transparent';
 
     if (el.$_ptooltipFitContent) {
         container.style.width = 'fit-content';


### PR DESCRIPTION
###Defect Fixes

white background on the tooltip container:
<img width="215" alt="image" src="https://user-images.githubusercontent.com/20030721/185618397-e56b7503-2479-45f6-96ed-10ed13e81958.png">

just add background color transparent
now is like that:
<img width="215" alt="image" src="https://user-images.githubusercontent.com/20030721/185618266-0c766cf8-3001-4b75-8041-83cdf67af273.png">

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.