### PR TITLE
Fix #3504: SpeedDial: Overlapping Issue

### DIFF
--- a/components/speeddial/SpeedDial.vue
+++ b/components/speeddial/SpeedDial.vue
@@ -593,6 +593,10 @@ export default {
     transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
+.p-speeddial-opened {
+    z-index: 2;
+}
+
 .p-speeddial-opened .p-speeddial-list {
     pointer-events: auto;
 }


### PR DESCRIPTION
When a SpeedDial overlaps another SpeedDial, the closed one can block clicks from the open one. Giving the open SpeedDial a higher z-index fixes the conflict.