### PR TITLE
fix: tree toggler leaf class

### DIFF
--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -2724,7 +2724,7 @@ export default {
                     'text-blue-600 hover:bg-white/30': context.selected
                 },
                 {
-                    hidden: context.leaf
+                    invisible: context.leaf
                 }
             ]
         }),


### PR DESCRIPTION
Tree leaf toggler must have "visibility: hidden" instead of "display: none"