### PR TITLE
Fix: Add preventDefault on SplitButton click event

### DIFF
--- a/components/lib/splitbutton/SplitButton.vue
+++ b/components/lib/splitbutton/SplitButton.vue
@@ -56,7 +56,8 @@ export default {
         });
     },
     methods: {
-        onDropdownButtonClick() {
+        onDropdownButtonClick(event) {
+            event.preventDefault();
             this.$refs.menu.toggle({ currentTarget: this.$el, relatedTarget: this.$refs.button.$el });
             this.isExpanded = this.$refs.menu.visible;
         },
@@ -67,6 +68,8 @@ export default {
             }
         },
         onDefaultButtonClick(event) {
+            event.preventDefault()
+
             if (this.isExpanded) {
                 this.$refs.menu.hide(event);
             }


### PR DESCRIPTION
The SplitButton component of PrimeVue was missing a preventDefault() call when clicking on the button that opens the dropdown menu. This caused unexpected behavior when interacting with the dropdown menu. The issue has been resolved by adding the preventDefault() on the click event, ensuring smooth and expected functionality.

Fixes #4223"

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.