### PR TITLE
Removes css class "p-button-icon-only" when there is a badge from BaseButton.vue

### DIFF
--- a/components/lib/button/BaseButton.vue
+++ b/components/lib/button/BaseButton.vue
@@ -77,7 +77,7 @@ const classes = {
     root: ({ instance, props }) => [
         'p-button p-component',
         {
-            'p-button-icon-only': instance.hasIcon && !props.label,
+            'p-button-icon-only': instance.hasIcon && !props.label && !props.badge,
             'p-button-vertical': (props.iconPos === 'top' || props.iconPos === 'bottom') && props.label,
             'p-disabled': instance.$attrs.disabled || instance.$attrs.disabled === '' || props.loading,
             'p-button-loading': props.loading,


### PR DESCRIPTION
removes css class "p-button-icon-only" when there is a badge

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

https://github.com/primefaces/primevue/issues/4083