### PR TITLE
#3624 Calendar.vue Fix calendar not allowing focus/input

### DIFF
--- a/components/calendar/Calendar.vue
+++ b/components/calendar/Calendar.vue
@@ -2503,7 +2503,7 @@ export default {
             if (cell) {
                 cell.tabIndex = '0';
 
-                if (!this.inline && (!this.navigationState || !this.navigationState.button) && !this.timePickerChange) {
+                if (!this.preventFocus && !this.inline && (!this.navigationState || !this.navigationState.button) && !this.timePickerChange) {
                     cell.focus();
                 }
 


### PR DESCRIPTION
This fixes https://github.com/primefaces/primevue/issues/3624 

As noted by [aliehsdev](https://github.com/aliehsdev) as it was missing the check that was previous removed for preventing focus