### PR TITLE
feat(#3118): change button to render as a-tag when href is given

### DIFF
--- a/components/button/Button.spec.js
+++ b/components/button/Button.spec.js
@@ -81,4 +81,29 @@ describe('Button.vue', () => {
 
         expect(wrapper.html()).toBe('<button class="p-button p-component" type="button"><span class="ml-2 font-bold">Default PrimeVue Button</span></button>');
     });
+
+    it('should render default slot for a tag', () => {
+        const wrapper = mount(Button, {
+            props: { href: 'https://www.primefaces.org/primevue/' },
+            slots: {
+                default: h('span', { class: 'ml-2 font-bold' }, 'Default PrimeVue Button')
+            }
+        });
+
+        expect(wrapper.html()).toBe('<a class="p-button p-component" href="https://www.primefaces.org/primevue/"><span class="ml-2 font-bold">Default PrimeVue Button</span></a>');
+    });
+});
+
+describe('Button.vue', () => {
+    it('should render a tag when href is given', () => {
+        const href = 'https://www.primefaces.org/primevue/';
+        const props = { href };
+        let wrapper;
+
+        wrapper = mount(Button, {
+            props
+        });
+
+        expect(wrapper.find('a').exists()).toBe(true);
+    });
 });

--- a/components/button/Button.vue
+++ b/components/button/Button.vue
@@ -1,12 +1,24 @@
 <template>
-    <button v-ripple :class="buttonClass" type="button" :aria-label="defaultAriaLabel" :disabled="disabled">
-        <slot>
-            <span v-if="loading && !icon" :class="iconStyleClass"></span>
-            <span v-if="icon" :class="iconStyleClass"></span>
-            <span class="p-button-label">{{ label || '&nbsp;' }}</span>
-            <span v-if="badge" :class="badgeStyleClass">{{ badge }}</span>
-        </slot>
-    </button>
+    <template v-if="isLink">
+        <a v-ripple :class="buttonClass" :aria-label="defaultAriaLabel" :href="href">
+            <slot>
+                <span v-if="loading && !icon" :class="iconStyleClass"></span>
+                <span v-if="icon" :class="iconStyleClass"></span>
+                <span class="p-button-label">{{ label || '&nbsp;' }}</span>
+                <span v-if="badge" :class="badgeStyleClass">{{ badge }}</span>
+            </slot>
+        </a>
+    </template>
+    <template v-else>
+        <button v-ripple :class="buttonClass" type="button" :aria-label="defaultAriaLabel" :disabled="disabled">
+            <slot>
+                <span v-if="loading && !icon" :class="iconStyleClass"></span>
+                <span v-if="icon" :class="iconStyleClass"></span>
+                <span class="p-button-label">{{ label || '&nbsp;' }}</span>
+                <span v-if="badge" :class="badgeStyleClass">{{ badge }}</span>
+            </slot>
+        </button>
+    </template>
 </template>
 
 <script>
@@ -46,7 +58,11 @@ export default {
         loadingIcon: {
             type: String,
             default: 'pi pi-spinner pi-spin'
-        }
+        },
+        href: {
+            type: String,
+            default: null
+        },
     },
     computed: {
         buttonClass() {
@@ -86,7 +102,10 @@ export default {
         },
         defaultAriaLabel() {
             return this.label ? this.label + (this.badge ? ' ' + this.badge : '') : this.$attrs['aria-label'];
-        }
+        },
+        isLink() {
+            return !!this.href;
+        },
     },
     directives: {
         ripple: Ripple


### PR DESCRIPTION
###Feature Requests
Relates to #3118. Change button implementation to render as a-tag (instead of button-tag) when href is given