### PR TITLE
fix(docs): autocomplete disabled

### DIFF
--- a/doc/autocomplete/DisabledDoc.vue
+++ b/doc/autocomplete/DisabledDoc.vue
@@ -1,6 +1,6 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>Invalid state style is added using the <i>p-invalid</i> class to indicate a failed validation.</p>
+        <p>When <i>disabled</i> is present, the element cannot be edited and focused.</p>
     </DocSectionText>
     <div class="card flex justify-content-center">
         <AutoComplete disabled placeholder="Disabled" />


### PR DESCRIPTION
This PR fixes the description of `autocomplete/disabled` in docs. I didn't create an issue to associate with it because it was simple.