### PR TITLE
feat(menu): Added badge component to MenuModel and related components.

### DIFF
--- a/src/components/badge/Badge.d.ts
+++ b/src/components/badge/Badge.d.ts
@@ -1,7 +1,7 @@
 import { VNode } from 'vue';
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers';
 
-type BadgeSeverityType = 'info' | 'success' | 'warning' | 'danger' | undefined;
+export type BadgeSeverityType = 'info' | 'success' | 'warning' | 'danger' | undefined;
 
 type BadgeSizeType = 'large' | 'xlarge' | undefined;
 

--- a/src/components/breadcrumb/BreadcrumbItem.vue
+++ b/src/components/breadcrumb/BreadcrumbItem.vue
@@ -5,11 +5,13 @@
                 <a :href="href" :class="linkClass({ isActive, isExactActive })" :aria-current="isCurrentUrl()" @click="onClick($event, navigate)">
                     <span v-if="item.icon" :class="iconClass"></span>
                     <span v-if="item.label" class="p-menuitem-text">{{ label() }}</span>
+                    <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge()" class="ml-1" :aria-label="label() + ' Badge'" />
                 </a>
             </router-link>
             <a v-else :href="item.url || '#'" :class="linkClass()" :target="item.target" :aria-current="isCurrentUrl()" @click="onClick">
                 <span v-if="item.icon" :class="iconClass"></span>
                 <span v-if="item.label" class="p-menuitem-text">{{ label() }}</span>
+                <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge()" class="ml-1" :aria-label="label() + ' Badge'" />
             </a>
         </template>
         <component v-else :is="template" :item="item"></component>
@@ -17,6 +19,8 @@
 </template>
 
 <script>
