### PR TITLE
Add lazySelectAllPreservesSelection to DataTable

### DIFF
--- a/components/datatable/DataTable.d.ts
+++ b/components/datatable/DataTable.d.ts
@@ -234,6 +234,10 @@ export interface DataTableRowUnselectAllEvent {
      * Browser event
      */
     originalEvent: Event;
+    /**
+     * Selected dataset
+     */
+    data: any;
 }
 
 export interface DataTableSelectAllChangeEvent {
@@ -624,6 +628,10 @@ export interface DataTableProps {
      * Whether all data is selected.
      */
     selectAll?: Nullable<boolean>;
+    /**
+     * Whether the select all checkbox clears the selection when lazy loading.
+     */
+    lazySelectAllPreservesSelection?: boolean | undefined;
     /**
      * When enabled, background of the rows change on hover.
      */

--- a/components/datatable/DataTable.vue
+++ b/components/datatable/DataTable.vue
@@ -385,6 +385,10 @@ export default {
             type: Boolean,
             default: null
         },
+        lazySelectAllPreservesSelection: {
+            type: Boolean,
+            default: false
+        },
         rowHover: {
             type: Boolean,
             default: false
@@ -1195,10 +1199,19 @@ export default {
                 let _selection = [];
 
                 if (checked) {
-                    _selection = this.frozenValue ? [...this.frozenValue, ...this.processedData] : this.processedData;
+                    if (this.lazySelectAllPreservesSelection) {
+                        _selection = [...this.selection, ...this.processedData.filter((val) => this.findIndexInSelection(val) < 0)];
+                    } else {
+                        _selection = this.frozenValue ? [...this.frozenValue, ...this.processedData] : this.processedData;
+                    }
+
                     this.$emit('row-select-all', { originalEvent, data: _selection });
                 } else {
-                    this.$emit('row-unselect-all', { originalEvent });
+                    if (this.lazySelectAllPreservesSelection) {
+                        _selection = [...this.selection].filter((val) => this.findIndex(val, this.processedData) < 0);
+                    }
+
+                    this.$emit('row-unselect-all', { originalEvent, data: _selection });
                 }
 
                 this.$emit('update:selection', _selection);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,6 +1575,28 @@
                 "@types/chai": "*"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.0.tgz",
+            "integrity": "sha512-35EhHNOXgxnUgh4XCJsGhE7zdlDhYDN/aMG6UbkByCFFNgQ7b3U+uVoqBpicFydR8JEfgdjCF7SJ7MiJfzuiTA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -2167,6 +2189,181 @@
                 "vue": ">=2.7 || >=3"
             }
         },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/@zhead/schema": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.0.9.tgz",
@@ -2220,6 +2417,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -3262,6 +3469,16 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/ci-info": {
@@ -4621,6 +4838,13 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/es5-ext": {
             "version": "0.10.62",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
@@ -5621,6 +5845,16 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.x"
+            }
         },
         "node_modules/execa": {
             "version": "5.1.1",
@@ -6653,6 +6887,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/glob-watcher": {
             "version": "5.0.5",
@@ -8255,6 +8496,13 @@
                 "node": ">=4"
             }
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8465,6 +8713,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/loader-runner": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6.11.5"
             }
         },
         "node_modules/loader-utils": {
@@ -13798,6 +14056,111 @@
                 "node": ">=10"
             }
         },
+        "node_modules/terser-webpack-plugin": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.14",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "terser": "^5.14.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15675,6 +16038,20 @@
                 "node": ">=12"
             }
         },
+        "node_modules/watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/wcwidth": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15702,6 +16079,54 @@
                 "node": ">=12"
             }
         },
+        "node_modules/webpack": {
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/webpack-sources": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -15716,6 +16141,32 @@
             "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
             "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
             "dev": true
+        },
+        "node_modules/webpack/node_modules/@types/estree": {
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/webpack/node_modules/schema-utils": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
         },
         "node_modules/whatwg-encoding": {
             "version": "2.0.0",
@@ -17176,7 +17627,8 @@
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-wasm/-/plugin-wasm-6.1.2.tgz",
             "integrity": "sha512-YdrQ7zfnZ54Y+6raCev3tR1PrhQGxYKSTajGylhyP0oBacouuNo6KcNCk+pYKw9M98jxRWLFFca/udi76IDXzg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@rollup/pluginutils": {
             "version": "5.0.2",
@@ -17222,6 +17674,28 @@
             "dev": true,
             "requires": {
                 "@types/chai": "*"
+            }
+        },
+        "@types/eslint": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.0.tgz",
+            "integrity": "sha512-35EhHNOXgxnUgh4XCJsGhE7zdlDhYDN/aMG6UbkByCFFNgQ7b3U+uVoqBpicFydR8JEfgdjCF7SJ7MiJfzuiTA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/eslint-scope": {
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+            "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
             }
         },
         "@types/estree": {
@@ -17390,7 +17864,8 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.2.0.tgz",
             "integrity": "sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@vitejs/plugin-vue-jsx": {
             "version": "2.1.1",
@@ -17688,6 +18163,181 @@
                 "@unhead/vue": "^1.0.18"
             }
         },
