### PR TITLE
Calendar: Scroll problem when passing slot

### DIFF
--- a/components/calendar/Calendar.vue
+++ b/components/calendar/Calendar.vue
@@ -637,7 +637,7 @@ export default {
     updated() {
         if (this.overlay) {
             this.preventFocus = true;
-            this.updateFocus();
+            setTimeout(this.updateFocus, 0);
         }
 
         if (this.input && this.selectionStart != null && this.selectionEnd != null) {


### PR DESCRIPTION
Fixed #3791 

When we pass any slot, there was a problem in the first focus because the change was in the portal component. this problem is solved