### PR TITLE
fix: DataTable: Selection and focus loss when no custom ContextMenu is defined

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -1011,8 +1011,10 @@ export default {
             this.$emit('row-dblclick', e);
         },
         onRowRightClick(event) {
-            DomHandler.clearSelection();
-            event.originalEvent.target.focus();
+            if(this.contextMenu){
+                DomHandler.clearSelection();
+                event.originalEvent.target.focus();
+            }
 
             this.$emit('update:contextMenuSelection', event.data);
             this.$emit('row-contextmenu', event);


### PR DESCRIPTION
### Defect Fixes

When a `DataTable` does not use a custom `ContextMenu`, it still clears the user's selection.

A demonstration of the bug:
[data-table-bug.webm](https://user-images.githubusercontent.com/10552683/236423826-8d42fce6-3a99-43a3-b746-b251ec4c818e.webm)

And with this proposed fix:
[data-table-fix.webm](https://user-images.githubusercontent.com/10552683/236423870-a51eb5c0-bda2-408f-bb35-0746f54c7ca0.webm)

All custom events will work as before, but users might have to manually call the selection clear and focus methods from their own `row-contextmenu` listeners, which is less restrictive, but maybe a BC break.

closes #3927 