### PR TITLE
AutoComplete: show overlay if there are no suggestions

### DIFF
--- a/components/lib/autocomplete/AutoComplete.spec.js
+++ b/components/lib/autocomplete/AutoComplete.spec.js
@@ -55,6 +55,21 @@ describe('AutoComplete.vue', () => {
         expect(wrapper.findAll('.p-autocomplete-item').length).toBe(1);
     });
 
+    it('should show overlay and empty-message if there are no suggestions', async () => {
+        const event = { target: { value: 'b' } };
+
+        wrapper.vm.search(event, event.target.value, 'input');
+        await wrapper.vm.$nextTick();
+
+        await wrapper.setProps({
+            suggestions: []
+        });
+
+        expect(wrapper.find('.p-autocomplete-items').exists()).toBe(true);
+        expect(wrapper.findAll('.p-autocomplete-item').length).toBe(0);
+        expect(wrapper.find('.p-autocomplete-empty-message').exists()).toBe(true);
+    })
+
     it('dropdown', () => {
         it('should have correct custom icon', async () => {
             wrapper.setProps({

--- a/components/lib/autocomplete/AutoComplete.spec.js
+++ b/components/lib/autocomplete/AutoComplete.spec.js
@@ -68,7 +68,7 @@ describe('AutoComplete.vue', () => {
         expect(wrapper.find('.p-autocomplete-items').exists()).toBe(true);
         expect(wrapper.findAll('.p-autocomplete-item').length).toBe(0);
         expect(wrapper.find('.p-autocomplete-empty-message').exists()).toBe(true);
-    })
+    });
 
     it('dropdown', () => {
         it('should have correct custom icon', async () => {

--- a/components/lib/autocomplete/AutoComplete.vue
+++ b/components/lib/autocomplete/AutoComplete.vue
@@ -215,7 +215,7 @@ export default {
         },
         suggestions() {
             if (this.searching) {
-                ObjectUtils.isNotEmpty(this.suggestions) ? this.show() : !!this.$slots.empty ? this.show() : this.hide();
+                this.show();
                 this.focusedOptionIndex = this.overlayVisible && this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : -1;
                 this.searching = false;
             }


### PR DESCRIPTION
This pr fixes the bug from issue #3669 (Fix #3669).

The problem was, that the overlay was going to be hidden if the search input did not match any suggestions and therefor the empty message was not shown.

I also added some tests that should prevent this bug from happening again.

As this is my first pull request to this repository, I am happy to refactor to your needs and I hope I submitted everything by your satisfaction. If not or if I missed some of your protocol, just let me know!

During the debugging, I also found a further bug (#3865)