### PR TITLE
Update Dropdown.vue

### DIFF
--- a/components/dropdown/Dropdown.vue
+++ b/components/dropdown/Dropdown.vue
@@ -571,6 +571,9 @@ export default {
                     break;
 
                 case 'Enter':
+                    if (event.keyCode === 229) {
+                        break;
+                    }
                     this.onEnterKey(event);
                     break;
 


### PR DESCRIPTION
Fixes #3766
Fixed a bug that caused the Dropdown component filter to close when full-width characters were entered.