### PR TITLE
docs: fix nuxt config setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ export default defineNuxtConfig({
         'primevue/resources/themes/saga-blue/theme.css',
         'primevue/resources/primevue.css',
         'primeicons/primeicons.css'
-    ]
+    ],
+	build: {
+		transpile: ['primevue']
+	}
 })
 ```
 

--- a/src/views/setup/Setup.vue
+++ b/src/views/setup/Setup.vue
@@ -191,7 +191,10 @@ export default defineNuxtConfig({
         'primevue/resources/themes/saga-blue/theme.css',
         'primevue/resources/primevue.css',
         'primeicons/primeicons.css'
-    ]
+    ],
+	build: {
+		transpile: ['primevue']
+	}
 })
 
 </code></pre>


### PR DESCRIPTION
Fixes incorrect Nuxt3 config in the docs/readme. [Reference from starter template](https://github.com/primefaces/primevue-quickstart-nuxt3/blob/main/nuxt.config.js#L8-L10).