### PR TITLE
Add isVertical prop for changing tabs orientation

### DIFF
--- a/components/lib/tabview/TabView.vue
+++ b/components/lib/tabview/TabView.vue
@@ -128,7 +128,11 @@ export default {
         nextIcon: {
             type: String,
             default: undefined
-        }
+        },
+        isVertical: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -366,6 +370,9 @@ export default {
         },
         getTabContentClass(tab) {
             return ['p-tabview-panel', this.getTabProp(tab, 'contentClass')];
+        },
+        setOrientationClass() {
+            return this.isVertical ? 'p-tabview-vertical' : 'p-tabview-horizontal';
         }
     },
     computed: {
@@ -374,7 +381,8 @@ export default {
                 'p-tabview p-component',
                 {
                     'p-tabview-scrollable': this.scrollable
-                }
+                },
+                this.setOrientationClass()
             ];
         },
         tabs() {
@@ -410,6 +418,36 @@ export default {
 </script>
 
 <style>
+.p-tabview-vertical {
+    display: flex;
+    flex-direction: row;
+}
+.p-tabview-vertical .p-tabview-nav {
+    flex-direction: column;
+    border: 1px solid var(--surface-d);
+    background: var(--surface-a);
+    border-radius: 7px;
+    padding-block: 1rem;
+}
+.p-tabview-vertical .p-tabview-nav li.p-highlight .p-tabview-nav-link {
+    background: var(--surface-hover);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    backdrop-filter: blur(5px);
+}
+.p-tabview-vertical .p-tabview-nav li:last-of-type {
+    height: 0;
+}
+.p-tabview-vertical .p-tabview-nav-container {
+   min-width: 150px;
+}
+.p-tabview-vertical .p-tabview-nav li .p-tabview-nav-link {
+    background-color: var(--surface-a);
+    border-radius: 0;
+    border-width: 0 0 0 3px;
+    margin: 0;
+}
+
 .p-tabview-nav-container {
     position: relative;
 }
@@ -479,4 +517,5 @@ export default {
 .p-tabview-nav-content::-webkit-scrollbar {
     display: none;
 }
+
 </style>

--- a/doc/tabview/OrientationDoc.vue
+++ b/doc/tabview/OrientationDoc.vue
@@ -1,0 +1,79 @@
+<template>
+    <DocSectionText v-bind="$attrs">
+        <p>Tabs orientation can be changed to vertical by set <i> isVertical </i> props to true </p>
+    </DocSectionText>
+    <div class="card">
+        <TabView :isVertical="true">
+            <TabPanel v-for="tab in tabs" :key="tab.title" :header="tab.title">
+                <p>{{ tab.content }}</p>
+            </TabPanel>
+        </TabView>
+    </div>
+    <DocSectionCode :code="code" />
+</template>
+
+<script>    
+export default {
+    data() {
+        return {
+            tabs: [
+                { title: 'Tab 1', content: 'Tab 1 Lorem ipsum dolor sit amet' },
+                { title: 'Tab 2', content: 'Tab 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua' },
+                { title: 'Tab 3', content: 'Tab 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ' }
+            ],
+            code: {
+                basic: `
+<TabView :isVertical="true">
+    <TabPanel v-for="tab in tabs" :key="tab.title" :header="tab.title">
+        <p>{{ tab.content }}</p>
+    </TabPanel>
+</TabView>`,
+                options: `
+<template>
+    <div class="card">
+        <TabView :isVertical="true">
+            <TabPanel v-for="tab in tabs" :key="tab.title" :header="tab.title">
+                <p>{{ tab.content }}</p>
+            </TabPanel>
+        </TabView>
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            tabs: [
+                { title: 'Tab 1', content: 'Tab 1 Content' },
+                { title: 'Tab 2', content: 'Tab 2 Content' },
+                { title: 'Tab 3', content: 'Tab 3 Content' }
+            ]
+        };
+    }
+};
+<\/script>`,
+                composition: `
+<template>
+    <div class="card">
+        <TabView :isVertical="true">
+            <TabPanel v-for="tab in tabs" :key="tab.title" :header="tab.title">
+                <p>{{ tab.content }}</p>
+            </TabPanel>
+        </TabView>
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const tabs = ref([
+    { title: 'Tab 1', content: 'Tab 1 Content' },
+    { title: 'Tab 2', content: 'Tab 2 Content' },
+    { title: 'Tab 3', content: 'Tab 3 Content' }
+]);
+<\/script>`
+            }
+        };
+    }
+};
+</script>

--- a/pages/tabview/index.vue
+++ b/pages/tabview/index.vue
@@ -10,6 +10,7 @@ import DisabledDoc from '@/doc/tabview/DisabledDoc.vue';
 import DynamicDoc from '@/doc/tabview/DynamicDoc.vue';
 import ImportDoc from '@/doc/tabview/ImportDoc.vue';
 import ScrollableDoc from '@/doc/tabview/ScrollableDoc.vue';
+import OrientationDoc from '@/doc/tabview/OrientationDoc.vue';
 import StyleDoc from '@/doc/tabview/StyleDoc.vue';
 import TemplateDoc from '@/doc/tabview/TemplateDoc.vue';
 import PTComponent from '@/doc/tabview/pt/index.vue';
@@ -42,6 +43,11 @@ export default {
                     id: 'scrollable',
                     label: 'Scrollable',
                     component: ScrollableDoc
+                },
+                {
+                    id: 'orientation',
+                    label: 'Orientation',
+                    component: OrientationDoc
                 },
                 {
                     id: 'disabled',

--- a/vite.config.js
+++ b/vite.config.js
@@ -65,6 +65,8 @@ export default {
             'primevue/menu': path.resolve(__dirname, './components/lib/menu/Menu.vue'),
             'primevue/tieredmenu': path.resolve(__dirname, './components/lib/tieredmenu/TieredMenu.vue'),
             'primevue/dropdown': path.resolve(__dirname, './components/lib/dropdown/Dropdown.vue'),
+            'primevue/tabpanel': path.resolve(__dirname, './components/lib/tabpanel/TabPanel.vue'),
+            'primevue/tabview': path.resolve(__dirname, './components/lib/tabview/TabView.vue'),
             'primevue/inputnumber': path.resolve(__dirname, './components/lib/inputnumber/InputNumber.vue'),
             'primevue/paginator': path.resolve(__dirname, './components/lib/paginator/Paginator.vue'),
             'primevue/progressbar': path.resolve(__dirname, './components/lib/progressbar/ProgressBar.vue'),


### PR DESCRIPTION
###Feature Requests
This commit adds a new boolean prop "isVertical" that allows the orientation of tabs to be changed from horizontal to vertical. When the prop is set to "true", the tabs will be displayed vertically instead of horizontally. 

```
<TabView :isVertical="true">
    <TabPanel v-for="tab in tabs" :key="tab.title" :header="tab.title">
        <p>{{ tab.content }}</p>
    </TabPanel>
</TabView>
```
