### PR TITLE
Fix #4605: Use DocSearch in non prod env too

### DIFF
--- a/layouts/AppTopBar.vue
+++ b/layouts/AppTopBar.vue
@@ -186,7 +186,23 @@ export default {
             container: '#docsearch',
             appId: '01CMUF4W4R',
             indexName: 'primevue',
-            apiKey: '9bb5939e36897b26ff7de5b7b64d6c43'
+            apiKey: '9bb5939e36897b26ff7de5b7b64d6c43',
+            transformItems: (items) => {
+                const isLocalhost = process.env.NODE_ENV !== 'production';
+
+                return items.map((item) => {
+                    if (isLocalhost) {
+                        const url = new URL(item.url);
+
+                        url.protocol = window.location.protocol;
+                        url.hostname = window.location.hostname;
+                        url.port = window.location.port;
+                        item.url = url.toString();
+                    }
+
+                    return item;
+                });
+            }
         });
     },
     beforeUnmount() {


### PR DESCRIPTION
Fix #4605: Use DocSearch in non prod env too

Copying the logic from https://github.com/primefaces/primereact/pull/4213 