### PR TITLE
Fix #4671 - PanelMenu: Error when using #item slot

### DIFF
--- a/components/lib/panelmenu/PanelMenu.vue
+++ b/components/lib/panelmenu/PanelMenu.vue
@@ -263,7 +263,7 @@ export default {
                     {
                         class: this.cx('headerLabel')
                     },
-                    this.getPTOptions('headerLabel', processedItem, index)
+                    this.getPTOptions('headerLabel', item, index)
                 )
             };
         }


### PR DESCRIPTION
Fix #4671 - PanelMenu: Error when using #item slot