### PR TITLE
Fix #4861: Unexpected multiselect menu close when select

### DIFF
--- a/components/lib/multiselect/MultiSelect.vue
+++ b/components/lib/multiselect/MultiSelect.vue
@@ -760,7 +760,7 @@ export default {
             }
         },
         isOutsideClicked(event) {
-            return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)));
+            return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)) || event.target.className.includes("p-multiselect-item"));
         },
         getLabelByValue(value) {
             const options = this.optionGroupLabel ? this.flatOptions(this.options) : this.options || [];


### PR DESCRIPTION
This Pull Request fixed issue #4861: Multiselect - Menu closes on select

Change match rule:
```diff
isOutsideClicked(event) {
-    return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)));
+    return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)) || event.target.className.includes("p-multiselect-item"));
},
```