### PR TITLE
Fix #4586 Crashes when Tab pressed and calendar overlay is not showing

### DIFF
--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -2245,7 +2245,9 @@ export default {
                         }
                     }
                     else if (event.keyCode === 9) {
-                        DomHandler.getFocusableElements($vm.$refs.overlay).forEach(el => el.tabIndex = '-1');
+                        if($vm.showOnFocus){
+                            DomHandler.getFocusableElements($vm.$refs.overlay).forEach(el => el.tabIndex = '-1');
+                        }
                         if ($vm.overlayVisible) {
                             $vm.overlayVisible = false;
                         }


### PR DESCRIPTION
Fix #4586 - primevue2