### PR TITLE
Improve datatable performance

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -775,8 +775,8 @@ export default {
             }
 
             data.sort((data1, data2) => {
-                let value1 = lookupMap(data1);
-                let value2 = lookupMap(data2);
+                let value1 = lookupMap.get(data1);
+                let value2 = lookupMap.get(data2);
 
                 let result = null;
 

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -871,10 +871,6 @@ export default {
 
             let activeFilters = this.getActiveFilters(this.filters);
 
-            if (Object.keys(activeFilters).length == 0) {
-                return data;
-            }
-
             this.clearEditingMetaData();
 
             let globalFilterFieldsArray;
@@ -939,7 +935,7 @@ export default {
                 }
             }
 
-            if (filteredValue.length === this.value.length) {
+            if (filteredValue.length === this.value.length || Object.keys(activeFilters).length == 0) {
                 filteredValue = data;
             }
 


### PR DESCRIPTION
Helps fix https://github.com/primefaces/primevue/issues/4007

This PR does 2 main things to help improve filtering and sorting performance for DataTables:

- Within the `sortSingle` function, performing calls to `resolveFieldData(data1, this.d_sortField)` only once for each item in the dataset, and using a `Map` for later lookups.
- Within the `filter` function, only run filters whose `value` is not `null`.