### PR TITLE
fix(carousel): page attribute not updating shown items

### DIFF
--- a/components/lib/carousel/Carousel.vue
+++ b/components/lib/carousel/Carousel.vue
@@ -126,6 +126,12 @@ export default {
     },
     watch: {
         page(newValue) {
+            if (newValue > this.d_page) {
+                this.navForward({}, newValue);
+            } else if (newValue < this.d_page) {
+                this.navBackward({}, newValue);
+            }
+
             this.d_page = newValue;
         },
         circular(newValue) {


### PR DESCRIPTION
###Defect Fixes

Fixes an issue where updating the `page` attribute from outside the `Carousel` component wasn't updating the items visible.

Closes #4684 