### PR TITLE
fix #4799 - icon only buttons ignore size

### DIFF
--- a/components/lib/button/style/ButtonStyle.js
+++ b/components/lib/button/style/ButtonStyle.js
@@ -27,7 +27,9 @@ const classes = {
             'p-button-icon-left': props.iconPos === 'left' && props.label,
             'p-button-icon-right': props.iconPos === 'right' && props.label,
             'p-button-icon-top': props.iconPos === 'top' && props.label,
-            'p-button-icon-bottom': props.iconPos === 'bottom' && props.label
+            'p-button-icon-bottom': props.iconPos === 'bottom' && props.label,
+            'p-button-sm': props.size === 'small',
+            'p-button-lg': props.size === 'large'
         }
     ],
     label: 'p-button-label'

--- a/public/themes/arya-blue/theme.css
+++ b/public/themes/arya-blue/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/arya-orange/theme.css
+++ b/public/themes/arya-orange/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/arya-purple/theme.css
+++ b/public/themes/arya-purple/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/bootstrap4-dark-blue/theme.css
+++ b/public/themes/bootstrap4-dark-blue/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;

--- a/public/themes/bootstrap4-dark-purple/theme.css
+++ b/public/themes/bootstrap4-dark-purple/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;

--- a/public/themes/bootstrap4-light-blue/theme.css
+++ b/public/themes/bootstrap4-light-blue/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;

--- a/public/themes/bootstrap4-light-purple/theme.css
+++ b/public/themes/bootstrap4-light-purple/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;

--- a/public/themes/fluent-light/theme.css
+++ b/public/themes/fluent-light/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/lara-dark-amber/theme.css
+++ b/public/themes/lara-dark-amber/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-blue/theme.css
+++ b/public/themes/lara-dark-blue/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-green/theme.css
+++ b/public/themes/lara-dark-green/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-indigo/theme.css
+++ b/public/themes/lara-dark-indigo/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-pink/theme.css
+++ b/public/themes/lara-dark-pink/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-purple/theme.css
+++ b/public/themes/lara-dark-purple/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-dark-teal/theme.css
+++ b/public/themes/lara-dark-teal/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-amber/theme.css
+++ b/public/themes/lara-light-amber/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-blue/theme.css
+++ b/public/themes/lara-light-blue/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-green/theme.css
+++ b/public/themes/lara-light-green/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-indigo/theme.css
+++ b/public/themes/lara-light-indigo/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-pink/theme.css
+++ b/public/themes/lara-light-pink/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-purple/theme.css
+++ b/public/themes/lara-light-purple/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/lara-light-teal/theme.css
+++ b/public/themes/lara-light-teal/theme.css
@@ -1866,6 +1866,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/md-dark-deeppurple/theme.css
+++ b/public/themes/md-dark-deeppurple/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.62475rem 0.875rem;

--- a/public/themes/md-dark-indigo/theme.css
+++ b/public/themes/md-dark-indigo/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.62475rem 0.875rem;

--- a/public/themes/md-light-deeppurple/theme.css
+++ b/public/themes/md-light-deeppurple/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.62475rem 0.875rem;

--- a/public/themes/md-light-indigo/theme.css
+++ b/public/themes/md-light-indigo/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.62475rem 0.875rem;

--- a/public/themes/mdc-dark-deeppurple/theme.css
+++ b/public/themes/mdc-dark-deeppurple/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 2.25rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.499625rem 0.65625rem;

--- a/public/themes/mdc-dark-indigo/theme.css
+++ b/public/themes/mdc-dark-indigo/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 2.25rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.499625rem 0.65625rem;

--- a/public/themes/mdc-light-deeppurple/theme.css
+++ b/public/themes/mdc-light-deeppurple/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 2.25rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.499625rem 0.65625rem;

--- a/public/themes/mdc-light-indigo/theme.css
+++ b/public/themes/mdc-light-indigo/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 2.25rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.499625rem 0.65625rem;

--- a/public/themes/mira/theme.css
+++ b/public/themes/mira/theme.css
@@ -1875,6 +1875,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/nano/theme.css
+++ b/public/themes/nano/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.21875rem 0.4375rem;

--- a/public/themes/nova-accent/theme.css
+++ b/public/themes/nova-accent/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/nova-alt/theme.css
+++ b/public/themes/nova-alt/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/nova-vue/theme.css
+++ b/public/themes/nova-vue/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/nova/theme.css
+++ b/public/themes/nova/theme.css
@@ -1859,6 +1859,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.375375rem 0.875rem;

--- a/public/themes/saga-blue/theme.css
+++ b/public/themes/saga-blue/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/saga-green/theme.css
+++ b/public/themes/saga-green/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/saga-orange/theme.css
+++ b/public/themes/saga-orange/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/saga-purple/theme.css
+++ b/public/themes/saga-purple/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/soho-dark/theme.css
+++ b/public/themes/soho-dark/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/soho-light/theme.css
+++ b/public/themes/soho-light/theme.css
@@ -1871,6 +1871,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 1.09375rem;

--- a/public/themes/tailwind-light/theme.css
+++ b/public/themes/tailwind-light/theme.css
@@ -1882,6 +1882,15 @@
     border-radius: 50%;
     height: 3rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.65625rem 0.875rem;

--- a/public/themes/vela-blue/theme.css
+++ b/public/themes/vela-blue/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/vela-green/theme.css
+++ b/public/themes/vela-green/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/vela-orange/theme.css
+++ b/public/themes/vela-orange/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/vela-purple/theme.css
+++ b/public/themes/vela-purple/theme.css
@@ -1847,6 +1847,15 @@
     border-radius: 50%;
     height: 2.357rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/viva-dark/theme.css
+++ b/public/themes/viva-dark/theme.css
@@ -1879,6 +1879,15 @@
     border-radius: 50%;
     height: 2.857rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;

--- a/public/themes/viva-light/theme.css
+++ b/public/themes/viva-light/theme.css
@@ -1879,6 +1879,15 @@
     border-radius: 50%;
     height: 2.857rem;
   }
+  .p-button.p-button-icon-only.p-button-sm {
+    height: 2rem;
+    width: 2rem;
+    padding: 0;
+  }
+  .p-button.p-button-icon-only.p-button-lg {
+    height: 4rem;
+    width: 4rem;
+  }
   .p-button.p-button-sm {
     font-size: 0.875rem;
     padding: 0.4375rem 0.875rem;


### PR DESCRIPTION
###Defect Fixes
Icon Only buttons did not have a size checker. The size prop was added to the component and the class was added to the themes.