### PR TITLE
fix(Steps): add text-overflow ellipsis

### DIFF
--- a/components/lib/steps/Steps.vue
+++ b/components/lib/steps/Steps.vue
@@ -226,6 +226,7 @@ export default {
     display: flex;
     justify-content: center;
     flex: 1 1 auto;
+    overflow: hidden;
 }
 
 .p-steps-item .p-menuitem-link {
@@ -246,6 +247,9 @@ export default {
 
 .p-steps-title {
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 .p-steps-number {


### PR DESCRIPTION
###Defect Fixes
In case of long labels, steps component goes beyond the frame.
It is clearly visible on mobile devices.

This is fixed by adding text-overflow: ellipsis to the label.

Here you can find a sandbox with the fix applied: https://codesandbox.io/s/dreamy-tree-8xequk?file=/src/Steps.vue

Fix #3631 