### PR TITLE
DataTable.d.ts groupRowsBy type fix

### DIFF
--- a/components/datatable/DataTable.d.ts
+++ b/components/datatable/DataTable.d.ts
@@ -684,7 +684,7 @@ export interface DataTableProps {
     /**
      * One or more field names to use in row grouping.
      */
-    groupRowsBy?: (field: string) => object | string[] | string | undefined;
+    groupRowsBy?: ((field: string) => object) | string[] | string | undefined;
     /**
      * Whether the row groups can be expandable.
      */


### PR DESCRIPTION
When give string to groupRowsBy prop in Data Table it gives this error: 
 `Type 'string' is not assignable to type '(field: string) => string | object | string[]'.`

Before fix;
![image](https://user-images.githubusercontent.com/76409169/209767596-98fbb74d-91a3-4f29-b11d-bba05219415d.png)

After fix;
![image](https://user-images.githubusercontent.com/76409169/209767665-b7d3cd7e-aca3-4530-bae4-03287909b5f7.png)

brackets added to function type.

###Feature Requests
Brackets need to be added to the function type, otherwise it gives an error when getting build.