### PR TITLE
Fixes InputText component "float" label styles for webkit based auto-fill

### DIFF
--- a/components/lib/basecomponent/style/BaseComponentStyle.js
+++ b/components/lib/basecomponent/style/BaseComponentStyle.js
@@ -145,6 +145,7 @@ const inputTextCSS = `
 
 .p-float-label input:focus ~ label,
 .p-float-label input.p-filled ~ label,
+.p-float-label input:-webkit-autofill ~ label,
 .p-float-label textarea:focus ~ label,
 .p-float-label textarea.p-filled ~ label,
 .p-float-label .p-inputwrapper-focus ~ label,
@@ -153,10 +154,6 @@ const inputTextCSS = `
     font-size: 12px;
 }
 
-.p-float-label .input:-webkit-autofill ~ label {
-    top: -20px;
-    font-size: 12px;
-}
 
 .p-float-label .p-placeholder,
 .p-float-label input::placeholder,


### PR DESCRIPTION
Applies same fix for the same issue implemented to "primeng" in 2018: https://github.com/primefaces/primeng/pull/5473/commits/d2abf21fb9c63862f28b67ce581274464c01986d

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
Issue: https://github.com/primefaces/primevue/issues/4533

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.