### PR TITLE
fix: navigate to page instead of full page load

### DIFF
--- a/doc/menu/RouterDoc.vue
+++ b/doc/menu/RouterDoc.vue
@@ -9,7 +9,7 @@
         <Menu :model="items">
             <template #item="{ label, item, props }">
                 <router-link v-if="item.route" v-slot="routerProps" :to="item.route" custom>
-                    <a :href="routerProps.href" v-bind="props.action">
+                    <a :href="routerProps.href" v-bind="props.action" @click="routerProps.navigate">
                         <span v-bind="props.icon" />
                         <span v-bind="props.label">{{ label }}</span>
                     </a>


### PR DESCRIPTION
When we use the Vue router as shown in the docs, the page is doing a full reload instead of navigating directly to a given route. This leads to state loss. 