+        "@webassemblyjs/ast": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/helper-numbers": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+            "dev": true,
+            "peer": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/helper-wasm-section": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-opt": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "@webassemblyjs/wast-printer": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-buffer": "1.11.1",
+                "@webassemblyjs/wasm-gen": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/helper-api-error": "1.11.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+                "@webassemblyjs/ieee754": "1.11.1",
+                "@webassemblyjs/leb128": "1.11.1",
+                "@webassemblyjs/utf8": "1.11.1"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.11.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "dev": true,
+            "peer": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "dev": true,
+            "peer": true
+        },
         "@zhead/schema": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.0.9.tgz",
@@ -17730,11 +18380,20 @@
                 }
             }
         },
+        "acorn-import-assertions": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+            "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+            "dev": true,
+            "peer": true,
+            "requires": {}
+        },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -17767,7 +18426,8 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-colors": {
             "version": "1.1.0",
@@ -18503,6 +19163,13 @@
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
             "dev": true
         },
+        "chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true,
+            "peer": true
+        },
         "ci-info": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
@@ -18978,7 +19645,8 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
             "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "css-select": {
             "version": "4.3.0",
@@ -19067,7 +19735,8 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
             "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "csso": {
             "version": "4.2.0",
@@ -19567,6 +20236,13 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-module-lexer": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+            "dev": true,
+            "peer": true
+        },
         "es5-ext": {
             "version": "0.10.62",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
@@ -20004,7 +20680,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
             "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-nuxt": {
             "version": "4.0.0",
@@ -20209,6 +20886,13 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "peer": true
         },
         "execa": {
             "version": "5.1.1",
@@ -21047,6 +21731,13 @@
                 }
             }
         },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "peer": true
+        },
         "glob-watcher": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
@@ -21550,7 +22241,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ieee754": {
             "version": "1.2.1",
@@ -22227,6 +22919,13 @@
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "peer": true
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -22401,6 +23100,13 @@
                 "pinkie-promise": "^2.0.0",
                 "strip-bom": "^2.0.0"
             }
+        },
+        "loader-runner": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "dev": true,
+            "peer": true
         },
         "loader-utils": {
             "version": "3.2.1",
@@ -24165,25 +24871,29 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
             "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
             "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
             "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
             "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-import": {
             "version": "15.1.0",
@@ -24316,7 +25026,8 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -24351,7 +25062,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
             "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "5.1.0",
@@ -26392,6 +27104,73 @@
                 "source-map-support": "~0.5.20"
             }
         },
+        "terser-webpack-plugin": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+            "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "^0.3.14",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.0",
+                "terser": "^5.14.1"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true,
+                    "peer": true
+                },
+                "jest-worker": {
+                    "version": "27.5.1",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+                    "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^8.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+                    "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.8",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                },
+                "serialize-javascript": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+                    "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "randombytes": "^2.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -27661,7 +28440,8 @@
             "version": "0.13.11",
             "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
             "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "vue-devtools-stub": {
             "version": "0.1.0",
@@ -27759,6 +28539,17 @@
                 "xml-name-validator": "^4.0.0"
             }
         },
+        "watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            }
+        },
         "wcwidth": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -27779,6 +28570,60 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "dev": true
+        },
+        "webpack": {
+            "version": "5.75.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^0.0.51",
+                "@webassemblyjs/ast": "1.11.1",
+                "@webassemblyjs/wasm-edit": "1.11.1",
+                "@webassemblyjs/wasm-parser": "1.11.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.7.6",
+                "browserslist": "^4.14.5",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.10.0",
+                "es-module-lexer": "^0.9.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.9",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.1.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.1.3",
+                "watchpack": "^2.4.0",
+                "webpack-sources": "^3.2.3"
+            },
+            "dependencies": {
+                "@types/estree": {
+                    "version": "0.0.51",
+                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+                    "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+                    "dev": true,
+                    "peer": true
+                },
+                "schema-utils": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+                    "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+                    "dev": true,
+                    "peer": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.8",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
+            }
         },
         "webpack-sources": {
             "version": "3.2.3",
@@ -27927,7 +28772,8 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
             "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xml-name-validator": {
             "version": "4.0.0",

--- a/pages/datatable/DataTableDoc.vue
+++ b/pages/datatable/DataTableDoc.vue
@@ -2088,6 +2088,15 @@ export default {
                             <td>Selected row instance with the ContextMenu.</td>
                         </tr>
                         <tr>
+                            <td>lazySelectAllPreservesSelection</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>
+                                When enabled, clicking the check all box on a lazily paginated table will preserve any
+                                existing selections.
+                            </td>
+                        </tr>
+                        <tr>
                             <td>rowHover</td>
                             <td>boolean</td>
                             <td>false</td>


### PR DESCRIPTION
###Defect Fixes
Fixes [3641](https://github.com/primefaces/primevue/issues/3641) - Lazy DataTable with multiple selection breaks when "select all" checkbox is checked.

This PR adds a new attribute `lazySelectAllPreservesSelection` that defaults to false (to preserve backwards "compatibility"). When set to true, this new attribute will slightly change the behaviour of the toggleRowsWithCheckbox method to allow prior selection to remain in-tact.

Similarly to the "check all" checkbox only adding the current page of results to the selection, when unchecking, only the current page of results will be removed from the selection. Because of this, the DataTableRowUnselectAllEvent was updated to also have the "data" key.


*note: I couldn't run `npm ci` because the package-lock.json was out of date. I can remove this file if need-be.