### PR TITLE
DataTable: Sorting icons feel wrong

### DIFF
--- a/src/components/datatable/HeaderCell.vue
+++ b/src/components/datatable/HeaderCell.vue
@@ -29,6 +29,9 @@ import ColumnSlot from './ColumnSlot.vue';
 import HeaderCheckbox from './HeaderCheckbox.vue';
 import ColumnFilter from './ColumnFilter.vue';
 
+const ascIcon = 'pi-sort-amount-up';
+const descIcon = 'pi-sort-amount-down';
+
 export default {
     props: {
         column: {
@@ -217,17 +220,17 @@ export default {
             return [
                 'p-sortable-column-icon pi pi-fw', {
                     'pi-sort-alt': !sorted,
-                    'pi-sort-amount-up-alt': sorted && sortOrder > 0,
-                    'pi-sort-amount-down': sorted && sortOrder < 0
+                    [ascIcon]: sorted && sortOrder > 0,
+                    [descIcon]: sorted && sortOrder < 0
                 }
             ];
         },
         ariaSort() {
             if (this.columnProp('sortable')) {
                 const sortIcon = this.sortableColumnIcon;
-                if (sortIcon[1]['pi-sort-amount-down'])
+                if (sortIcon[1][descIcon])
                     return 'descending';
-                else if (sortIcon[1]['pi-sort-amount-up-alt'])
+                else if (sortIcon[1][ascIcon])
                     return 'ascending';
                 else
                     return 'none';


### PR DESCRIPTION
Replaced the sorting icons with the following:
* For ascending order `pi-sort-amount-up`
* For descending order `pi-sort-amount-down`

This way, the arrow and the bars properly reflect the sort order:
* In ascending order the arrow points (up) towards the biggest bar and starts at the smallest
* In descending order the arrow points (down) towards the smallest bar and starts at the biggest
* The order of the bars doesn't change between states, giving better consistency
* The way the arrow points up or down mimics its mnemonic association
* The arrow points either up or down, which mirrors the unsorted state's icon

Fixes #3730 