### PR TITLE
fix Calendar value typings

### DIFF
--- a/components/calendar/Calendar.d.ts
+++ b/components/calendar/Calendar.d.ts
@@ -1,7 +1,8 @@
 import { HTMLAttributes, InputHTMLAttributes, VNode } from 'vue';
 import { ClassComponent, GlobalComponentConstructor } from '../ts-helpers';
 
-type CalendarValueType = string | Date | string[] | Date[] | undefined;
+type OpenDateRange = [Date | null | undefined, Date | null | undefined];
+type CalendarValueType = string | Date | string[] | Date[] | OpenDateRange | undefined;
 
 type CalendarSlotDateType = { day: number; month: number; year: number; today: boolean; selectable: boolean };
 


### PR DESCRIPTION
Add missing typings for open date ranges. These are necessary when you are using the calendar to select a date range. One end of the range may not be chosen yet. This adds the typing for a fixed size array of size 2.

Optionally, to simplify the code, we can define it separately (this is how I have it in my code):
```typescript
type OpenDateRange = [Date | null | undefined, Date | null | undefined];
type CalendarValueType = string | Date | string[] | Date[] | OpenDateRange | undefined;
```
Alternatively, `OpenDateRange` could be defined as `(Date | null | undefined )[]`

Fixes #3521 

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.