### PR TITLE
feat(MultiSelect): add onCloseIconClick prop

### DIFF
--- a/api-generator/components/multiselect.js
+++ b/api-generator/components/multiselect.js
@@ -282,6 +282,12 @@ const MultiSelectProps = [
         description: 'Index of the element in tabbing order.'
     },
     {
+        name: 'onCloseIconClick',
+        type: 'function(e): promise',
+        default: '',
+        description: 'Callback to invoke when closeIcon be clicked.'
+    },
+    {
         name: 'aria-label',
         type: 'string',
         default: 'null',

--- a/src/components/multiselect/MultiSelect.vue
+++ b/src/components/multiselect/MultiSelect.vue
@@ -516,7 +516,7 @@ export default {
                 await this.onCloseIconClick(event)
                 this.hide(true);
             }catch(err){
-                threw new Error(err)
+                throw new Error(err)
             }
         },
         onHeaderCheckboxFocus() {

--- a/src/components/multiselect/MultiSelect.vue
+++ b/src/components/multiselect/MultiSelect.vue
@@ -266,6 +266,9 @@ export default {
             type: Boolean,
             default: null
         },
+        onCloseIconClick:{
+            type:Function
+        }
         resetFilterOnHide: {
             type: Boolean,
             default: false
@@ -505,8 +508,16 @@ export default {
         onLastHiddenFocus() {
             DomHandler.focus(this.$refs.firstHiddenFocusableElementOnOverlay);
         },
-        onCloseClick() {
-            this.hide(true);
+        async onCloseClick(event) {
+            if(!this.onCloseIconClick){
+                return this.hide(true);
+            }
+            try{
+                await this.onCloseIconClick(event)
+                this.hide(true);
+            }catch(err){
+                threw new Error(err)
+            }
         },
         onHeaderCheckboxFocus() {
             this.headerCheckboxFocused = true;


### PR DESCRIPTION
###Defect Fixes
 #https://github.com/primefaces/primevue/issues/3048

###Feature Requests
can control the closeIcon behavior is close or not close by prop.onCloseIconClick return promise status 

and it's not an emit event , because in vue3 ,when prop be defined in emits form attrs ,cause  no way to know it be  listener or not by user, so i set it in a prop link react ,or you have some good way?