### PR TITLE
#4901 - parse date when in time-only mode

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -1272,14 +1272,10 @@ export default {
             let formattedValue = null;
 
             if (date) {
-                if (this.timeOnly) {
-                    formattedValue = this.formatTime(date);
-                } else {
-                    formattedValue = this.formatDate(date, this.datePattern);
+               formattedValue = this.formatDate(date, this.datePattern);
 
-                    if (this.showTime) {
-                        formattedValue += ' ' + this.formatTime(date);
-                    }
+                if (this.showTime || this.timeOnly) {
+                   formattedValue += ' ' + this.formatTime(date);
                 }
             }
 
@@ -1798,18 +1794,13 @@ export default {
             let date;
             let parts = text.split(' ');
 
-            if (this.timeOnly) {
-                date = new Date();
-                this.populateTime(date, parts[0], parts[1]);
-            } else {
-                const dateFormat = this.datePattern;
+            const dateFormat = this.datePattern;
 
-                if (this.showTime) {
-                    date = this.parseDate(parts[0], dateFormat);
-                    this.populateTime(date, parts[1], parts[2]);
-                } else {
-                    date = this.parseDate(text, dateFormat);
-                }
+            if (this.showTime || this.timeOnly) {
+                date = this.parseDate(parts[0], dateFormat);
+                this.populateTime(date, parts[1], parts[2]);
+            } else {
+                date = this.parseDate(text, dateFormat);
             }
 
             return date;


### PR DESCRIPTION
Potential fix for #4901.

Includes date when formatting and parsing in time-only mode, preventing override of initial date value to `new Date()`.