### PR TITLE
Fix #4986: Toolbar is hidden when the image is zoomed

### DIFF
--- a/components/lib/image/style/ImageStyle.js
+++ b/components/lib/image/style/ImageStyle.js
@@ -43,6 +43,7 @@ const css = `
         top: 0;
         right: 0;
         display: flex;
+        z-index: 1;
     }
 
     .p-image-action.p-link {


### PR DESCRIPTION
### Defect Fixes
#4986: Image: Toolbar is hidden when the image is zoomed

![image](https://github.com/primefaces/primevue/assets/122610766/19d4dd6a-c7f7-40bc-9d70-bec1f04f73b5)
