### PR TITLE
fix:4072 - Picklist: Unexpected behavior on double click while holding control

### DIFF
--- a/components/lib/picklist/PickList.spec.js
+++ b/components/lib/picklist/PickList.spec.js
@@ -107,6 +107,7 @@ describe('PickList.vue', () => {
 
         expect(wrapper.emitted()['update:modelValue'][0][0][1]).toEqual([wrapper.vm.modelValue[0][0]]);
         expect(wrapper.emitted()['move-to-target'][0]).toEqual([{ originalEvent: {}, items: [wrapper.vm.modelValue[0][0]] }]);
+        expect(wrapper.emitted()['move-to-source'][0]).toEqual([{ originalEvent: {}, items: [wrapper.vm.modelValue[0][0]] }]);
         expect(wrapper.emitted()['update:selection'][0][0]).toEqual([[], []]);
     });
 

--- a/components/lib/picklist/PickList.vue
+++ b/components/lib/picklist/PickList.vue
@@ -440,7 +440,7 @@ export default {
 
                 this.$emit('move-to-target', {
                     originalEvent: event,
-                    items: selection
+                    items: [...new Set(selection)]
                 });
 
                 this.d_selection[0] = [];
@@ -500,7 +500,7 @@ export default {
 
                 this.$emit('move-to-source', {
                     originalEvent: event,
-                    items: selection
+                    items: [...new Set(selection)]
                 });
 
                 this.d_selection[1] = [];


### PR DESCRIPTION
Fix: #4072 
 - Prevent Double click add item twice, only unique