### PR TITLE
force computed tabs methods to update

### DIFF
--- a/src/components/tabview/TabView.vue
+++ b/src/components/tabview/TabView.vue
@@ -102,6 +102,7 @@ export default {
     },
     data() {
         return {
+            updateKey: 0,
             d_activeIndex: this.activeIndex,
             focusedTabIndex: -1,
             isPrevButtonDisabled: true,
@@ -117,6 +118,9 @@ export default {
     },
     mounted() {
         this.updateInkBar();
+    },
+    beforeUpdate() {
+        this.updateKey++;
     },
     updated() {
         this.updateInkBar();
@@ -333,6 +337,8 @@ export default {
             ];
         },
         tabs() {
+            this.updateKey;
+
             return this.$slots.default().reduce((tabs, child) => {
                 if (this.isTabPanel(child)) {
                     tabs.push(child);


### PR DESCRIPTION
I found that the `TabView` component wasn't getting updated when I changed the `TabPanel` components inside it (either props like `header`, or the default slot content).

Dug into it and I think it's because the tabs are a computed variable, defined as:

```javascript
return this.$slots.default().reduce((tabs, child) => {
    if (this.isTabPanel(child)) {
        tabs.push(child);
    } else if (child.children && child.children instanceof Array) {
        child.children.forEach((nestedChild) => {
            if (this.isTabPanel(nestedChild)) {
                tabs.push(nestedChild);
            }
        });
    }

    return tabs;
}, []);
```

https://github.com/primefaces/primevue/blob/master/src/components/tabview/TabView.vue#L335

But nothing inside here is reactive, so it doesn't get updated when the slots change.

This PR forces this computed variable to be recomputed on any update.