+import Badge from '../badge/Badge';
+
 export default {
     name: 'BreadcrumbItem',
     props: {
@@ -58,6 +62,9 @@ export default {
         label() {
             return typeof this.item.label === 'function' ? this.item.label() : this.item.label;
         },
+        badge() {
+            return typeof this.item.badge === 'function' ? this.item.badge() : this.item.badge;
+        },
         isCurrentUrl() {
             const { to, url } = this.item;
             let lastPath = this.$router ? this.$router.currentRoute.path : '';
@@ -69,6 +76,9 @@ export default {
         iconClass() {
             return ['p-menuitem-icon', this.item.icon];
         }
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/contextmenu/ContextMenuSub.vue
+++ b/src/components/contextmenu/ContextMenuSub.vue
@@ -22,11 +22,13 @@
                                 <a v-ripple :href="href" :class="getItemActionClass(processedItem, { isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                                     <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                     <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                    <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                                 </a>
                             </router-link>
                             <a v-else v-ripple :href="getItemProp(processedItem, 'url')" :class="getItemActionClass(processedItem)" :target="getItemProp(processedItem, 'target')" tabindex="-1" aria-hidden="true">
                                 <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                                 <span v-if="getItemProp(processedItem, 'items')" class="p-submenu-icon pi pi-angle-right"></span>
                             </a>
                         </template>
@@ -58,6 +60,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { DomHandler, ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'ContextMenuSub',
@@ -112,6 +115,12 @@ export default {
         },
         getItemLabel(processedItem) {
             return this.getItemProp(processedItem, 'label');
+        },
+        getItemBadge(processedItem) {
+            return this.getItemProp(processedItem, 'badge');
+        },
+        getItemBadgeSeverity(processedItem) {
+            return this.getItemProp(processedItem, 'badgeSeverity');
         },
         isItemActive(processedItem) {
             return this.activeItemPath.some((path) => path.key === processedItem.key);
@@ -193,6 +202,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/megamenu/MegaMenuSub.vue
+++ b/src/components/megamenu/MegaMenuSub.vue
@@ -1,6 +1,8 @@
 <template>
     <ul>
-        <li v-if="submenu" :class="getSubmenuHeaderClass(submenu)" :style="getItemProp(submenu, 'style')" role="presentation">{{ getItemLabel(submenu) }}</li>
+        <li v-if="submenu" :class="getSubmenuHeaderClass(submenu)" :style="getItemProp(submenu, 'style')" role="presentation">
+            {{ getItemLabel(submenu) }}<PVBadge v-if="getItemBadge(submenu)" :severity="getItemBadgeSeverity(submenu)" :value="getItemBadge(submenu)" class="ml-1" :aria-label="getItemLabel(submenu) + ' Badge'" />
+        </li>
         <template v-for="(processedItem, index) of items" :key="getItemKey(processedItem)">
             <li
                 v-if="isItemVisible(processedItem) && !getItemProp(processedItem, 'separator')"
@@ -22,11 +24,14 @@
                             <a v-ripple :href="href" :class="getItemActionClass(processedItem, { isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                                 <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                <code>{{ getItemBadge(processedItem) }}</code>
+                                <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             </a>
                         </router-link>
                         <a v-else v-ripple :href="getItemProp(processedItem, 'url')" :class="getItemActionClass(processedItem)" :target="getItemProp(processedItem, 'target')" tabindex="-1" aria-hidden="true">
                             <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                             <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                            <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             <span v-if="isItemGroup(processedItem)" :class="getItemToggleIconClass()"></span>
                         </a>
                     </template>
@@ -63,6 +68,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'MegaMenuSub',
@@ -123,6 +129,12 @@ export default {
         },
         getItemLabel(processedItem) {
             return this.getItemProp(processedItem, 'label');
+        },
+        getItemBadge(processedItem) {
+            return this.getItemProp(processedItem, 'badge');
+        },
+        getItemBadgeSeverity(processedItem) {
+            return this.getItemProp(processedItem, 'badgeSeverity');
         },
         isItemActive(processedItem) {
             return ObjectUtils.isNotEmpty(this.activeItem) ? this.activeItem.key === processedItem.key : false;
@@ -226,6 +238,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/menu/Menu.d.ts
+++ b/src/components/menu/Menu.d.ts
@@ -1,14 +1,24 @@
 import { VNode } from 'vue';
+import { BadgeSeverityType } from '../badge/Badge';
 import { MenuItem } from '../menuitem';
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers';
 
 type MenuAppendToType = 'body' | 'self' | string | undefined | HTMLElement;
+type MenuItemBadgeType = number | ((...args: any) => number) | undefined;
 
 export interface MenuProps {
     /**
      * An array of menuitems.
      */
     model?: MenuItem[] | undefined;
+    /**
+     * A number or a function to return a number to specify if there is a badge and its content.
+     */
+    badge?: MenuItemBadgeType;
+    /**
+     * Severity of the displayed badge.
+     */
+    badgeSeverity?: BadgeSeverityType;
     /**
      * Defines if menu would displayed as a popup.
      */

--- a/src/components/menu/Menu.vue
+++ b/src/components/menu/Menu.vue
@@ -19,6 +19,7 @@
                         <template v-if="item.items && visible(item) && !item.separator">
                             <li v-if="item.items" :id="id + '_' + i" class="p-submenu-header" role="none">
                                 <slot name="item" :item="item">{{ label(item) }}</slot>
+                                <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge(item)" class="ml-1" :aria-label="label(item) + ' Badge'" />
                             </li>
                             <template v-for="(child, j) of item.items" :key="child.label + i + '_' + j">
                                 <PVMenuitem v-if="visible(child) && !child.separator" :id="id + '_' + i + '_' + j" :item="child" :template="$slots.item" :exact="exact" :focusedOptionId="focusedOptionId" @item-click="itemClick" />
@@ -38,6 +39,7 @@
 import OverlayEventBus from 'primevue/overlayeventbus';
 import Portal from 'primevue/portal';
 import { ConnectedOverlayScrollHandler, DomHandler, UniqueComponentId, ZIndexUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 import Menuitem from './Menuitem.vue';
 
 export default {
@@ -356,6 +358,9 @@ export default {
         label(item) {
             return typeof item.label === 'function' ? item.label() : item.label;
         },
+        badge(item) {
+            return typeof item.badge === 'function' ? item.badge() : item.badge;
+        },
         separatorClass(item) {
             return ['p-menuitem-separator', item.class];
         },
@@ -392,6 +397,7 @@ export default {
     },
     components: {
         PVMenuitem: Menuitem,
+        PVBadge: Badge,
         Portal: Portal
     }
 };

--- a/src/components/menu/Menuitem.vue
+++ b/src/components/menu/Menuitem.vue
@@ -6,11 +6,13 @@
                     <a v-ripple :href="href" :class="linkClass({ isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                         <span v-if="item.icon" :class="['p-menuitem-icon', item.icon]"></span>
                         <span class="p-menuitem-text">{{ label() }}</span>
+                        <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge()" class="ml-1" :aria-label="label() + ' Badge'" />
                     </a>
                 </router-link>
                 <a v-else v-ripple :href="item.url" :class="linkClass()" :target="item.target" tabindex="-1" aria-hidden="true">
                     <span v-if="item.icon" :class="['p-menuitem-icon', item.icon]"></span>
                     <span class="p-menuitem-text">{{ label() }}</span>
+                    <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge()" class="ml-1" :aria-label="label() + ' Badge'" />
                 </a>
             </template>
             <component v-else :is="template" :item="item"></component>
@@ -21,6 +23,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge.vue';
 
 export default {
     name: 'Menuitem',
@@ -66,10 +69,16 @@ export default {
         },
         label() {
             return typeof this.item.label === 'function' ? this.item.label() : this.item.label;
+        },
+        badge() {
+            return typeof this.item.badge === 'function' ? this.item.badge() : this.item.badge;
         }
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/menubar/MenubarSub.vue
+++ b/src/components/menubar/MenubarSub.vue
@@ -21,11 +21,13 @@
                             <a v-ripple :href="href" :class="getItemActionClass(processedItem, { isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                                 <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             </a>
                         </router-link>
                         <a v-else v-ripple :href="getItemProp(processedItem, 'url')" :class="getItemActionClass(processedItem)" :target="getItemProp(processedItem, 'target')" tabindex="-1" aria-hidden="true">
                             <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                             <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                            <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             <span v-if="getItemProp(processedItem, 'items')" :class="getSubmenuIcon()"></span>
                         </a>
                     </template>
@@ -55,6 +57,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'MenubarSub',
@@ -114,6 +117,12 @@ export default {
         },
         getItemLabel(processedItem) {
             return this.getItemProp(processedItem, 'label');
+        },
+        getItemBadge(processedItem) {
+            return this.getItemProp(processedItem, 'badge');
+        },
+        getItemBadgeSeverity(processedItem) {
+            return this.getItemProp(processedItem, 'badgeSeverity');
         },
         isItemActive(processedItem) {
             return this.activeItemPath.some((path) => path.key === processedItem.key);
@@ -185,6 +194,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/menuitem/MenuItem.d.ts
+++ b/src/components/menuitem/MenuItem.d.ts
@@ -1,6 +1,9 @@
 import { RouteLocationRaw } from 'vue-router';
+import { BadgeSeverityType } from '../badge/Badge';
 
 type MenuItemLabelType = string | ((...args: any) => string) | undefined;
+
+type MenuItemBadgeType = number | ((...args: any) => number) | undefined;
 
 type MenuItemDisabledType = boolean | ((...args: any) => boolean) | undefined;
 
@@ -55,6 +58,14 @@ export interface MenuItem {
      * A boolean or a function to return a boolean to specify if the item is visible.
      */
     visible?: MenuItemVisibleType;
+    /**
+     * A number or a function to return a number to specify if there is a badge and its content.
+     */
+    badge?: MenuItemBadgeType;
+    /**
+     * Severity of the displayed badge.
+     */
+    badgeSeverity?: BadgeSeverityType;
     /**
      * Specifies where to open the linked document.
      */

--- a/src/components/panelmenu/PanelMenu.vue
+++ b/src/components/panelmenu/PanelMenu.vue
@@ -20,12 +20,14 @@
                                 <a :href="href" :class="getHeaderActionClass(item, { isActive, isExactActive })" :tabindex="-1" @click="onHeaderActionClick($event, navigate)">
                                     <span v-if="getItemProp(item, 'icon')" :class="getHeaderIconClass(item)"></span>
                                     <span class="p-menuitem-text">{{ getItemLabel(item) }}</span>
+                                    <PVBadge v-if="getItemBadge(item)" :severity="getItemBadgeSeverity(item)" :value="getItemBadge(item)" class="ml-1" :aria-label="getItemLabel(item) + ' Badge'" />
                                 </a>
                             </router-link>
                             <a v-else :href="getItemProp(item, 'url')" :class="getHeaderActionClass(item)" :tabindex="-1">
                                 <span v-if="getItemProp(item, 'items')" :class="getHeaderToggleIconClass(item)"></span>
                                 <span v-if="getItemProp(item, 'icon')" :class="getHeaderIconClass(item)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(item) }}</span>
+                                <PVBadge v-if="getItemBadge(item)" :severity="getItemBadgeSeverity(item)" :value="getItemBadge(item)" class="ml-1" :aria-label="getItemLabel(item) + ' Badge'" />
                             </a>
                         </template>
                         <component v-else :is="$slots.item" :item="item"></component>
@@ -45,6 +47,7 @@
 
 <script>
 import { DomHandler, ObjectUtils, UniqueComponentId } from 'primevue/utils';
+import Badge from '../badge/Badge';
 import PanelMenuList from './PanelMenuList.vue';
 
 export default {
@@ -79,6 +82,12 @@ export default {
         },
         getItemLabel(item) {
             return this.getItemProp(item, 'label');
+        },
+        getItemBadge(item) {
+            return this.getItemProp(item, 'badge');
+        },
+        getItemBadgeSeverity(item) {
+            return this.getItemProp(item, 'badgeSeverity');
         },
         isItemActive(item) {
             return this.expandedKeys ? this.expandedKeys[this.getItemProp(item, 'key')] : item === this.activeItem;
@@ -256,7 +265,8 @@ export default {
         }
     },
     components: {
-        PanelMenuList: PanelMenuList
+        PanelMenuList: PanelMenuList,
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/panelmenu/PanelMenuSub.vue
+++ b/src/components/panelmenu/PanelMenuSub.vue
@@ -19,12 +19,14 @@
                             <a v-ripple :href="href" :class="getItemActionClass(processedItem, { isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                                 <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             </a>
                         </router-link>
                         <a v-else v-ripple :href="getItemProp(processedItem, 'url')" :class="getItemActionClass(processedItem)" :target="getItemProp(processedItem, 'target')" tabindex="-1" aria-hidden="true">
                             <span v-if="isItemGroup(processedItem)" :class="getItemToggleIconClass(processedItem)"></span>
                             <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                             <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                            <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                         </a>
                     </template>
                     <component v-else :is="template" :item="processedItem.item"></component>
@@ -55,6 +57,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'PanelMenuSub',
@@ -101,6 +104,12 @@ export default {
         },
         getItemLabel(processedItem) {
             return this.getItemProp(processedItem, 'label');
+        },
+        getItemBadge(processedItem) {
+            return this.getItemProp(processedItem, 'badge');
+        },
+        getItemBadgeSeverity(processedItem) {
+            return this.getItemProp(processedItem, 'badgeSeverity');
         },
         isItemActive(processedItem) {
             return this.activeItemPath.some((path) => path.key === processedItem.key);
@@ -166,6 +175,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -14,12 +14,12 @@
                                 @keydown="onItemKeydown($event, item, navigate)"
                             >
                                 <span class="p-steps-number">{{ index + 1 }}</span>
-                                <span class="p-steps-title">{{ label(item) }}</span>
+                                <span class="p-steps-title">{{ label(item) }}<PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge(item)" class="ml-1" :aria-label="label(item) + ' Badge'" /></span>
                             </a>
                         </router-link>
                         <span v-else :class="linkClass()" @keydown="onItemKeydown($event, item)">
                             <span class="p-steps-number">{{ index + 1 }}</span>
-                            <span class="p-steps-title">{{ label(item) }}</span>
+                            <span class="p-steps-title">{{ label(item) }}<PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge(item)" class="ml-1" :aria-label="label(item) + ' Badge'" /></span>
                         </span>
                     </template>
                     <component v-else :is="$slots.item" :item="item"></component>
@@ -31,6 +31,7 @@
 
 <script>
 import { DomHandler, UniqueComponentId } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'Steps',
@@ -196,12 +197,18 @@ export default {
         },
         label(item) {
             return typeof item.label === 'function' ? item.label() : item.label;
+        },
+        badge(item) {
+            return typeof item.badge === 'function' ? item.badge() : item.badge;
         }
     },
     computed: {
         containerClass() {
             return ['p-steps p-component', { 'p-readonly': this.readonly }];
         }
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/components/tabmenu/TabMenu.vue
+++ b/src/components/tabmenu/TabMenu.vue
@@ -11,6 +11,7 @@
                                 role="menuitem"
                                 :href="href"
                                 class="p-menuitem-link"
+                                :class="{ 'p-menuitem-link-with-badge': checkBadgePresence(model) == true }"
                                 :aria-label="label(item)"
                                 :aria-disabled="disabled(item)"
                                 :tabindex="isExactActive ? '0' : '-1'"
@@ -19,6 +20,7 @@
                             >
                                 <span v-if="item.icon" :class="getItemIcon(item)"></span>
                                 <span class="p-menuitem-text">{{ label(item) }}</span>
+                                <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge(item)" class="ml-1 p-tabmenu-badge" :aria-label="label(item) + ' Badge'" />
                             </a>
                         </template>
                         <component v-else :is="$slots.item" :item="item"></component>
@@ -32,6 +34,7 @@
                             role="menuitem"
                             :href="item.url"
                             class="p-menuitem-link"
+                            :class="{ 'p-menuitem-link-with-badge': checkBadgePresence(model) == true }"
                             :target="item.target"
                             :aria-label="label(item)"
                             :aria-disabled="disabled(item)"
@@ -41,6 +44,7 @@
                         >
                             <span v-if="item.icon" :class="getItemIcon(item)"></span>
                             <span class="p-menuitem-text">{{ label(item) }}</span>
+                            <PVBadge v-if="item.badge" :severity="item.badgeSeverity" :value="badge(item)" class="ml-1 p-tabmenu-badge" :aria-label="label(item) + ' Badge'" />
                         </a>
                     </template>
                     <component v-else :is="$slots.item" :item="item"></component>
@@ -54,6 +58,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { DomHandler } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'TabMenu',
@@ -252,6 +257,9 @@ export default {
         label(item) {
             return typeof item.label === 'function' ? item.label() : item.label;
         },
+        badge(item) {
+            return typeof item.badge === 'function' ? item.badge() : item.badge;
+        },
         setDefaultTabIndexes(tabLinkRef) {
             setTimeout(() => {
                 tabLinkRef.forEach((item) => {
@@ -261,6 +269,15 @@ export default {
         },
         setTabIndex(index) {
             return this.d_activeIndex === index ? '0' : '-1';
+        },
+        checkBadgePresence(model) {
+            for (let index = 0; index < model.length; index++) {
+                const item = model[index];
+
+                if (item.badge) return true;
+            }
+
+            return false;
         },
         updateInkBar() {
             let tabs = this.$refs.nav.children;
@@ -284,6 +301,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>
@@ -310,6 +330,11 @@ export default {
     text-decoration: none;
     text-decoration: none;
     overflow: hidden;
+}
+
+.p-menuitem-link-with-badge {
+    /* Same as Badge */
+    max-height: 0.75rem;
 }
 
 .p-tabmenu-nav a:focus {

--- a/src/components/tieredmenu/TieredMenuSub.vue
+++ b/src/components/tieredmenu/TieredMenuSub.vue
@@ -21,11 +21,13 @@
                             <a v-ripple :href="href" :class="getItemActionClass(processedItem, { isActive, isExactActive })" tabindex="-1" aria-hidden="true" @click="onItemActionClick($event, navigate)">
                                 <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                                 <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                                <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             </a>
                         </router-link>
                         <a v-else v-ripple :href="getItemProp(processedItem, 'url')" :class="getItemActionClass(processedItem)" :target="getItemProp(processedItem, 'target')" tabindex="-1" aria-hidden="true">
                             <span v-if="getItemProp(processedItem, 'icon')" :class="getItemIconClass(processedItem)"></span>
                             <span class="p-menuitem-text">{{ getItemLabel(processedItem) }}</span>
+                            <PVBadge v-if="getItemBadge(processedItem)" :severity="getItemBadgeSeverity(processedItem)" :value="getItemBadge(processedItem)" class="ml-1" :aria-label="getItemLabel(processedItem) + ' Badge'" />
                             <span v-if="isItemGroup(processedItem)" class="p-submenu-icon pi pi-angle-right"></span>
                         </a>
                     </template>
@@ -55,6 +57,7 @@
 <script>
 import Ripple from 'primevue/ripple';
 import { ObjectUtils } from 'primevue/utils';
+import Badge from '../badge/Badge';
 
 export default {
     name: 'TieredMenuSub',
@@ -101,6 +104,12 @@ export default {
         },
         getItemLabel(processedItem) {
             return this.getItemProp(processedItem, 'label');
+        },
+        getItemBadge(processedItem) {
+            return this.getItemProp(processedItem, 'badge');
+        },
+        getItemBadgeSeverity(processedItem) {
+            return this.getItemProp(processedItem, 'badgeSeverity');
         },
         isItemActive(processedItem) {
             return this.activeItemPath.some((path) => path.key === processedItem.key);
@@ -164,6 +173,9 @@ export default {
     },
     directives: {
         ripple: Ripple
+    },
+    components: {
+        PVBadge: Badge
     }
 };
 </script>

--- a/src/views/menumodel/MenuModel.vue
+++ b/src/views/menumodel/MenuModel.vue
@@ -13,7 +13,9 @@
 const items: [
     {
         label: 'Options',
-        items: [{label: 'New', icon: 'pi pi-fw pi-plus', command:() => {} },
+        badge: 2,
+        badgeSeverity: 'danger',
+        items: [{label: 'New', badge: () => 3, icon: 'pi pi-fw pi-plus', command:() => {} },
                 {label: 'Delete', icon: 'pi pi-fw pi-trash', url: 'http://primetek.com.tr'}]
     },
     {
@@ -67,6 +69,18 @@ const items: [
                             <td>string</td>
                             <td>null</td>
                             <td>External link to navigate when item is clicked.</td>
+                        </tr>
+                        <tr>
+                            <td>badge</td>
+                            <td>number | function</td>
+                            <td>null</td>
+                            <td>A badge value to be shown.</td>
+                        </tr>
+                        <tr>
+                            <td>badgeSeverity</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Severity type of the badge.</td>
                         </tr>
                         <tr>
                             <td>items</td>


### PR DESCRIPTION
### Features

This PR adds a `Badge` component to `MenuModel` and all of *menu-related* components. Also, I added a  `badgeSeverity` aimed to set the badge severity.

Here are some screenshots of the PR:

**Tabview**:
![imatge](https://user-images.githubusercontent.com/2920935/203401228-5a873893-6e5e-444f-aacd-a1b6f7f3e23f.png)

**Menubar**:
![imatge](https://user-images.githubusercontent.com/2920935/203401380-32664b12-4fb5-4da7-b542-b61ffe907385.png)
