### PR TITLE
Added css 'import' line in icons doc's import section for clarity that we can use .css

### DIFF
--- a/doc/icons/ImportDoc.vue
+++ b/doc/icons/ImportDoc.vue
@@ -1,17 +1,21 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>CSS file of the icon library needs to be imported in <i>styles.scss</i> of your application.</p>
+        <p>CSS file of the icon library needs to be imported in <i>styles.css</i> or <i>styles.scss</i> of your application.</p>
     </DocSectionText>
-    <DocSectionCode :code="code" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
+    <DocSectionCode :code="code_css" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
+    <DocSectionCode :code="code_scss" hideToggleCode importCode hideCodeSandbox hideStackBlitz />
 </template>
 
 <script>
 export default {
     data() {
         return {
-            code: {
-                basic: `import 'primeicons/primeicons.css';`
-            }
+            code_css: {
+                basic: `// For .scss files\nimport 'primeicons/primeicons.css';`
+            },
+            code_scss: {
+                basic: `// For .css files\n@import 'primeicons/primeicons.css';`
+                        }
         };
     }
 };


### PR DESCRIPTION
### This is an improvement for icons doc

I already made an issue about it. 

This is what it looks like now: 
![screenshot](https://github.com/primefaces/primevue/assets/114055827/179b8c32-be8a-48cb-a404-521c769f5637)
