### PR TITLE
Fixes #3609 - Update Calendar typings to be precise

### DIFF
--- a/components/lib/calendar/Calendar.d.ts
+++ b/components/lib/calendar/Calendar.d.ts
@@ -126,7 +126,7 @@ export interface CalendarBlurEvent {
 
 /**
  * Custom passthrough(pt) options.
- * @see {@link CalendarProps.pt}
+ * @see {@link BaseCalendarProps.pt}
  */
 export interface CalendarPassThroughOptions {
     /**
@@ -494,19 +494,9 @@ export interface CalendarYearOptions {
 }
 
 /**
- * Defines valid properties in Calendar component.
+ * Defines valid base properties in Calendar component.
  */
-export interface CalendarProps {
-    /**
-     * Value of the component.
-     * @defaultValue null
-     */
-    modelValue?: string | Date | string[] | Date[] | undefined | null;
-    /**
-     * Defines the quantity of the selection.
-     * @defaultValue single
-     */
-    selectionMode?: 'single' | 'multiple' | 'range' | undefined;
+interface BaseCalendarProps {
     /**
      * Format of the date. Defaults to PrimeVue Locale configuration.
      */
@@ -786,6 +776,57 @@ export interface CalendarProps {
      */
     unstyled?: boolean;
 }
+
+/**
+ * Defines valid single selection properties in Calendar component.
+ */
+interface CalendarPropsSingle extends BaseCalendarProps {
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    modelValue?: Date | undefined | null;
+    /**
+     * Defines the quantity of the selection.
+     * @defaultValue single
+     */
+    selectionMode?: 'single' | undefined;
+}
+
+/**
+ * Defines valid range selection properties in Calendar component.
+ */
+interface CalendarPropsRange extends BaseCalendarProps {
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    modelValue?: Array<Date | null> | undefined | null;
+    /**
+     * Defines the quantity of the selection.
+     * @defaultValue single
+     */
+    selectionMode?: 'range';
+}
+
+/**
+ * Defines valid multiple selection properties in Calendar component.
+ */
+interface CalendarPropsMultiple extends BaseCalendarProps {
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    modelValue?: Array<Date> | undefined | null;
+    /**
+     * Defines the quantity of the selection.
+     * @defaultValue single
+     */
+    selectionMode?: 'multiple';
+}
+
+export type CalendarProps = CalendarPropsSingle | CalendarPropsRange | CalendarPropsMultiple
+
 /**
  * Defines valid options of the date slot in Calendar component.
  */
@@ -928,9 +969,9 @@ export interface CalendarSlots {
 export interface CalendarEmits {
     /**
      * Emitted when the value changes.
-     * @param {string | Date | string[] | Date[] | undefined} value - New value.
+     * @param {Date | Array<Date | null> | null} value - New value.
      */
-    'update:modelValue'(value: string | Date | string[] | Date[] | undefined): void;
+    'update:modelValue'(value: Date | Array<Date | null> | null): void;
     /**
      * Callback to invoke when input field is being typed.
      * @param {Event} event - Browser event


### PR DESCRIPTION
As the calendar only allows to select two values, which one of them can be null (first range item selected, second not) the types should be precise and declared as tuple, and not allow arrays of unspecified length.

Fixes #3609