### PR TITLE
fix: delete check for headeraction in the initDrag method

### DIFF
--- a/components/lib/dialog/Dialog.vue
+++ b/components/lib/dialog/Dialog.vue
@@ -283,10 +283,7 @@ export default {
                 this.styleElement = null;
             }
         },
-        initDrag(event) {
-            if (DomHandler.findSingle(event.target, '[data-pc-section="headeraction"]') || DomHandler.findSingle(event.target.parentElement, '[data-pc-section="headeraction"]')) {
-                return;
-            }
+        initDrag(event) {          
 
             if (this.draggable) {
                 this.dragging = true;

--- a/components/lib/dialog/Dialog.vue
+++ b/components/lib/dialog/Dialog.vue
@@ -283,8 +283,7 @@ export default {
                 this.styleElement = null;
             }
         },
-        initDrag(event) {          
-
+        initDrag(event) {
             if (this.draggable) {
                 this.dragging = true;
                 this.lastPageX = event.pageX;


### PR DESCRIPTION
Fix #4330

Hi, guys! We have a problem with dragging the Dialog when we have TabView component within it. But in this case we can can drag the dialog only by clicking on the title text or close button.
[Implementation with header title](https://stackblitz.com/edit/3hxjac?file=src%2FApp.vue)
But it doesn't solve the problem.

I've figured out the reason for the bug. Inside the `Dialog` component, we have an `initDrag` method. Inside this method, we have the condition for checking if the element or its parent has `'data-pc-section' `attribute with` "headeraction" `value. If the element meets this condition` initDrag `stops working and Dialog doesn't drag. 
```
  if (DomHandler.findSingle(event.target, '[data-pc-section="headeraction"]') || DomHandler.findSingle(event.target.parentElement, '[data-pc-section="headeraction"]')) {
                return;
            }
```
We can solve this problem by deleting this condition from the` initDrag `method. But it could cause unexpected behavior in the `Dialog`.

@bahadirsofuoglu could you please check this solution cause you added this condition in [commit](https://github.com/primefaces/primevue/commit/ac65dd284041bb2b2f607b319f893d9a7e2a52f1). Won't it cause the unexpected behavior of the Dialog component?
