### PR TITLE
Fix #4294: bug in prev() function of Galleria controlled docs example

### DIFF
--- a/doc/galleria/ControlledDoc.vue
+++ b/doc/galleria/ControlledDoc.vue
@@ -106,7 +106,7 @@ export default {
             this.activeIndex = this.activeIndex === this.images.length - 1 ? 0 : this.activeIndex + 1;
         },
         prev() {
-            this.activeIndex = this.activeIndex === 0 ? 0 : this.images.length - 1;
+            this.activeIndex = this.activeIndex === 0 ? this.images.length - 1 : this.activeIndex - 1;
         }
     }
 };
@@ -158,7 +158,7 @@ const next = () => {
     activeIndex.value = activeIndex.value === images.value.length - 1 ? 0 : activeIndex.value + 1;
 };
 const prev = () => {
-    activeIndex.value = activeIndex.value === 0 ? 0 : images.value.length - 1;
+    activeIndex.value = activeIndex.value === 0 ? images.value.length - 1 : activeIndex.value - 1;
 };
 <\/script>`,
                 data: `
@@ -182,7 +182,7 @@ const prev = () => {
             this.activeIndex = this.activeIndex === this.images.length - 1 ? 0 : this.activeIndex + 1;
         },
         prev() {
-            this.activeIndex = this.activeIndex === 0 ? 0 : this.images.length - 1;
+            this.activeIndex = this.activeIndex === 0 ? this.images.length - 1 : this.activeIndex - 1;
         }
     }
 };


### PR DESCRIPTION
This commit addresses a bug found in the prev() function within the Galleria Controlled docs example: https://github.com/primefaces/primevue/issues/4294

The issue involved the function returning the same index from the images array consistently, instead of decreasing the currentIndex value. 

The original code for the function:
`const prev = () => { activeIndex.value = activeIndex.value === 0 ? 0 : images.value.length - 1; };`

Steps to reproduce included navigating to the Galleria Controlled Example and clicking on the 'previous' button (minus button).

The expected behavior should follow this code format: 
`const prev = () => { activeIndex.value = activeIndex.value === 0 ? images.value.length - 1 : activeIndex.value - 1; }; `

By implementing this fix, the prev() function should appropriately reduce the currentIndex value as expected.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.