### PR TITLE
OrderList: keep correct order when moving multiple to top or bottom

### DIFF
--- a/src/components/orderlist/OrderList.vue
+++ b/src/components/orderlist/OrderList.vue
@@ -110,7 +110,7 @@ export default {
             if(this.d_selection) {
                 let value = [...this.value];
 
-                for (let i = 0; i < this.d_selection.length; i++) {
+                for (let i = this.d_selection.length - 1; i >= 0; i--) {
                     let selectedItem = this.d_selection[i];
                     let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, value);
 
@@ -164,7 +164,7 @@ export default {
             if (this.d_selection) {
                 let value = [...this.value];
 
-                for (let i = this.d_selection.length - 1; i >= 0; i--) {
+                for (let i = 0; i < this.d_selection.length; i++) {
                     let selectedItem = this.d_selection[i];
                     let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, value);
 


### PR DESCRIPTION
This PR fixes a bug in the OrderList component when moving multiple items to the top or bottom.

Fixes #4700

When multiple items are selected and moved to the top or bottom of an OrderList at the same time, they are moved one by one in a loop until the entire selection has been moved.

To make sure that the item at the top of the selection (the selected item that is highest up in the current order) will still be at the top after the selection, we should move items in the right order: move the top item last when inserting at the top, and first when inserting at the bottom. Currently, this order is exactly reversed, meaning the selected items are reversed in those cases. 

This commit reverses both loop orders to fix this problem
