### PR TITLE
Fix #4568: Add missing message property on ToastProps type

### DIFF
--- a/components/lib/toast/Toast.d.ts
+++ b/components/lib/toast/Toast.d.ts
@@ -239,6 +239,11 @@ export interface ToastProps {
      */
     closeButtonProps?: ButtonHTMLAttributes | undefined;
     /**
+     * Used to access message options.
+     * @type {ToastMessageOptions}
+     */
+    message?: ToastMessageOptions;
+    /**
      * Used to pass attributes to DOM elements inside the component.
      * @type {ToastPassThroughOptions}
      */


### PR DESCRIPTION
Fix #4568: Adds type support to allow access to message props in Toasts by adding the message property to the ToastProps type.