### PR TITLE
Recommend Vite instead of Vue CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,6 @@ app.use(PrimeVue, {
 
 PrimeVue provides a Locale API to support i18n and l7n, visit the [Locale](https://www.primefaces.org/primevue/showcase/#/locale) documentation for more information.
 
-## Quickstart with Vue CLI
-
-An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github.
-
 ## Quickstart with Vite
 
 A [starter application](https://github.com/primefaces/primevue-quickstart-vite) is also provided for Vite users.
@@ -266,3 +262,7 @@ A [sample application](https://github.com/primefaces/primevue-quickstart-nuxt3) 
 ## Quickstart with TypeScript
 
 Typescript is fully supported as type definition files are provided in the npm package of PrimeVue. A sample [typescript-primevue](https://github.com/primefaces/primevue-typescript-quickstart) application with Vue CLI is available as at github.
+
+## Quickstart with Vue CLI
+
+An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github.


### PR DESCRIPTION
Vue CLI has been strongly discouraged in Vue 3 since January 2021.  Starting a new project with it is a big mistake.

![Screenshot_20221028-210513](https://user-images.githubusercontent.com/876076/198583563-98956e6d-e776-4be1-a594-562c5e8403e1.png)

https://cli.vuejs.org/
https://vuejs.org/guide/scaling-up/tooling.html#vue-cli
https://vueschool.io/articles/vuejs-tutorials/how-to-migrate-from-vue-cli-to-vite/

There is also the issue of compatibility... Vue CLI simply does not run in many configurations and cloud IDEs due to binary dependencies and legacy code.
