### PR TITLE
Fix #2589 vue.js warning for DataTable with dataKey as a function

### DIFF
--- a/components/lib/datatable/TableBody.vue
+++ b/components/lib/datatable/TableBody.vue
@@ -190,7 +190,7 @@ export default {
             default: 0
         },
         dataKey: {
-            type: String,
+            type: [String, Function],
             default: null
         },
         expandedRowIcon: {


### PR DESCRIPTION
Complete initiated work on https://github.com/primefaces/primevue/pull/2595 and #2589 
