### PR TITLE
fix: Resolve duplicate clipPath URL on multiple icon instances

### DIFF
--- a/components/lib/icons/filterslash/index.vue
+++ b/components/lib/icons/filterslash/index.vue
@@ -1,6 +1,6 @@
 <template>
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" v-bind="pti()">
-        <g clip-path="url(#clip0_408_20963)">
+        <g :clip-path="'url(#clip0_408_20963' + id + ')'">
             <path
                 fill-rule="evenodd"
                 clip-rule="evenodd"
@@ -9,7 +9,7 @@
             />
         </g>
         <defs>
-            <clipPath id="clip0_408_20963">
+            <clipPath :id="'clip0_408_20963' + id">
                 <rect width="14" height="14" fill="white" />
             </clipPath>
         </defs>
@@ -17,9 +17,15 @@
 </template>
 <script>
 import BaseIcon from 'primevue/baseicon';
+import {uid} from "chart.js/helpers";
 
 export default {
     name: 'FilterSlashIcon',
-    extends: BaseIcon
+    extends: BaseIcon,
+    computed: {
+        id() {
+            return uid();
+        }
+    }
 };
 </script>


### PR DESCRIPTION
The origin of this issue is using a clipPath URL inside an instance of an icon. Those URLs should be unique over the entire webpage as they reference the first element found with the ID.

This results in datatable filters as a reference to the first icon. So the clear-icons are only visible if the first one is as well.

###Defect Fixes
#3959 