### PR TITLE
Bugfix: prevent tooltip to appear if the binded element is removed from DOM

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -88,7 +88,7 @@ function onKeydown(event) {
 }
 
 function tooltipActions(el) {
-    if (el.$_ptooltipDisabled) {
+    if (el.$_ptooltipDisabled || !DomHandler.isExist(el) ) {
         return;
     }
 


### PR DESCRIPTION
bugfix for #4029 