### PR TITLE
Menu: set the initial focus item of the menu when `popup` is true.

### DIFF
--- a/components/lib/menu/Menu.d.ts
+++ b/components/lib/menu/Menu.d.ts
@@ -153,6 +153,11 @@ export interface MenuProps {
      */
     exact?: boolean | undefined;
     /**
+     * Set the initial focus item of the menu when `popup` is true.
+     * @defaultValue 0
+     */
+    initialFocus?: number | undefined;
+    /**
      * Index of the element in tabbing order.
      */
     tabindex?: number | string | undefined;

--- a/components/lib/menu/Menu.vue
+++ b/components/lib/menu/Menu.vue
@@ -78,6 +78,10 @@ export default {
             type: Boolean,
             default: true
         },
+        initialFocus: {
+            type: Number,
+            default: 0
+        },
         tabindex: {
             type: Number,
             default: 0
@@ -295,7 +299,7 @@ export default {
 
             if (this.popup) {
                 DomHandler.focus(this.list);
-                this.changeFocusedOptionIndex(0);
+                this.changeFocusedOptionIndex(this.initialFocus);
             }
 
             this.$emit('show');


### PR DESCRIPTION
Close #3210.

This PR is a successor of #3211. Since it is outdated and I also need this prop in my code, so I've updated the code to suit the latest version.