### PR TITLE
Add warning about using Vue CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ PrimeVue provides a Locale API to support i18n and l7n, visit the [Locale](https
 
 ## Quickstart with Vue CLI
 
-An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github.
+An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github. is now in maintenance mode and we recommend starting new projects with Vite unless you rely on specific webpack-only features. Vite will provide superior developer experience in most cases.
 
 ## Quickstart with Vite
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ PrimeVue provides a Locale API to support i18n and l7n, visit the [Locale](https
 
 ## Quickstart with Vue CLI
 
-An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github. is now in maintenance mode and we recommend starting new projects with Vite unless you rely on specific webpack-only features. Vite will provide superior developer experience in most cases.
+An [example application](https://github.com/primefaces/primevue-quickstart) based on Vue CLI is available at github. Vue CLI is now in maintenance mode and we recommend starting new projects with Vite unless you rely on specific webpack-only features. Vite will provide superior developer experience in most cases.
 
 ## Quickstart with Vite
 


### PR DESCRIPTION
This warning is literally copied straight from the Vue Docs... Not sure why Vue CLI is listed first, it's deprecated, unpopular and alphabetically inferior to Vite.

https://vuejs.org/guide/scaling-up/tooling.html#vue-cli

