### PR TITLE
use Intl.Collator instead of localeCompare to boost sort time

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -515,7 +515,8 @@ export default {
             }
 
             let data = [...value];
-
+            
+            const stringCompare = new Intl.Collator(undefined, { numeric: true }).compare;
             data.sort((data1, data2) => {
                 let value1 = ObjectUtils.resolveFieldData(data1, this.d_sortField);
                 let value2 = ObjectUtils.resolveFieldData(data2, this.d_sortField);
@@ -525,7 +526,7 @@ export default {
                 if (value1 == null && value2 != null) result = -1;
                 else if (value1 != null && value2 == null) result = 1;
                 else if (value1 == null && value2 == null) result = 0;
-                else if (typeof value1 === 'string' && typeof value2 === 'string') result = value1.localeCompare(value2, undefined, { numeric: true });
+                else if (typeof value1 === 'string' && typeof value2 === 'string') result = stringCompare(value1, value2);
                 else result = value1 < value2 ? -1 : value1 > value2 ? 1 : 0;
 
                 return this.d_sortOrder * result;


### PR DESCRIPTION
Big performance gain using Int.Collator. It is not recommended to use localeCompare against large arrays.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
#4007 