### PR TITLE
Added "main" to menuitem's package.json

### DIFF
--- a/src/components/menuitem/package.json
+++ b/src/components/menuitem/package.json
@@ -1,3 +1,4 @@
 {
-    "types": "./MenuItem.d.ts"
+    "types": "./MenuItem.d.ts",
+    "main": "./MenuItem.d.ts"
 }


### PR DESCRIPTION


###Defect Fixes
On vite the build fails for us if we do not supply a main definition here. It was unable to resolve the import for MenuItems properly.
