### PR TITLE
Added a feature that allows using non-locale chars in InputNumber. #1859

### DIFF
--- a/src/components/inputnumber/InputNumber.d.ts
+++ b/src/components/inputnumber/InputNumber.d.ts
@@ -7,6 +7,8 @@ type InputNumberLocaleMatcherType = 'lookup' | 'best fit' | undefined;
 
 type InputNumberModeType = 'decimal' | 'currency' | undefined;
 
+type InputNumberCharInjection = (code: number) => number;
+
 export interface InputNumberInputEvent {
     /**
      * Browser event
@@ -170,6 +172,10 @@ export interface InputNumberProps {
      * Uses to pass all properties of the HTMLButtonElement to decrement button inside the component.
      */
     decrementButtonProps?: ButtonHTMLAttributes | undefined;
+    /**
+     * Function is for use as an adapter for non-numeric characters.
+     */
+    charAdapter?: InputNumberCharInjection | undefined;
     /**
      * Establishes relationships between the component and label(s) where its value should be one or more element IDs.
      */

--- a/src/components/inputnumber/InputNumber.vue
+++ b/src/components/inputnumber/InputNumber.vue
@@ -166,6 +166,10 @@ export default {
             type: null,
             default: null
         },
+        charInjection: {
+            type: Function,
+            default: null
+        },
         'aria-labelledby': {
             type: String,
             default: null
@@ -627,11 +631,16 @@ export default {
 
             event.preventDefault();
             let code = event.which || event.keyCode;
+
+            if (!this.isNumericCode(code) && typeof this.charInjection === 'function') {
+                code = this.charInjection(code);
+            }
+
             let char = String.fromCharCode(code);
             const isDecimalSign = this.isDecimalSign(char);
             const isMinusSign = this.isMinusSign(char);
 
-            if ((48 <= code && code <= 57) || isMinusSign || isDecimalSign) {
+            if (this.isNumericCode(code) || isMinusSign || isDecimalSign) {
                 this.insert(event, char, { isDecimalSign, isMinusSign });
             }
         },
@@ -649,6 +658,9 @@ export default {
         },
         allowMinusSign() {
             return this.min === null || this.min < 0;
+        },
+        isNumericCode(code) {
+            return 48 <= code && code <= 57;
         },
         isMinusSign(char) {
             if (this._minusSign.test(char) || char === '-') {

--- a/src/views/inputnumber/InputNumberDoc.vue
+++ b/src/views/inputnumber/InputNumberDoc.vue
@@ -335,6 +335,12 @@ Vertical
                         <td>null</td>
                         <td>Uses to pass all properties of the HTMLButtonElement to decrement button inside the component.</td>
                     </tr>
+                    <tr>
+                        <td>charInjection</td>
+                        <td>function</td>
+                        <td>null</td>
+                        <td>Function is for use as an adapter for non-numeric characters.</td>
+                    </tr>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
Solves: [#1859](https://github.com/primefaces/primevue/issues/1859).

It is inconvenient when the decimal is separated by comma (for example, "fr-FR", "ru-RU") and the user cannot use the dot key.
