### PR TITLE
#3858 #3896 - fix row grouping with pagination

### DIFF
--- a/components/lib/datatable/TableBody.vue
+++ b/components/lib/datatable/TableBody.vue
@@ -331,7 +331,7 @@ export default {
         getRowIndex(index) {
             const getItemOptions = this.getVirtualScrollerProp('getItemOptions');
 
-            return getItemOptions ? getItemOptions(index).index : this.first + index;
+            return getItemOptions ? getItemOptions(index).index : index;
         },
         getRowStyle(rowData) {
             if (this.rowStyle) {


### PR DESCRIPTION
As detailed in #3858 and #3896, row grouping is not working with pagination.  This is due to the [`getRowIndex` function](https://github.com/primefaces/primevue/blob/511db538de02f77abc916110a6134012b24708f5/components/lib/datatable/TableBody.vue#L331-L335) adding `this.first` to the row index.  `getRowIndex` is called by as part of the [`shouldRenderRowGroupHeader` call](https://github.com/primefaces/primevue/blob/511db538de02f77abc916110a6134012b24708f5/components/lib/datatable/TableBody.vue#L6).

The problem is that when pagination is enabled, the `DataTable` competent slices the data passed to `TableBody` in the [`dataToRender` function](https://github.com/primefaces/primevue/blob/511db538de02f77abc916110a6134012b24708f5/components/lib/datatable/DataTable.vue#L2161-L2171), so the size of the `value` array being passed to `TableBody` is the page size.  `dataToRender` is being [called when the `value` prop is being passed to `TableBody`](https://github.com/primefaces/primevue/blob/511db538de02f77abc916110a6134012b24708f5/components/lib/datatable/DataTable.vue#LL154C39-L154C39).

This means if the are `100` rows total, with a rows per page of `20`, only `20` rows get passed to `TableBody` at any given time.  If you were on page `2` for example the `getRowIndex` function is adding `this.first` to the `index`, the index it is trying to compare would be `20 + index`, which is out of range for the `value` array of `20` (max) items.

The proposed fix in the PR is to simply stop adding `this.value` to the indexes.  This has fixed the issue in my local testing.