### PR TITLE
fix: DataTable ExportDoc.vue closing script tag

### DIFF
--- a/doc/datatable/ExportDoc.vue
+++ b/doc/datatable/ExportDoc.vue
@@ -73,7 +73,7 @@ export default {
         }
     }
 }
-<\/script>
+</script>
 `,
                 composition: `
 <template>
@@ -105,7 +105,7 @@ const products = ref();
 const exportCSV = () => {
     dt.value.exportCSV();
 };
-<\/script>
+</script>
 `,
                 data: `
 /* ProductService */


### PR DESCRIPTION
Fix the closing `script` tags in the example

###Defect Fixes
This should fix #3723 
