### PR TITLE
Fix: Support non-empty values

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -950,7 +950,7 @@ export default {
                     'p-disabled': this.disabled,
                     'p-dropdown-clearable': this.showClear && !this.disabled,
                     'p-focus': this.focused,
-                    'p-inputwrapper-filled': this.modelValue,
+                    'p-inputwrapper-filled': this.hasSelectedOption,
                     'p-inputwrapper-focus': this.focused || this.overlayVisible,
                     'p-overlay-open': this.overlayVisible
                 }


### PR DESCRIPTION
Dropdown does not show correct styling if using a falsey value such as `false` or `0`.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
https://github.com/primefaces/primevue/issues/3891

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.