### PR TITLE
Added v-tooltip support to Dropdown

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -442,7 +442,7 @@ const Tooltip = BaseTooltip.extend('tooltip', {
             return targetLeft + width > viewport.width || targetLeft < 0 || targetTop < 0 || targetTop + height > viewport.height;
         },
         getTarget(el) {
-            return DomHandler.hasClass(el, 'p-inputwrapper') ? DomHandler.findSingle(el, 'input') : el;
+						return ((DomHandler.hasClass(el, 'p-inputwrapper') && !DomHandler.hasClass(el, 'p-dropdown')) ? DomHandler.findSingle(el, 'input') : el);
         },
         getModifiers(options) {
             // modifiers


### PR DESCRIPTION
Fix #2344 - Dropdown doesn't have a input element but has p-inputwrapper class. v-tooltip doesn't work on Dropdown because of this. The same solution was also suggested by @hakiiver2.

I'm sorry if there's something I missed.