### PR TITLE
Fix #4712 Overlaypanel: Overlaypanel closes when any key is pressed

### DIFF
--- a/components/lib/overlaypanel/OverlayPanel.vue
+++ b/components/lib/overlaypanel/OverlayPanel.vue
@@ -168,7 +168,7 @@ export default {
             }
         },
         onContentKeydown(event) {
-            if (event.code === 'Escape') {
+            if (event.code === 'Escape' && this.closeOnEscape) {
                 this.hide();
                 DomHandler.focus(this.target);
             }

--- a/components/lib/overlaypanel/OverlayPanel.vue
+++ b/components/lib/overlaypanel/OverlayPanel.vue
@@ -139,6 +139,7 @@ export default {
             this.unbindOutsideClickListener();
             this.unbindScrollListener();
             this.unbindResizeListener();
+            this.unbindDocumentKeyDownListener();
             OverlayEventBus.off('overlay-click', this.overlayEventListener);
             this.overlayEventListener = null;
             this.$emit('hide');
@@ -192,7 +193,7 @@ export default {
             }
         },
         onKeyDown(event) {
-            if (event.code === 'Escape' || this.closeOnEscape) {
+            if (event.code === 'Escape' && this.closeOnEscape) {
                 this.visible = false;
             }
         },


### PR DESCRIPTION
###Defect Fixes
Fix [#4712 ](https://github.com/primefaces/primevue/issues/4712) Overlaypanel: Overlaypanel closes when any key is pressed. It should be closed when the "Escape" key is pressed.