### PR TITLE
Add 'resizestart' emit event when splitter is resized

### DIFF
--- a/src/components/splitter/Splitter.vue
+++ b/src/components/splitter/Splitter.vue
@@ -23,7 +23,7 @@ import { DomHandler, ObjectUtils } from 'primevue/utils';
 
 export default {
     name: 'Splitter',
-    emits: ['resizeend'],
+    emits: ['resizestart','resizeend'],
     props: {
         layout: {
             type: String,
@@ -102,6 +102,8 @@ export default {
         onResizeStart(event, index, isKeyDown) {
             this.gutterElement = event.currentTarget || event.target.parentElement;
             this.size = this.horizontal ? DomHandler.getWidth(this.$el) : DomHandler.getHeight(this.$el);
+
+            this.$emit('resizestart', { originalEvent: event, sizes: this.panelSizes });
 
             if (!isKeyDown) {
                 this.dragging = true;

--- a/src/components/splitter/Splitter.vue
+++ b/src/components/splitter/Splitter.vue
@@ -23,7 +23,7 @@ import { DomHandler, ObjectUtils } from 'primevue/utils';
 
 export default {
     name: 'Splitter',
-    emits: ['resizestart','resizeend'],
+    emits: ['resizestart', 'resizeend'],
     props: {
         layout: {
             type: String,

--- a/src/views/splitter/SplitterDoc.vue
+++ b/src/views/splitter/SplitterDoc.vue
@@ -229,6 +229,14 @@ import SplitterPanel from 'primevue/splitterpanel';
                 </thead>
                 <tbody>
                     <tr>
+                        <td>resizestart</td>
+                        <td>
+                            event.originalEvent: Original event <br />
+                            event.sizes: Sizes of the panels as an array
+                        </td>
+                        <td>Callback to invoke when resize starts.</td>
+                    </tr>
+                    <tr>
                         <td>resizeend</td>
                         <td>
                             event.originalEvent: Original event <br />
@@ -277,7 +285,7 @@ import SplitterPanel from 'primevue/splitterpanel';
                     </tr>
                     <tr>
                         <td>p-splitter-gutter-handle</td>
-                        <td>Handl element of the gutter.</td>
+                        <td>Handle element of the gutter.</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
This just adds a 'resizestart' emit event from the existing onResizeStart function.

Resolves:
https://github.com/primefaces/primevue/issues/3203
