### PR TITLE
fix (docs): PickList documentation properties default value fix

### DIFF
--- a/components/lib/picklist/PickList.d.ts
+++ b/components/lib/picklist/PickList.d.ts
@@ -283,12 +283,12 @@ export interface PickListProps {
     stripedRows?: boolean | undefined;
     /**
      * Whether to show buttons of source list.
-     * @defaultValue false
+     * @defaultValue true
      */
     showSourceControls?: boolean | undefined;
     /**
      * Whether to show buttons of target list.
-     * @defaultValue false
+     * @defaultValue true
      */
     showTargetControls?: boolean | undefined;
     /**


### PR DESCRIPTION
The **showSourceControls** and **showTargetControls** properties have a default value of true in the codebase (https://github.com/primefaces/primevue/blob/master/components/lib/picklist/BasePickList.vue), while the docs incorrectly says the default value is false. (https://github.com/primefaces/primevue/blob/master/components/lib/picklist/PickList.d.ts)