### PR TITLE
change prettier endOfLine to crlf and format

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,5 +6,6 @@
     "singleQuote": true,
     "vueIndentScriptAndStyle": false,
     "printWidth": 250,
-    "bracketSameLine": false
+    "bracketSameLine": false,
+    "endOfLine": "crlf"
 }

--- a/app.vue
+++ b/app.vue
@@ -36,12 +36,12 @@ export default {
             if (itemString) {
                 const item = JSON.parse(itemString);
 
-                if (!item.hiddenNews || item.hiddenNews !== News.id)
+                if (!item.hiddenNews || item.hiddenNews !== News.id) {
                     this.$appState.newsActive = true;
-                
-                else this.$appState.newsActive = false;
-            } 
-            else {
+                } else {
+                    this.$appState.newsActive = false;
+                }
+            } else {
                 this.$appState.newsActive = true;
             }
         };

--- a/plugins/appState.js
+++ b/plugins/appState.js
@@ -1,11 +1,11 @@
 const $appState = {
     install: (Vue, options) => {
-        Vue.config.globalProperties.$appState = reactive({ 
-            theme: 'lara-light-blue', 
-            darkTheme: false, 
-            codeSandbox: false, 
-            sourceType: 'options-api', 
-            newsActive: true, 
+        Vue.config.globalProperties.$appState = reactive({
+            theme: 'lara-light-blue',
+            darkTheme: false,
+            codeSandbox: false,
+            sourceType: 'options-api',
+            newsActive: true,
             announcement: {},
             storageKey: 'primevue'
         });


### PR DESCRIPTION
Running `npm run format` was causing every single file in the project to change its line endings to `lf`. Setting `endOfLine` to `crlf` in the prettier config meant all the files remained unchanged.