### PR TITLE
feat(data-table): Render with wrapped columns

### DIFF
--- a/components/lib/column/Column.vue
+++ b/components/lib/column/Column.vue
@@ -4,6 +4,18 @@ import BaseColumn from './BaseColumn.vue';
 export default {
     name: 'Column',
     extends: BaseColumn,
+    inject: ['registerColumn', 'unregisterColumn'],
+    mounted() {
+        if (this.registerColumn) {
+            this.$.children = new Proxy(this.$.slots, {});
+            this.registerColumn(this.$);
+        }
+    },
+    unmounted() {
+        if (this.unregisterColumn) {
+            this.unregisterColumn(this.$);
+        }
+    },
     render() {
         return null;
     }

--- a/components/lib/datatable/BaseDataTable.vue
+++ b/components/lib/datatable/BaseDataTable.vue
@@ -269,6 +269,10 @@ export default {
         filterInputProps: {
             type: null,
             default: null
+        },
+        registerColumns: {
+            type: Boolean,
+            default: false
         }
     },
     style: DataTableStyle,

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -349,7 +349,8 @@ export default {
             d_columnOrder: null,
             d_editingRowKeys: null,
             d_editingMeta: {},
-            d_filters: this.cloneFilters(this.filters)
+            d_filters: this.cloneFilters(this.filters),
+            d_registeredColumns: []
         };
     },
     rowTouched: false,
@@ -1976,17 +1977,30 @@ export default {
         },
         hasSpacerStyle(style) {
             return ObjectUtils.isNotEmpty(style);
+        },
+        registerColumn(column) {
+            if (this.registerColumns && column.type.name === 'Column') {
+                this.d_registeredColumns.push(column);
+            }
+        },
+        unregisterColumn(column) {
+            this.d_registeredColumns = this.d_registeredColumns.filter((c) => c !== column);
         }
     },
     computed: {
         columns() {
             let children = this.getChildren();
 
-            if (!children) {
-                return;
+            const cols = [];
+            if (this.registerColumns) {
+                cols.push(...this.d_registeredColumns);
+            } else if (children) {
+                cols.push(...this.recursiveGetChildren(children, []));
             }
 
-            const cols = this.recursiveGetChildren(children, []);
+            if (!cols.length) {
+                return;
+            }
 
             if (this.reorderableColumns && this.d_columnOrder) {
                 let orderedColumns = [];
@@ -2102,6 +2116,12 @@ export default {
         ArrowDownIcon: ArrowDownIcon,
         ArrowUpIcon: ArrowUpIcon,
         SpinnerIcon: SpinnerIcon
+    },
+    provide() {
+        return {
+            registerColumn: this.registerColumn,
+            unregisterColumn: this.unregisterColumn
+        };
     }
 };
 </script>

--- a/components/lib/datatable/TableBody.vue
+++ b/components/lib/datatable/TableBody.vue
@@ -597,6 +597,9 @@ export default {
     },
     computed: {
         columnsLength() {
+            if (!this.columns) {
+                return 0;
+            }
             let hiddenColLength = 0;
 
             this.columns.forEach((column) => {


### PR DESCRIPTION
Implements #4646 

This commit allows arbitrarily nested columns to work with DataTable.
The following currently does not work:
```
// ❌️ Currently does not work

// App.vue
...
<DataTable>
  <CustomColumn></CustomColumn>
</DataTable>
...

// CustomColumn.vue
<template>
  <Column field='custom' header='Custom'></Column>
</template>
<script>
export default {
  name: 'CustomColumn'
}
</script>
```

The commit introduces a new property to the DataTable named `registerColumns`, which is false by default and does not change any behavior when false to provide backward compatibility.
When true, it allows Column components, which are registered with the next parent DataTable by using the new `registerColumn` function provided by DataTable, to be discovered in the `columns()` computed property.
The following now works with this commit:

```
// ✅️ Will work with this commit

// App.vue
...
<DataTable registerColumns>
  <CustomColumn></CustomColumn>
</DataTable>
...

// CustomColumn.vue
<template>
  <Column field='custom' header='Custom'></Column>
</template>
<script>
export default {
  name: 'CustomColumn'
}
</script>
```

