### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/modules/nuxt-primevue/runtime/plugin.client.js
+++ b/modules/nuxt-primevue/runtime/plugin.client.js
@@ -1,3 +1,3 @@
-import { defineNuxtPlugin } from 'nuxt/app';
+import { defineNuxtPlugin } from '#imports';
 
 export default defineNuxtPlugin(({ vueApp }) => {});


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.