### PR TITLE
fix: splitbutton click handler, when clicked on down arrow

### DIFF
--- a/components/splitbutton/SplitButton.vue
+++ b/components/splitbutton/SplitButton.vue
@@ -12,7 +12,7 @@
             aria-haspopup="true"
             :aria-expanded="isExpanded"
             :aria-controls="ariaId + '_overlay'"
-            @click="onDropdownButtonClick"
+            @click.stop="onDropdownButtonClick"
             @keydown="onDropdownKeydown"
             v-bind="menuButtonProps"
         />


### PR DESCRIPTION
Fixes #3389