### PR TITLE
Fix #4650 -  Adding the "z-10" Tailwind class to the toolbar class

### DIFF
--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -2497,7 +2497,7 @@ export default {
             class: ['fixed top-0 left-0 w-full h-full', 'flex items-center justify-center', 'bg-black bg-opacity-90']
         },
         toolbar: {
-            class: ['absolute top-0 right-0 flex', 'p-4']
+            class: ['absolute top-0 right-0 z-10 flex', 'p-4']
         },
         rotaterightbutton: {
             class: [


### PR DESCRIPTION
The issue has been addressed by adding the "z-10" Tailwind class to the toolbar class in order to position it over the image.

###Defect Fixes
Issue : [#4650](https://github.com/primefaces/primevue/issues/4650)
