### PR TITLE
Add Speeddial fix #10831 from primeng to primevue

### DIFF
--- a/src/components/speeddial/SpeedDial.vue
+++ b/src/components/speeddial/SpeedDial.vue
@@ -4,7 +4,7 @@
             <SDButton type="button" :class="buttonClassName" :icon="iconClassName" @click="onClick($event)" :disabled="disabled" />
         </slot>
         <ul :ref="listRef" class="p-speeddial-list" role="menu">
-            <li v-for="(item, index) of model" :key="index" class="p-speeddial-item" :style="getItemStyle(index)" role="none">
+            <li v-for="(item, index) of model" :key="index" :class="['p-speeddial-item', { 'p-hidden': !item.visible } ]" :style="getItemStyle(index)" role="none">
                 <template v-if="!$slots.item">
                     <a
                         v-tooltip:[tooltipOptions]="{ value: item.label, disabled: !tooltipOptions }"


### PR DESCRIPTION
(from primeng) Fixed #10831 - SpeedDial items visible even if MenuItem object property "visible" is false #10832 

https://github.com/primefaces/primeng/pull/10832/files

###Defect Fixes
#3131 

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.