### PR TITLE
chore(nuxt-primevue): fix unable to start nuxt when including a service component

### DIFF
--- a/modules/nuxt-primevue/register.js
+++ b/modules/nuxt-primevue/register.js
@@ -10,8 +10,8 @@ function registerItems(items = [], options = {}, params) {
 
     return items.filter((item) => {
         const name = item?.name;
-        const matchedIn = included === '*' || included === undefined ? true : Utils.object.isNotEmpty(included) ? included.some((inc) => name?.toLowerCase() === inc.toLowerCase()) : false;
-        const matchedEx = excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc) => name?.toLowerCase() === exc.toLowerCase()) : false;
+        const matchedIn = included === '*' || included === undefined ? true : Utils.object.isNotEmpty(included) ? included.some((inc) => name?.toLowerCase() === Utils.object.isString(inc) ? inc?.toLowerCase() : inc?.name?.toLowerCase()) : false;
+        const matchedEx = excluded === '*' ? true : Utils.object.isNotEmpty(excluded) ? excluded.some((exc) => name?.toLowerCase() === Utils.object.isString(exc) ? exc?.toLowerCase() : exc?.name?.toLowerCase()) : false;
 
         return matchedIn && !matchedEx;
     });


### PR DESCRIPTION
There's a bug that causes nuxt app not to start: Cannot start nuxt:  inc?.toLowerCase is not a function.

Reproduction:
```ts
primevue: {
components: {
include: [{ name: 'Toast', use: { as: 'ToastService' } }]
}
}
```

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.