### PR TITLE
Fix #3443: Datatable: RowReorder fails in case of pagination on page other than first & last

### DIFF
--- a/components/datatable/DataTable.vue
+++ b/components/datatable/DataTable.vue
@@ -1685,7 +1685,7 @@ export default {
                 let dropIndex = this.draggedRowIndex > this.droppedRowIndex ? this.droppedRowIndex : this.droppedRowIndex === 0 ? 0 : this.droppedRowIndex - 1;
                 let processedData = [...this.processedData];
 
-                ObjectUtils.reorderArray(processedData, this.draggedRowIndex, dropIndex);
+                ObjectUtils.reorderArray(processedData, this.draggedRowIndex + this.d_first, dropIndex + this.d_first);
 
                 this.$emit('row-reorder', {
                     originalEvent: event,

--- a/components/utils/ObjectUtils.js
+++ b/components/utils/ObjectUtils.js
@@ -106,15 +106,10 @@ export default {
     },
 
     reorderArray(value, from, to) {
-        let target;
-
         if (value && from !== to) {
             if (to >= value.length) {
-                target = to - value.length;
-
-                while (target-- + 1) {
-                    value.push(undefined);
-                }
+                to %= value.length;
+                from %= value.length;
             }
 
             value.splice(to, 0, value.splice(from, 1)[0]);


### PR DESCRIPTION
This fixes #3443.

I did not update the Reorder demo, but if you add `:paginator="true" :rows="5"` to it you can confirm the issue and subsequent fix. Also tested on the existing Reorder demo without pagination and it works there as well.