### PR TITLE
Don't write directly to classList in FocusTrap.js

### DIFF
--- a/components/lib/focustrap/FocusTrap.js
+++ b/components/lib/focustrap/FocusTrap.js
@@ -69,7 +69,7 @@ function createHiddenFocusableElements(el, binding) {
     const createFocusableElement = (onFocus) => {
         const element = document.createElement('span');
 
-        element.classList = 'p-hidden-accessible p-hidden-focusable';
+        element.classList.value = 'p-hidden-accessible p-hidden-focusable';
         element.tabIndex = tabIndex;
         element.setAttribute('aria-hidden', 'true');
         element.setAttribute('role', 'presentation');


### PR DESCRIPTION
According to [MDN][1] `classList` is a read-only property. To properly write to it you use its [`value`][2] property (`DOMTokenList#value`) 

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
[2]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/value

###Defect Fixes
#4015
