### PR TITLE
set readonly prop to readonly attribute

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -17,7 +17,7 @@
             :aria-label="ariaLabel"
             inputmode="none"
             :disabled="disabled"
-            :readonly="!manualInput"
+            :readonly="readonly"
             :tabindex="0"
             @input="onInput"
             @click="onInputClick"

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -17,7 +17,7 @@
             :aria-label="ariaLabel"
             inputmode="none"
             :disabled="disabled"
-            :readonly="readonly"
+            :readonly="!manualInput || readonly"
             :tabindex="0"
             @input="onInput"
             @click="onInputClick"


### PR DESCRIPTION
### Defect Fixes
When submitting a PR, please also create an issue documenting the error.

In Calendar component, `readonly` prop is not working as expected since `manualInput` prop is set to readonly attribute instead.
Currently, when `readonly` prop is set true, input still accepts new input.
```
<Calendar v-model="value" :readonly="true" />
```
The issue is described here https://github.com/primefaces/primevue/issues/125

The repo for readonly bug is here https://github.com/nagisaando/primevue-calendar-readonly-error
