### PR TITLE
Dropdown: add clear input key binding

### DIFF
--- a/components/lib/dropdown/Dropdown.spec.js
+++ b/components/lib/dropdown/Dropdown.spec.js
@@ -89,6 +89,14 @@ describe('clear checks', () => {
     it('should have correct icon', () => {
         expect(wrapper.find('.p-dropdown-clear-icon').classes()).toContain('pi-discord');
     });
+
+    it('should clear with delete key', async () => {
+        const updateModelSpy = vi.spyOn(wrapper.vm, 'updateModel');
+
+        await wrapper.find('.p-dropdown-label.p-inputtext').trigger('keydown', { code: 'Delete' });
+        expect(updateModelSpy).toHaveBeenCalledOnce();
+        expect(updateModelSpy).toHaveBeenCalledWith(expect.any(KeyboardEvent), null);
+    });
 });
 
 describe('editable checks', () => {

--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -356,6 +356,9 @@ export default {
                     this.onArrowLeftKey(event, this.editable);
                     break;
 
+                case 'Delete':
+                    this.onDeleteKey(event);
+
                 case 'Home':
                     this.onHomeKey(event, this.editable);
                     break;
@@ -522,6 +525,12 @@ export default {
 
                 default:
                     break;
+            }
+        },
+        onDeleteKey(event) {
+            if (this.showClear) {
+                this.updateModel(event, null);
+                event.preventDefault();
             }
         },
         onArrowDownKey(event) {


### PR DESCRIPTION
Add key binding for clearing the input of the Dropdown in the showClear mode.

This is a proposal of a possible implementation of the requested feature. Feel free to share your thoughts or improvements!.

Fix  #3834