### PR TITLE
Dropdown: Change prop autoFilterFocus default value to true

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -266,7 +266,7 @@ export default {
         },
         autoFilterFocus: {
             type: Boolean,
-            default: false
+            default: true
         },
         selectOnFocus: {
             type: Boolean,


### PR DESCRIPTION
Hi,

The filter input of the dropdown has always been auto focused until 3.16.0
This allows the user to start typing and filtering without the need to manually click on the filter text input

This is a stackblitz using 3.15.0 demonstrating what i just described https://stackblitz.com/edit/angular-4ppqqo-bwmcks?file=src%2Fmain.js,src%2FApp.vue,package.json

And this another one using 3.16.0 where the auto focus no longer occurs https://stackblitz.com/edit/angular-4ppqqo-hkajcu?file=package.json

###Feature Requests
https://github.com/primefaces/primevue/issues/3840