### PR TITLE
Update package.json for menuitem

### DIFF
--- a/components/menuitem/package.json
+++ b/components/menuitem/package.json
@@ -1,3 +1,4 @@
 {
-    "types": "./MenuItem.d.ts"
+    "types": "./MenuItem.d.ts",
+    "main": "./MenuItem.d.ts"    
 }


### PR DESCRIPTION
Simple bugfix to correct vite dev dependency error :

✘ [ERROR] [plugin vite:dep-scan] Failed to resolve entry for package "primevue/menuitem". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "primevue/menuitem". The package may have incorrect main/module/exports specified in its package.json.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.