### PR TITLE
recursively traverse the vnode tree until tabs are found, fixes #3625

### DIFF
--- a/components/tabview/TabView.vue
+++ b/components/tabview/TabView.vue
@@ -333,6 +333,13 @@ export default {
         },
         getTabContentClass(tab) {
             return ['p-tabview-panel', this.getTabProp(tab, 'contentClass')];
+        },
+        getTabNodes(nodes) {
+            if (this.isTabPanel(nodes[0])) {
+                return nodes;
+            } else {
+                return this.getTabNodes(nodes[0].children);
+            }
         }
     },
     computed: {
@@ -345,7 +352,10 @@ export default {
             ];
         },
         tabs() {
-            return this.$slots.default().reduce((tabs, child) => {
+            const nodes = this.$slots.default();
+            const tabNodes = this.getTabNodes(nodes);
+
+            return tabNodes.reduce((tabs, child) => {
                 if (this.isTabPanel(child)) {
                     tabs.push(child);
                 } else if (child.children && child.children instanceof Array) {

--- a/components/tabview/TabView.vue
+++ b/components/tabview/TabView.vue
@@ -353,21 +353,8 @@ export default {
         },
         tabs() {
             const nodes = this.$slots.default();
-            const tabNodes = this.getTabNodes(nodes);
 
-            return tabNodes.reduce((tabs, child) => {
-                if (this.isTabPanel(child)) {
-                    tabs.push(child);
-                } else if (child.children && child.children instanceof Array) {
-                    child.children.forEach((nestedChild) => {
-                        if (this.isTabPanel(nestedChild)) {
-                            tabs.push(nestedChild);
-                        }
-                    });
-                }
-
-                return tabs;
-            }, []);
+            return this.getTabNodes(nodes);
         },
         prevButtonAriaLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.previous : undefined;


### PR DESCRIPTION
fixes https://github.com/primefaces/primevue/issues/3625

Previous:
https://codesandbox.io/p/sandbox/extending-tabview-nx8rwl?file=%252Fsrc%252Fcomponents%252FTabView.vue

Now:
https://codesandbox.io/p/sandbox/extending-tabview-forked-ipxj7h?file=%252Fsrc%252Fcomponents%252FTabView.vue