### PR TITLE
fixed disabled prop on Password component

### DIFF
--- a/components/lib/password/Password.vue
+++ b/components/lib/password/Password.vue
@@ -14,6 +14,7 @@
             :aria-haspopup="true"
             :placeholder="placeholder"
             :required="required"
+            :disabled="disabled"
             @input="onInput"
             @focus="onFocus"
             @blur="onBlur"


### PR DESCRIPTION
Password component would not be completely disabled using disabled prop because disabled wouldn't be passed to primevue/inputtext.
As a result if the field was disabled while it was focused user could type and user can also still navigate with tab and write in the disabled field.
![Screenshot_20230813_005652](https://github.com/primefaces/primevue/assets/18124559/40cee300-8591-4b79-bffb-5849b42ad71e)
![Screenshot_20230813_005911](https://github.com/primefaces/primevue/assets/18124
![Screenshot_20230813_010202](https://github.com/primefaces/primevue/assets/18124559/161f02ae-7da6-4e47-9028-b765187a3297)
559/c76bb7bb-bbcd-4401-be3e-5ca6bb3764e7)

