### PR TITLE
Snap slider to min max step on click

### DIFF
--- a/components/lib/slider/Slider.vue
+++ b/components/lib/slider/Slider.vue
@@ -101,8 +101,9 @@ export default {
             if (this.step) {
                 const oldValue = this.range ? this.modelValue[this.handleIndex] : this.modelValue;
                 const diff = newValue - oldValue;
-
-                if (diff < 0) newValue = oldValue + Math.ceil(newValue / this.step - oldValue / this.step) * this.step;
+                if ((newValue - (this.step / 2)) < this.min) newValue = this.min;
+                else if ((newValue + (this.step / 2)) > this.max) newValue = this.max;
+                else if (diff < 0) newValue = oldValue + Math.ceil(newValue / this.step - oldValue / this.step) * this.step;
                 else if (diff > 0) newValue = oldValue + Math.floor(newValue / this.step - oldValue / this.step) * this.step;
             } else {
                 newValue = Math.floor(newValue);


### PR DESCRIPTION
This is for https://github.com/primefaces/primevue/issues/4577 which was solved but led to jerky slide movements, which was then reverted in https://github.com/primefaces/primevue/issues/4625

This is tested with a few cases locally. It does snap to min and max while dragging, which may or may not be desirable. At least it solves the issue of not being able to select min and max values by clicking.