### PR TITLE
Fix: stopPropagation on SplitButton click event

### DIFF
--- a/components/lib/splitbutton/SplitButton.vue
+++ b/components/lib/splitbutton/SplitButton.vue
@@ -81,6 +81,7 @@ export default {
     methods: {
         onDropdownButtonClick(event) {
             event.preventDefault();
+            event.stopPropagation();
             this.$refs.menu.toggle({ currentTarget: this.$el, relatedTarget: this.$refs.button.$el });
             this.isExpanded = this.$refs.menu.visible;
         },


### PR DESCRIPTION
The SplitButton component of PrimeVue was missing a `stopPropagation()` call when clicking on the button that opens the dropdown menu. This caused unexpected behavior when interacting with the dropdown menu. The issue has been resolved by adding the preventDefault() on the click event, ensuring smooth and expected functionality.

Fixes https://github.com/primefaces/primevue/issues/4223"

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.