### PR TITLE
Fix "InputNumber: float label initially broken if allowEmpty = false"

### DIFF
--- a/components/lib/inputnumber/style/InputNumberStyle.js
+++ b/components/lib/inputnumber/style/InputNumberStyle.js
@@ -109,7 +109,7 @@ const classes = {
     root: ({ instance, props }) => [
         'p-inputnumber p-component p-inputwrapper',
         {
-            'p-inputwrapper-filled': instance.filled,
+            'p-inputwrapper-filled': instance.filled || props.allowEmpty === false,
             'p-inputwrapper-focus': instance.focused,
             'p-inputnumber-buttons-stacked': props.showButtons && props.buttonLayout === 'stacked',
             'p-inputnumber-buttons-horizontal': props.showButtons && props.buttonLayout === 'horizontal',


### PR DESCRIPTION
Fixes [#4516 ](https://github.com/primefaces/primevue/issues/4516)