### PR TITLE
Add 'NumpadEnter' after each 'Enter' key event value

### DIFF
--- a/components/lib/accordion/Accordion.vue
+++ b/components/lib/accordion/Accordion.vue
@@ -144,6 +144,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onTabEnterKey(event, tab, index);
                     break;

--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -2185,7 +2185,7 @@ export default {
                 }
 
                 case 'Enter':
-
+                case 'NumpadEnter':
                 case 'Space': {
                     this.onDateSelect(event, date);
                     event.preventDefault();
@@ -2361,7 +2361,7 @@ export default {
                 }
 
                 case 'Enter':
-
+                case 'NumpadEnter':
                 case 'Space': {
                     this.onMonthSelect(event, index);
                     event.preventDefault();
@@ -2454,7 +2454,7 @@ export default {
                 }
 
                 case 'Enter':
-
+                case 'NumpadEnter':
                 case 'Space': {
                     this.onYearSelect(event, index);
                     event.preventDefault();

--- a/components/lib/cascadeselect/CascadeSelect.vue
+++ b/components/lib/cascadeselect/CascadeSelect.vue
@@ -243,6 +243,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/chips/Chips.vue
+++ b/components/lib/chips/Chips.vue
@@ -110,6 +110,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     if (inputValue && inputValue.trim().length && !this.maxedOut) {
                         this.addItem(event, inputValue, true);
                     }

--- a/components/lib/contextmenu/ContextMenu.vue
+++ b/components/lib/contextmenu/ContextMenu.vue
@@ -181,6 +181,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/datatable/ColumnFilter.vue
+++ b/components/lib/datatable/ColumnFilter.vue
@@ -402,6 +402,7 @@ export default {
         onToggleButtonKeyDown(event) {
             switch (event.code) {
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.toggleMenu(event);
 

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -840,6 +840,7 @@ export default {
                         break;
 
                     case 'Enter':
+                    case 'NumpadEnter':
                         this.onEnterKey(event, rowData, rowIndex);
                         break;
 

--- a/components/lib/dock/DockSub.vue
+++ b/components/lib/dock/DockSub.vue
@@ -197,7 +197,7 @@ export default {
                 }
 
                 case 'Enter':
-
+                case 'NumpadEnter':
                 case 'Space': {
                     this.onSpaceKey(event);
                     event.preventDefault();

--- a/components/lib/galleria/GalleriaItem.vue
+++ b/components/lib/galleria/GalleriaItem.vue
@@ -149,6 +149,7 @@ export default {
         onIndicatorKeyDown(event, index) {
             switch (event.code) {
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.stopSlideShow();
 

--- a/components/lib/listbox/Listbox.vue
+++ b/components/lib/listbox/Listbox.vue
@@ -266,6 +266,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onSpaceKey(event);
                     break;
@@ -414,6 +415,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/megamenu/MegaMenu.vue
+++ b/components/lib/megamenu/MegaMenu.vue
@@ -223,6 +223,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/menu/Menu.vue
+++ b/components/lib/menu/Menu.vue
@@ -152,6 +152,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/menubar/Menubar.vue
+++ b/components/lib/menubar/Menubar.vue
@@ -211,6 +211,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/multiselect/MultiSelect.vue
+++ b/components/lib/multiselect/MultiSelect.vue
@@ -379,6 +379,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onEnterKey(event);
                     break;
@@ -511,6 +512,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/orderlist/OrderList.vue
+++ b/components/lib/orderlist/OrderList.vue
@@ -176,6 +176,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/panelmenu/PanelMenu.vue
+++ b/components/lib/panelmenu/PanelMenu.vue
@@ -153,6 +153,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onHeaderEnterKey(event, item);
                     break;

--- a/components/lib/panelmenu/PanelMenuList.vue
+++ b/components/lib/panelmenu/PanelMenuList.vue
@@ -126,6 +126,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/picklist/PickList.vue
+++ b/components/lib/picklist/PickList.vue
@@ -642,6 +642,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event, listType);
                     break;
 

--- a/components/lib/speeddial/SpeedDial.vue
+++ b/components/lib/speeddial/SpeedDial.vue
@@ -197,6 +197,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onEnterKey(event);
                     break;

--- a/components/lib/steps/Steps.vue
+++ b/components/lib/steps/Steps.vue
@@ -115,7 +115,7 @@ export default {
                     break;
 
                 case 'Enter':
-
+                case 'NumpadEnter':
                 case 'Space': {
                     this.onItemClick(event, item);
                     event.preventDefault();

--- a/components/lib/tabmenu/TabMenu.vue
+++ b/components/lib/tabmenu/TabMenu.vue
@@ -120,9 +120,9 @@ export default {
                     break;
                 }
 
-                case 'Space':
-
-                case 'Enter': {
+                case 'Enter':
+                case 'NumpadEnter':
+                case 'Space': {
                     this.onItemClick(event, item, index);
                     event.preventDefault();
                     break;

--- a/components/lib/tabview/TabView.vue
+++ b/components/lib/tabview/TabView.vue
@@ -220,6 +220,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onTabEnterKey(event, tab, index);
                     break;

--- a/components/lib/tieredmenu/TieredMenu.vue
+++ b/components/lib/tieredmenu/TieredMenu.vue
@@ -205,6 +205,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/tree/TreeNode.vue
+++ b/components/lib/tree/TreeNode.vue
@@ -185,6 +185,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onEnterKey(event);
 

--- a/components/lib/treeselect/TreeSelect.vue
+++ b/components/lib/treeselect/TreeSelect.vue
@@ -230,6 +230,7 @@ export default {
 
                 case 'Space':
                 case 'Enter':
+                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 

--- a/components/lib/treetable/TreeTableRow.vue
+++ b/components/lib/treetable/TreeTableRow.vue
@@ -177,6 +177,7 @@ export default {
                     break;
 
                 case 'Enter':
+                case 'NumpadEnter':
                 case 'Space':
                     this.onEnterKey(event, item);
                     break;


### PR DESCRIPTION
It's very annoying when you're filling in a Chips and you accidentally press NumpadEnter and it submits the form rather than adding the token.