### PR TITLE
Fix #4923 - Overlapping Clear Icon while disabled

### DIFF
--- a/components/lib/dropdown/style/DropdownStyle.js
+++ b/components/lib/dropdown/style/DropdownStyle.js
@@ -116,7 +116,7 @@ const classes = {
             'p-dropdown-label-empty': !props.editable && !instance.$slots['value'] && (instance.label === 'p-emptylabel' || instance.label.length === 0)
         }
     ],
-    clearIcon: 'p-dropdown-clear-icon',
+    clearIcon: ({ props }) => [{ 'p-dropdown-clear-icon': !props.disabled }],
     trigger: 'p-dropdown-trigger',
     loadingicon: 'p-dropdown-trigger-icon',
     dropdownIcon: 'p-dropdown-trigger-icon',


### PR DESCRIPTION
###Defect Fixes
Fix #4923 - When Dropdown is disabled, clearIcon should not be display.