### PR TITLE
fix primevue#4794

### DIFF
--- a/components/lib/splitter/Splitter.vue
+++ b/components/lib/splitter/Splitter.vue
@@ -1,15 +1,21 @@
 <template>
-    <div :class="cx('root')" :style="sx('root')" :data-p-resizing="false" v-bind="ptm('root', getPTOptions())"
-        data-pc-name="splitter">
+    <div :class="cx('root')" :style="sx('root')" :data-p-resizing="false" v-bind="ptm('root', getPTOptions())" data-pc-name="splitter">
         <template v-for="(panel, i) of panels" :key="i">
             <component :is="panel" tabindex="-1"></component>
-            <div v-if="i !== panels.length - 1" ref="gutter" :class="cx('gutter')" role="separator" tabindex="-1"
-                @mousedown="onGutterMouseDown($event, i)" @touchstart="onGutterTouchStart($event, i)"
-                @touchmove="onGutterTouchMove($event, i)" @touchend="onGutterTouchEnd($event, i)"
-                :data-p-gutter-resizing="false" v-bind="ptm('gutter')">
-                <div :class="cx('gutterHandler')" tabindex="0" :style="[gutterStyle]" :aria-orientation="layout"
-                    :aria-valuenow="prevSize" @keyup="onGutterKeyUp" @keydown="onGutterKeyDown($event, i)"
-                    v-bind="ptm('gutterHandler')"></div>
+            <div
+                v-if="i !== panels.length - 1"
+                ref="gutter"
+                :class="cx('gutter')"
+                role="separator"
+                tabindex="-1"
+                @mousedown="onGutterMouseDown($event, i)"
+                @touchstart="onGutterTouchStart($event, i)"
+                @touchmove="onGutterTouchMove($event, i)"
+                @touchend="onGutterTouchEnd($event, i)"
+                :data-p-gutter-resizing="false"
+                v-bind="ptm('gutter')"
+            >
+                <div :class="cx('gutterHandler')" tabindex="0" :style="[gutterStyle]" :aria-orientation="layout" :aria-valuenow="prevSize" @keyup="onGutterKeyUp" @keydown="onGutterKeyDown($event, i)" v-bind="ptm('gutterHandler')"></div>
             </div>
         </template>
     </div>
@@ -373,4 +379,5 @@ export default {
         }
     }
 };
+
 </script>

--- a/components/lib/splitter/Splitter.vue
+++ b/components/lib/splitter/Splitter.vue
@@ -1,21 +1,15 @@
 <template>
-    <div :class="cx('root')" :style="sx('root')" :data-p-resizing="false" v-bind="ptm('root', getPTOptions())" data-pc-name="splitter">
+    <div :class="cx('root')" :style="sx('root')" :data-p-resizing="false" v-bind="ptm('root', getPTOptions())"
+        data-pc-name="splitter">
         <template v-for="(panel, i) of panels" :key="i">
             <component :is="panel" tabindex="-1"></component>
-            <div
-                v-if="i !== panels.length - 1"
-                ref="gutter"
-                :class="cx('gutter')"
-                role="separator"
-                tabindex="-1"
-                @mousedown="onGutterMouseDown($event, i)"
-                @touchstart="onGutterTouchStart($event, i)"
-                @touchmove="onGutterTouchMove($event, i)"
-                @touchend="onGutterTouchEnd($event, i)"
-                :data-p-gutter-resizing="false"
-                v-bind="ptm('gutter')"
-            >
-                <div :class="cx('gutterHandler')" tabindex="0" :style="[gutterStyle]" :aria-orientation="layout" :aria-valuenow="prevSize" @keyup="onGutterKeyUp" @keydown="onGutterKeyDown($event, i)" v-bind="ptm('gutterHandler')"></div>
+            <div v-if="i !== panels.length - 1" ref="gutter" :class="cx('gutter')" role="separator" tabindex="-1"
+                @mousedown="onGutterMouseDown($event, i)" @touchstart="onGutterTouchStart($event, i)"
+                @touchmove="onGutterTouchMove($event, i)" @touchend="onGutterTouchEnd($event, i)"
+                :data-p-gutter-resizing="false" v-bind="ptm('gutter')">
+                <div :class="cx('gutterHandler')" tabindex="0" :style="[gutterStyle]" :aria-orientation="layout"
+                    :aria-valuenow="prevSize" @keyup="onGutterKeyUp" @keydown="onGutterKeyDown($event, i)"
+                    v-bind="ptm('gutterHandler')"></div>
             </div>
         </template>
     </div>
@@ -343,6 +337,7 @@ export default {
 
                 children.forEach((child, i) => {
                     child.style.flexBasis = 'calc(' + this.panelSizes[i] + '% - ' + (this.panels.length - 1) * this.gutterSize + 'px)';
+                    child.style.flexGrow = 1;
                 });
 
                 return true;


### PR DESCRIPTION
@melloware 
###Defect Fixes
fix https://github.com/primefaces/primevue/issues/4794

link https://github.com/primefaces/primevue/pull/4801

###Feature Requests
After careful consideration, I believe that the no-style mode does indeed not support adding styles. However, for components, it should be designed to accommodate as many scenarios as possible. In a fixed panel scenario, for example, (which can have many variations), the remaining panels should automatically fill the remaining space. One simple way to achieve this is by using flex-grow: 1.