### PR TITLE
Fix TailwindCSS theme for splitter component

### DIFF
--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -369,11 +369,6 @@ export default {
                 }
             ]
         }),
-        splitterpanel: {
-            root: {
-                class: 'flex grow'
-            }
-        },
         gutter: ({ props }) => ({
             class: [
                 'flex items-center justify-center shrink-0',
@@ -393,6 +388,11 @@ export default {
                 }
             ]
         })
+    },
+    splitterpanel: {
+        root: {
+            class: 'flex grow'
+        }
     },
     dialog: {
         root: ({ state }) => ({


### PR DESCRIPTION
The style of the splitter-panel component is written in the wrong place.