### PR TITLE
fix: button border right bug on hover

### DIFF
--- a/components/lib/basecomponent/BaseComponent.vue
+++ b/components/lib/basecomponent/BaseComponent.vue
@@ -52,7 +52,7 @@ const buttonStyles = `
     margin: 0;
 }
 
-.p-buttonset .p-button:not(:last-child) {
+.p-buttonset .p-button:not(:last-child), .p-buttonset .p-button:not(:last-child):hover {
     border-right: 0 none;
 }
 


### PR DESCRIPTION
Fix #2238 
-  On hover to outline button groups, button redundant right border removed. Mentioned in https://github.com/primefaces/primevue/issues/2238
