### PR TITLE
fix(TreeNode): stop keydown event propagation from content

### DIFF
--- a/components/lib/tree/Tree.spec.js
+++ b/components/lib/tree/Tree.spec.js
@@ -1,0 +1,45 @@
+import { mount } from '@vue/test-utils';
+import PrimeVue from 'primevue/config';
+import { nextTick } from 'vue';
+import Tree from './Tree.vue';
+
+describe('Tree.vue', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = mount(Tree, {
+            props: {
+                value: [
+                    {
+                      key: "0",
+                      label: "Documents",
+                      data: "Documents Folder",
+                      icon: "pi pi-fw pi-inbox",
+                      children: [],
+                    },
+                ],
+            },
+            slots: {
+                default: `<input data-tree-input />`
+            },
+        });
+    });
+
+    it('should exists', () => {
+        expect(wrapper.find('.p-tree.p-component').exists()).toBe(true);
+    });
+
+    it('triggers event', async () => {
+        wrapper.trigger('keydown.space')
+        expect(wrapper.emitted('keydown')).toBeTruthy()
+    });
+
+    it('stops event propagation from content', async () => {
+        // If the event propagation is not stopped from content, then inputs would not work as expected
+        let textInput = wrapper.find('input[data-tree-input]')
+
+        await textInput.trigger('keydown.space')
+
+        expect(wrapper.emitted('keydown')).toBeFalsy()
+    });
+});

--- a/components/lib/tree/Tree.spec.js
+++ b/components/lib/tree/Tree.spec.js
@@ -11,17 +11,17 @@ describe('Tree.vue', () => {
             props: {
                 value: [
                     {
-                      key: "0",
-                      label: "Documents",
-                      data: "Documents Folder",
-                      icon: "pi pi-fw pi-inbox",
-                      children: [],
-                    },
-                ],
+                        key: '0',
+                        label: 'Documents',
+                        data: 'Documents Folder',
+                        icon: 'pi pi-fw pi-inbox',
+                        children: []
+                    }
+                ]
             },
             slots: {
                 default: `<input data-tree-input />`
-            },
+            }
         });
     });
 
@@ -30,16 +30,16 @@ describe('Tree.vue', () => {
     });
 
     it('triggers event', async () => {
-        wrapper.trigger('keydown.space')
-        expect(wrapper.emitted('keydown')).toBeTruthy()
+        wrapper.trigger('keydown.space');
+        expect(wrapper.emitted('keydown')).toBeTruthy();
     });
 
     it('stops event propagation from content', async () => {
         // If the event propagation is not stopped from content, then inputs would not work as expected
-        let textInput = wrapper.find('input[data-tree-input]')
+        let textInput = wrapper.find('input[data-tree-input]');
 
-        await textInput.trigger('keydown.space')
+        await textInput.trigger('keydown.space');
 
-        expect(wrapper.emitted('keydown')).toBeFalsy()
+        expect(wrapper.emitted('keydown')).toBeFalsy();
     });
 });

--- a/components/lib/tree/TreeNode.vue
+++ b/components/lib/tree/TreeNode.vue
@@ -27,7 +27,7 @@
                 </div>
             </div>
             <span :class="cx('nodeIcon')" v-bind="getPTOptions('nodeIcon')"></span>
-            <span :class="cx('label')" v-bind="getPTOptions('label')">
+            <span :class="cx('label')" v-bind="getPTOptions('label')" @keydown.stop>
                 <component v-if="templates[node.type] || templates['default']" :is="templates[node.type] || templates['default']" :node="node" />
                 <template v-else>{{ label(node) }}</template>
             </span>


### PR DESCRIPTION
###Defect Fixes

Currently when you use a input within the TreeNode content, some keys (f.e. space key) do not work, because the event listener of the TreeNode uses them for navigating in the tree view. 
I stopped the event propagation from the content to the TreeNode, so that the elements in the content work fine, but also the navigation in the Tree is not affected.

If you have any questions regarding this PR, feel free to ask!

Fix  #3831
