### PR TITLE
Make initial focus index of popup configurable

### DIFF
--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -49,6 +49,10 @@ export default {
             type: Boolean,
             default: false
         },
+        initialFocusIndex: {
+            type: Number,
+            default: 0
+        },
         model: {
             type: Array,
             default: null
@@ -272,7 +276,7 @@ export default {
 
             if (this.popup) {
                 DomHandler.focus(this.list);
-                this.changeFocusedOptionIndex(0);
+                this.changeFocusedOptionIndex(this.initialFocusIndex);
             }
 
             this.$emit('show');


### PR DESCRIPTION
Adds a prop to configure the initial focus index of popup menu.

This adds functionality requested in #3210 
