### PR TITLE
#4120 DataTable: Selection and Row/Cell editing : Cannot input space character

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -920,7 +920,7 @@ export default {
             event.preventDefault();
         },
         onSpaceKey(event, rowData, rowIndex, slotProps) {
-            this.onEnterKey(event, rowData, rowIndex);
+            this.onRowClick({ originalEvent: event, data: rowData, index: rowIndex });
 
             if (event.shiftKey && this.selection !== null) {
                 const data = this.dataToRender(slotProps.rows);


### PR DESCRIPTION
Allow input of space character in editor when Datatable has row selection + row edit features enabled

The old code for `onSpaceKey` was calling `onEnterKey` which was cancelling the keyboard event. As the event handlers were attached on the keydown events, the subsequent keypress events were not raised for standard HTML form controls living in the datatable cells.
The modification for `onSpaceKey` just executes the same code as in `onEnterKey` without the `event.preventDefault();` thus living room for keypress events to be raised.