### PR TITLE
fix: typo in playground

### DIFF
--- a/pages/playground/index.vue
+++ b/pages/playground/index.vue
@@ -9,7 +9,7 @@
             <div class="doc-main">
                 <div class="doc-intro">
                     <h1>Playground</h1>
-                    <p>Experience PrimeVue right now with the interative environment.</p>
+                    <p>Experience PrimeVue right now with the interactive environment.</p>
                 </div>
                 <section class="py-4">
                     <iframe class="w-full h-full" style="border: 1px solid rgba(0, 0, 0, 0.1); border-radius: 2px; min-height: 800px" allowfullscreen src="https://stackblitz.com/edit/vitejs-vite-bpqpcf?file=src%2FApp.vue&embed=1"></iframe>


### PR DESCRIPTION
This PR just fixes a typo in the playground page, from 'interative' to 'interactive'