### PR TITLE
Fixed #4120 - DataTable: Selection and Row/Cell editing : Cannot input space character

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -386,9 +386,12 @@ export default {
                 this.updateExpandedRowKeys(newValue);
             }
         },
-        editingRows(newValue) {
-            if (this.dataKey) {
-                this.updateEditingRowKeys(newValue);
+        editingRows: {
+            deep: true,
+            handler(newValue) {
+                if (this.dataKey) {
+                    this.updateEditingRowKeys(newValue);
+                }
             }
         },
         filters: {

--- a/components/lib/datatable/TableBody.vue
+++ b/components/lib/datatable/TableBody.vue
@@ -35,7 +35,7 @@
                     @dblclick="onRowDblClick($event, rowData, getRowIndex(index))"
                     @contextmenu="onRowRightClick($event, rowData, getRowIndex(index))"
                     @touchend="onRowTouchEnd($event)"
-                    @keydown="onRowKeyDown($event, rowData, getRowIndex(index))"
+                    @keydown.self="onRowKeyDown($event, rowData, getRowIndex(index))"
                     @mousedown="onRowMouseDown($event)"
                     @dragstart="onRowDragStart($event, getRowIndex(index))"
                     @dragover="onRowDragOver($event, getRowIndex(index))"


### PR DESCRIPTION
Fixes #4120

Uses the self modifier on keydown event to catch events emitted on the <tr> tag only. This allows keydown events to be handled lower in the DOM tree and still allows row selection with keyboard.

Note that input by inputing a space or enter character in an Input field, it does not select the row where the Input belongs to.