### PR TITLE
Fixed kebab typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1334,7 +1334,7 @@
 
 **Implemented New Features and Enhancements:**
 
--   Kebap-case is not supported in some components like DataTable [\#1263](https://github.com/primefaces/primevue/issues/1263)
+-   Kebab-case is not supported in some components like DataTable [\#1263](https://github.com/primefaces/primevue/issues/1263)
 -   Improve sorting performance on DataTable [\#1633](https://github.com/primefaces/primevue/issues/1633)
 -   Improve accessibility on Editable DataTable [\#1632](https://github.com/primefaces/primevue/issues/1632)
 -   Add type definition for Utils modules [\#1622](https://github.com/primefaces/primevue/issues/1622)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ app.component('Button', Button);
 
 ## Prop Cases
 
-Component prop names are described as camel case throughout the documentation however kebap-case is also fully supported. Events on the other hand should always be kebap-case.
+Component prop names are described as camel case throughout the documentation however kebab-case is also fully supported. Events on the other hand should always be kebab-case.
 
 ```vue
 <Dialog :showHeader="false"></Dialog>

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -206,8 +206,8 @@ export default {
         let props = vnode.props;
 
         if (props) {
-            let kebapProp = prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-            let propName = Object.prototype.hasOwnProperty.call(props, kebapProp) ? kebapProp : prop;
+            let kebabProp = prop.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+            let propName = Object.prototype.hasOwnProperty.call(props, kebabProp) ? kebabProp : prop;
 
             return vnode.type.extends.props[prop].type === Boolean && props[propName] === '' ? true : props[propName];
         }


### PR DESCRIPTION
`kebap` was used in several places throughout the repo. The correct usage is `kebab` as seen here: https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case

https://github.com/primefaces/primevue/issues/4594