### PR TITLE
Fix #4623 - DataTable: Wrong alphabetical sorting for Norwegian

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -2669,7 +2669,7 @@ export default {
                 let innerHTML = '';
 
                 if (this.responsiveOptions) {
-                    const comparer = ObjectUtils.localeComparator();
+                    const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
                     let responsiveOptions = [...this.responsiveOptions].filter((o) => !!(o.breakpoint && o.numMonths)).sort((o1, o2) => -1 * comparer(o1.breakpoint, o2.breakpoint));
 
                     for (let i = 0; i < responsiveOptions.length; i++) {

--- a/components/lib/carousel/Carousel.vue
+++ b/components/lib/carousel/Carousel.vue
@@ -548,7 +548,7 @@ export default {
 
             if (this.responsiveOptions && !this.isUnstyled) {
                 let _responsiveOptions = [...this.responsiveOptions];
-                const comparer = ObjectUtils.localeComparator();
+                const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
                 _responsiveOptions.sort((data1, data2) => {
                     const value1 = data1.breakpoint;

--- a/components/lib/config/PrimeVue.d.ts
+++ b/components/lib/config/PrimeVue.d.ts
@@ -100,6 +100,7 @@ import { VirtualScrollerPassThroughOptions } from '../virtualscroller';
 export interface PrimeVueConfiguration {
     ripple?: boolean;
     inputStyle?: string;
+    localeCode?: string;
     locale?: PrimeVueLocaleOptions;
     filterMatchModeOptions?: any;
     zIndex?: PrimeVueZIndexOptions;

--- a/components/lib/config/PrimeVue.js
+++ b/components/lib/config/PrimeVue.js
@@ -4,6 +4,7 @@ import { inject, reactive } from 'vue';
 export const defaultOptions = {
     ripple: false,
     inputStyle: 'outlined',
+    localeCode: 'en',
     locale: {
         startsWith: 'Starts with',
         contains: 'Contains',

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -540,7 +540,7 @@ export default {
                 resolvedFieldData.set(item, ObjectUtils.resolveFieldData(item, this.d_sortField));
             }
 
-            const comparer = ObjectUtils.localeComparator();
+            const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
             data.sort((data1, data2) => {
                 let value1 = resolvedFieldData.get(data1);
@@ -575,7 +575,7 @@ export default {
         multisortField(data1, data2, index) {
             const value1 = ObjectUtils.resolveFieldData(data1, this.d_multiSortMeta[index].field);
             const value2 = ObjectUtils.resolveFieldData(data2, this.d_multiSortMeta[index].field);
-            const comparer = ObjectUtils.localeComparator();
+            const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
             if (value1 === value2) {
                 return this.d_multiSortMeta.length - 1 > index ? this.multisortField(data1, data2, index + 1) : 0;

--- a/components/lib/dataview/DataView.vue
+++ b/components/lib/dataview/DataView.vue
@@ -110,7 +110,7 @@ export default {
         sort() {
             if (this.value) {
                 const value = [...this.value];
-                const comparer = ObjectUtils.localeComparator();
+                const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
                 value.sort((data1, data2) => {
                     let value1 = ObjectUtils.resolveFieldData(data1, this.sortField);

--- a/components/lib/galleria/GalleriaThumbnails.vue
+++ b/components/lib/galleria/GalleriaThumbnails.vue
@@ -438,7 +438,7 @@ export default {
 
             if (this.responsiveOptions && !this.isUnstyled) {
                 this.sortedResponsiveOptions = [...this.responsiveOptions];
-                const comparer = ObjectUtils.localeComparator();
+                const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
                 this.sortedResponsiveOptions.sort((data1, data2) => {
                     const value1 = data1.breakpoint;

--- a/components/lib/treetable/TreeTable.vue
+++ b/components/lib/treetable/TreeTable.vue
@@ -429,7 +429,7 @@ export default {
         },
         sortNodesSingle(nodes) {
             let _nodes = [...nodes];
-            const comparer = ObjectUtils.localeComparator();
+            const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
             _nodes.sort((node1, node2) => {
                 const value1 = ObjectUtils.resolveFieldData(node1.data, this.d_sortField);
@@ -455,7 +455,7 @@ export default {
         multisortField(node1, node2, index) {
             const value1 = ObjectUtils.resolveFieldData(node1.data, this.d_multiSortMeta[index].field);
             const value2 = ObjectUtils.resolveFieldData(node2.data, this.d_multiSortMeta[index].field);
-            const comparer = ObjectUtils.localeComparator();
+            const comparer = ObjectUtils.localeComparator(this.$primevue.config.localeCode);
 
             if (value1 === value2) {
                 return this.d_multiSortMeta.length - 1 > index ? this.multisortField(node1, node2, index + 1) : 0;

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -328,9 +328,9 @@ export default {
         return result;
     },
 
-    localeComparator() {
+    localeComparator(localeCode) {
         //performance gain using Int.Collator. It is not recommended to use localeCompare against large arrays.
-        return new Intl.Collator(undefined, { numeric: true }).compare;
+        return new Intl.Collator(localeCode, { numeric: true }).compare;
     },
 
     nestedKeys(obj = {}, parentKey = '') {

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -14006,6 +14006,13 @@
                             "default": ""
                         },
                         {
+                            "name": "localeCode",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "string",
+                            "default": ""
+                        },
+                        {
                             "name": "locale",
                             "optional": true,
                             "readonly": false,

--- a/doc/configuration/locale/SetLocaleDoc.vue
+++ b/doc/configuration/locale/SetLocaleDoc.vue
@@ -17,6 +17,7 @@ export default {
             code1: {
                 basic: `
 app.use(PrimeVue, {
+    localeCode: 'es',
     locale: {
         accept: 'Aceptar',
         reject: 'Rechazar',
@@ -34,6 +35,7 @@ export default defineComponent({
     setup() {
         const changeToSpanish = () => {
             const primevue = usePrimeVue();
+            primevue.config.localeCode = "es";
             primevue.config.locale.accept = "Aceptar";
             primevue.config.locale.reject = "Rechazar";
         }


### PR DESCRIPTION
Fix #4623 - DataTable: Wrong alphabetical sorting for Norwegian

@mertsincan @melloware The actual locale code used in sorting was not stored anywhere in PrimeVue, just the locale options. This is the easy fix, so submitting as a draft. The more complex fix would be to reimplement the Locale API in PrimeVue to match closer to what PrimeReact does with Locale.js.

cc @rubjo 