### PR TITLE
Fix ambigious clearing behaviour on SelectButton

### DIFF
--- a/api-generator/components/selectbutton.js
+++ b/api-generator/components/selectbutton.js
@@ -51,6 +51,12 @@ const SelectButtonProps = [
         name: 'unselectable',
         type: 'boolean',
         default: 'false',
+        description: 'Whether selection can not be cleared.'
+    },
+    {
+        name: 'allowEmpty',
+        type: 'boolean',
+        default: 'true',
         description: 'Whether selection can be cleared.'
     },
     {

--- a/components/lib/selectbutton/BaseSelectButton.vue
+++ b/components/lib/selectbutton/BaseSelectButton.vue
@@ -27,6 +27,10 @@ export default {
             type: Boolean,
             default: false
         },
+        allowEmpty: {
+            type: Boolean,
+            default: true
+        },
         disabled: Boolean,
         dataKey: null,
         'aria-labelledby': {

--- a/components/lib/selectbutton/SelectButton.d.ts
+++ b/components/lib/selectbutton/SelectButton.d.ts
@@ -127,10 +127,16 @@ export interface SelectButtonProps {
      */
     dataKey?: string | undefined;
     /**
-     * Whether selection can be cleared.
+     * Whether selection can not be cleared.
      * @defaultValue false
+     * @deprecated Use 'allowEmpty' property instead.
      */
     unselectable?: boolean | undefined;
+    /**
+     * Whether selection can be cleared.
+     * @defaultValue true
+     */
+    allowEmpty?: boolean | undefined;
     /**
      * Identifier of the underlying element.
      */

--- a/components/lib/selectbutton/SelectButton.vue
+++ b/components/lib/selectbutton/SelectButton.vue
@@ -80,7 +80,7 @@ export default {
 
             let selected = this.isSelected(option);
 
-            if (selected && this.unselectable) {
+            if (selected && (this.unselectable || !this.allowEmpty)) {
                 return;
             }
 

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -33025,6 +33025,15 @@
                             "readonly": false,
                             "type": "boolean",
                             "default": "false",
+                            "description": "Whether selection can not be cleared.",
+                            "deprecated": "Use 'allowEmpty' property instead."
+                        },
+                        {
+                            "name": "allowEmpty",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "true",
                             "description": "Whether selection can be cleared."
                         },
                         {


### PR DESCRIPTION
In #3610, the meaning of the `unselectable` property on SelectButton was reversed from "able to unselect" to "**un**able to unselect". Because [the documentation](https://primevue.org/selectbutton/#api.selectbutton.props.unselectable) was not updated accordingly, the property currently behaves exactly opposite to how it's described. 

In #3708 and #3973, there was significant disagreement as to what the property should mean. I would agree with those arguing that the textbook meaning of "unselectable" would be that you are able to unselect. However, the name clearly causes some confusion. 

In this PR, I've therefore deprecated the `unselectable` property in favour of the `allowEmpty` property, to avoid further breaking changes. This naming is much less ambigious, and matches the one already found on InputNumber. I've also updated the documentation for `unselectable` to match current behaviour.

Please let me know if I've missed anything, or if further clarification is needed!

Fixes #3973.

