### PR TITLE
ConfirmPopup: acceptClass and rejectClass is not working on unstyled …

### DIFF
--- a/components/lib/confirmpopup/BaseConfirmPopup.vue
+++ b/components/lib/confirmpopup/BaseConfirmPopup.vue
@@ -86,8 +86,8 @@ const classes = {
     icon: ({ instance }) => ['p-confirm-popup-icon', instance.confirmation ? instance.confirmation.icon : null],
     message: 'p-confirm-popup-message',
     footer: 'p-confirm-popup-footer',
-    rejectButton: ({ instance }) => ['p-confirm-dialog-reject', instance.confirmation ? instance.confirmation.rejectClass || 'p-button-text' : null],
-    acceptButton: ({ instance }) => ['p-confirm-dialog-accept', instance.confirmation ? instance.confirmation.acceptClass : null]
+    rejectButton: ({ instance }) => ['p-confirm-dialog-reject', instance.confirmation && !instance.confirmation.rejectClass ? 'p-button-text' : null],
+    acceptButton: 'p-confirm-dialog-accept'
 };
 
 const { load: loadStyle } = useStyle(styles, { name: 'confirmpopup', manual: true });

--- a/components/lib/confirmpopup/ConfirmPopup.vue
+++ b/components/lib/confirmpopup/ConfirmPopup.vue
@@ -13,14 +13,14 @@
                 </template>
                 <component v-else :is="$slots.message" :message="confirmation"></component>
                 <div :class="cx('footer')" v-bind="ptm('footer')">
-                    <CPButton :label="rejectLabel" @click="reject()" @keydown="onRejectKeydown" :autofocus="autoFocusReject" :class="cx('rejectButton')" :unstyled="unstyled" :pt="ptm('rejectButton')" data-pc-name="rejectbutton">
+                    <CPButton :label="rejectLabel" @click="reject()" @keydown="onRejectKeydown" :autofocus="autoFocusReject" :class="[cx('rejectButton'), confirmation.rejectClass]" :unstyled="unstyled" :pt="ptm('rejectButton')" data-pc-name="rejectbutton">
                         <template v-if="rejectIcon || $slots.rejecticon" #icon="iconProps">
                             <slot name="rejecticon">
                                 <span :class="[rejectIcon, iconProps.class]" v-bind="ptm('rejectButton')['icon']" data-pc-name="rejectbuttonicon" />
                             </slot>
                         </template>
                     </CPButton>
-                    <CPButton :label="acceptLabel" @click="accept()" @keydown="onAcceptKeydown" :autofocus="autoFocusAccept" :class="cx('acceptButton')" :unstyled="unstyled" :pt="ptm('acceptButton')" data-pc-name="acceptbutton">
+                    <CPButton :label="acceptLabel" @click="accept()" @keydown="onAcceptKeydown" :autofocus="autoFocusAccept" :class="[cx('acceptButton'), confirmation.acceptClass]" :unstyled="unstyled" :pt="ptm('acceptButton')" data-pc-name="acceptbutton">
                         <template v-if="acceptIcon || $slots.accepticon" #icon="iconProps">
                             <slot name="accepticon">
                                 <span :class="[acceptIcon, iconProps.class]" v-bind="ptm('acceptButton')['icon']" data-pc-name="acceptbuttonicon" />


### PR DESCRIPTION
…mode

###Defect Fixes
Same as https://github.com/primefaces/primevue/issues/4412  but for ConfirmPopup
(Fix using the same solution as ConfirmDialog https://github.com/primefaces/primevue/commit/26c9df3424fd19404f449ca703ff7c695801624b)