### PR TITLE
Fix #4732 - Calendar: Console.Error/Crash when pressing Escape key using Inline Calendar

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -2646,8 +2646,11 @@ export default {
         onOverlayKeyDown(event) {
             switch (event.code) {
                 case 'Escape':
-                    this.input.focus();
-                    this.overlayVisible = false;
+                    if (!this.inline) {
+                        this.input.focus();
+                        this.overlayVisible = false;
+                    }
+
                     break;
 
                 default:


### PR DESCRIPTION
Fix #4732 - Calendar: Console.Error/Crash when pressing Escape key using Inline Calendar