### PR TITLE
Add `modules` property to Editor

### DIFF
--- a/api-generator/components/editor.js
+++ b/api-generator/components/editor.js
@@ -28,6 +28,12 @@ const EditorProps = [
         type: "any",
         default: "null",
         description: "Inline style of the container."
+    },
+    {
+        name: "modules",
+        type: "object",
+        default: "null",
+        description: "Modules configuration, see <a href=\"https://quilljs.com/docs/modules/\">here</a> for available options."
     }
 ];
 

--- a/src/components/editor/Editor.d.ts
+++ b/src/components/editor/Editor.d.ts
@@ -6,6 +6,7 @@ declare class Editor extends Vue {
     readonly?: boolean;
     formats?: any[];
     editorStyle?: string;
+    modules?: any;
     $emit(eventName: 'input', event: string): this;
     $emit(eventName: 'text-change', e: { htmlValue: string, textValue: any, delta: any, source: string}): this;
     $slot: {

--- a/src/components/editor/Editor.vue
+++ b/src/components/editor/Editor.vue
@@ -56,7 +56,8 @@ export default {
         placeholder: String,
         readonly: Boolean,
         formats: Array,
-        editorStyle: null
+        editorStyle: null,
+        modules: null
     },
     quill: null,
     watch: {
@@ -69,7 +70,8 @@ export default {
     mounted() {
         this.quill = new Quill(this.$refs.editorElement, {
             modules: {
-                toolbar: this.$refs.toolbarElement
+                toolbar: this.$refs.toolbarElement,
+                ...this.modules
             },
             readOnly: this.readonly,
             theme: 'snow',


### PR DESCRIPTION
Implements the feature requested in #4450, thus bringing Editor in primevue v2 on par with v3.