### PR TITLE
InputNumber: fix formatting of currencies with suffix

### DIFF
--- a/components/lib/inputnumber/InputNumber.vue
+++ b/components/lib/inputnumber/InputNumber.vue
@@ -906,7 +906,7 @@ export default {
                 this._decimal.lastIndex = 0;
 
                 if (this.suffixChar) {
-                    return val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar;
+                    return decimalCharIndex !== -1 ? val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar : val1;
                 } else {
                     return decimalCharIndex !== -1 ? val1.split(this._decimal)[0] + val2.slice(decimalCharIndex) : val1;
                 }


### PR DESCRIPTION
Currently if you enter a negative number in the InputNumber field (with formatting set to a currency with a suffix), the input becomes doubled (f.e. if you type -1, it becomes -11). This is because there is a missing check if decimalCharIndex is valid or not. 

Unfortunately I did not find a solution for writing a test, that covers this bug, because this relies on the keydown event handling of input fields (which vue-test-utils does not support at the time). If you have an idea how to fix this, please let me know, I am happy to write a test for this issue.

Fix #3382