### PR TITLE
Performance update for resolveFieldData

### DIFF
--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -56,6 +56,15 @@ export default {
     },
 
     resolveFieldData(data, field) {
+        try {
+            const value = data[field];
+            if (value)
+                return value;
+        }
+        catch {
+            // do nothing and continue to other methods to resolve field data
+        }
+
         if (data && Object.keys(data).length && field) {
             if (this.isFunction(field)) {
                 return field(data);


### PR DESCRIPTION
Object.keys can get expensive when called a lot of times. Adding a try catch for the quickest and probably highest use case can lead to big performance gains. Related to #4296 but for overall performance

I don't have the time to run through the other scenarios, but I think just doing try catch for each scenario would be faster than the call to Object.keys and isFunction. It would look something like.

```
let value = null;
try {
	value = data[field];
	if (value)
		return value;
}
catch { }

try {
	value = field(data);
	if (value)
		return value;
}
catch { }

try {
	let fields = field.split('.');
	let nestedValue = data;
	for (var i = 0, len = fields.length; i < len; ++i) {
		if (nestedValue == null) {
			return null;
		}
		nestedValue = nestedValue[fields[i]];
	}
	
	return nestedValue;
}
catch { }

return null;
```

A screen showing the difference when using chrome tools performance tab

![image](https://github.com/primefaces/primevue/assets/11836187/092a251f-967e-495d-b0d6-33aa847eec48)

![image](https://github.com/primefaces/primevue/assets/11836187/8030c434-12d0-4ed8-97e8-0e93dad4302c)

I imagine there are other places in the code that could also benefit from this type of improvement.



