### PR TITLE
fix: restore checkbox stop propagation in datatable checkbox from ver…

### DIFF
--- a/components/datatable/RowCheckbox.vue
+++ b/components/datatable/RowCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="['p-checkbox p-component', { 'p-checkbox-focused': focused }]" @click="onClick">
+    <div :class="['p-checkbox p-component', { 'p-checkbox-focused': focused }]" @click.stop.prevent="onClick">
         <div class="p-hidden-accessible">
             <input ref="input" type="checkbox" :checked="checked" :disabled="$attrs.disabled" :tabindex="$attrs.disabled ? null : '0'" :aria-label="checkboxAriaLabel" @focus="onFocus($event)" @blur="onBlur($event)" @keydown="onKeydown" />
         </div>


### PR DESCRIPTION
restore checkbox stop propagation in datatable checkbox from version 3.20

In version 3.21, if  set selectionMode in <Datatable>, and checkbox select column, then the checkbox in column not checked currectly:
can not uncheck when click the checkbox in column