### PR TITLE
Fix "frozen" logic on DataTable

### DIFF
--- a/components/datatable/BodyCell.vue
+++ b/components/datatable/BodyCell.vue
@@ -373,6 +373,10 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
                         right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
@@ -381,6 +385,10 @@ export default {
                 } else {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
+
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
 
                     if (prev) {
                         left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);

--- a/components/datatable/DataTable.spec.js
+++ b/components/datatable/DataTable.spec.js
@@ -669,9 +669,9 @@ describe('DataTable.vue', () => {
     });
 
     // frozen columns
-    it('should have frozen columns', () => {
+    it('should have frozen columns', async () => {
         wrapper = null;
-        wrapper = mount(DataTable, {
+        wrapper = await mount(DataTable, {
             global: {
                 plugins: [PrimeVue],
                 components: {
@@ -686,16 +686,33 @@ describe('DataTable.vue', () => {
             },
             slots: {
                 default: `
-                    <Column field="code" header="Code" frozen></Column>
-                    <Column field="name" header="Name"></Column>
+                    <Column field="id" header="ID" footer="ID Footer" frozen style="width:3rem" />
+                    <Column field="code" header="Code" style="width: 5rem" />
+                    <Column field="name" header="Name" footer="Name Footer" frozen style="width: 10rem" />
+                    <Column field="code" header="Code 2" style="width: 10rem" />
+                    <Column field="name" header="Name 2" style="width: 10rem" />
                 `
             }
         });
 
-        expect(wrapper.find('th.p-frozen-column').exists()).toBe(true);
-        // expect(wrapper.find('th.p-frozen-column').attributes().style).toBe('left: 0px;');
-        expect(wrapper.findAll('td.p-frozen-column').length).toBe(3);
-        // expect(wrapper.findAll('td.p-frozen-column')[0].attributes().style).toBe('left: 0px;');
+        const headerColumns = wrapper.findAll('thead th.p-frozen-column');
+        const bodyColumns = wrapper.findAll('tbody td.p-frozen-column');
+        const footerColumns = wrapper.findAll('tfoot td.p-frozen-column');
+
+        expect(headerColumns.length).toBe(2); // 1 per frozen column
+        expect(bodyColumns.length).toBe(6); // 1 per row per frozen column
+        expect(footerColumns.length).toBe(2); // 1 per frozen column
+
+        // first frozen column should be left: 0
+        expect(headerColumns[0].attributes().style).toContain('left: 0px;');
+        expect(bodyColumns[0].attributes().style).toContain('left: 0px;');
+        expect(footerColumns[0].attributes().style).toContain('left: 0px;');
+
+        // 2nd frozen column should be left: 48 (3 rem of 1st frozen column)
+        // offsetWidth is not set in testing, so this does not calculate correctly :(
+        // expect(headerColumns[1].attributes().style).toContain('left: 48px;');
+        // expect(bodyColumns[1].attributes().style).toContain('left: 48px;');
+        // expect(footerColumns[1].attributes().style).toContain('left: 48px;');
     });
 
     // lazy loading

--- a/components/datatable/FooterCell.vue
+++ b/components/datatable/FooterCell.vue
@@ -43,8 +43,12 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
-                        right = DomHandler.getOuterWidth(next) + parseFloat(next.style.left);
+                        right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
 
                     this.styleObject.right = right + 'px';
@@ -52,8 +56,12 @@ export default {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
 
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
+
                     if (prev) {
-                        left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left);
+                        left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
                     }
 
                     this.styleObject.left = left + 'px';
@@ -72,10 +80,10 @@ export default {
             ];
         },
         containerStyle() {
-            let bodyStyle = this.columnProp('footerStyle');
+            let footerStyle = this.columnProp('footerStyle');
             let columnStyle = this.columnProp('style');
 
-            return this.columnProp('frozen') ? [columnStyle, bodyStyle, this.styleObject] : [columnStyle, bodyStyle];
+            return this.columnProp('frozen') ? [columnStyle, footerStyle, this.styleObject] : [columnStyle, footerStyle];
         }
     }
 };

--- a/components/datatable/HeaderCell.vue
+++ b/components/datatable/HeaderCell.vue
@@ -216,6 +216,10 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
                         right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
@@ -224,6 +228,10 @@ export default {
                 } else {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
+
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
 
                     if (prev) {
                         left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);

--- a/components/treetable/BodyCell.vue
+++ b/components/treetable/BodyCell.vue
@@ -94,6 +94,10 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
                         right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
@@ -102,6 +106,10 @@ export default {
                 } else {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
+
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
 
                     if (prev) {
                         left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);

--- a/components/treetable/FooterCell.vue
+++ b/components/treetable/FooterCell.vue
@@ -43,6 +43,10 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
                         right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
@@ -51,6 +55,10 @@ export default {
                 } else {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
+
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
 
                     if (prev) {
                         left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);

--- a/components/treetable/HeaderCell.vue
+++ b/components/treetable/HeaderCell.vue
@@ -67,6 +67,10 @@ export default {
                     let right = 0;
                     let next = this.$el.nextElementSibling;
 
+                    while (next && !next.classList.contains('p-frozen-column')) {
+                      next = next.nextElementSibling;
+                    }
+
                     if (next) {
                         right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
                     }
@@ -75,6 +79,10 @@ export default {
                 } else {
                     let left = 0;
                     let prev = this.$el.previousElementSibling;
+
+                    while (prev && !prev.classList.contains('p-frozen-column')) {
+                      prev = prev.previousElementSibling;
+                    }
 
                     if (prev) {
                         left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);


### PR DESCRIPTION
Fixes https://github.com/primefaces/primevue/issues/3190


2 problems are solved by this PR.

1. Footer elements do not "freeze" with the header/body cells. This was fixed by adding an `|| 0` to the parseFloat calls in updateStickyPosition (like header/body had).
2. If you had a frozen column that was not next to another frozen column, the spacing was set to the wrong element. I.e.
(frozen, width 1rem) (frozen, width 2rem) (not frozen, width 3rem) (frozen, width 4rem)
You would expect the 3rd frozen column to line up with the 2nd frozen column (2rem), but it was pulling the width from the adjacent sibling (3rem), not the adjacent sibling that was also frozen. By cycling the siblings until finding one with the "frozen" column class, this now correctly lines them up.