### PR TITLE
fix: visibleOptions respecting optionGroupChildren

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -978,9 +978,10 @@ export default {
                     const filtered = [];
 
                     optionGroups.forEach((group) => {
-                        const filteredItems = group.items.filter((item) => filteredOptions.includes(item));
+                        const groupChildren = this.getOptionGroupChildren(group);
+                        const filteredItems = groupChildren.filter((item) => filteredOptions.includes(item));
 
-                        if (filteredItems.length > 0) filtered.push({ ...group, items: [...filteredItems] });
+                        if (filteredItems.length > 0) filtered.push({ ...group, [typeof this.optionGroupChildren === 'string' ? this.optionGroupChildren : 'items']: [...filteredItems] });
                     });
 
                     return this.flatOptions(filtered);

--- a/components/lib/multiselect/MultiSelect.vue
+++ b/components/lib/multiselect/MultiSelect.vue
@@ -1093,9 +1093,10 @@ export default {
                     const filtered = [];
 
                     optionGroups.forEach((group) => {
-                        const filteredItems = group.items.filter((item) => filteredOptions.includes(item));
+                        const groupChildren = this.getOptionGroupChildren(group);
+                        const filteredItems = groupChildren.filter((item) => filteredOptions.includes(item));
 
-                        if (filteredItems.length > 0) filtered.push({ ...group, items: [...filteredItems] });
+                        if (filteredItems.length > 0) filtered.push({ ...group, [typeof this.optionGroupChildren === 'string' ? this.optionGroupChildren : 'items']: [...filteredItems] });
                     });
 
                     return this.flatOptions(filtered);


### PR DESCRIPTION
Before this change, filtering with `optionGroupLabel`, etc, would assume that `optionGroupChildren` is `items`, and so when it was set to something else, `group.items` would be `undefined` and `(undefined).filter(...)` would cause an error.

resolves https://github.com/primefaces/primevue/issues/3807

**Please be sure to test this for yourself as you'd have better knowledge about filterservice!**