### PR TITLE
Fix #4816: Menu items with no sub-items toggling border radius

### DIFF
--- a/components/lib/panelmenu/style/PanelMenuStyle.js
+++ b/components/lib/panelmenu/style/PanelMenuStyle.js
@@ -43,7 +43,7 @@ const classes = {
     header: ({ instance, item }) => [
         'p-panelmenu-header',
         {
-            'p-highlight': instance.isItemActive(item),
+            'p-highlight': instance.isItemActive(item) && !!item.items,
             'p-disabled': instance.isItemDisabled(item)
         }
     ],


### PR DESCRIPTION
Fix #4816: Menu items with no sub-items toggling border radius