### PR TITLE
feat: add column field to header dragstart event's datatransfer

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -1370,7 +1370,7 @@ export default {
 
             this.draggedColumn = column;
             this.draggedColumnElement = this.findParentHeader(event.target);
-            event.dataTransfer.setData('text', 'b'); // Firefox requires this to make dragging possible
+            event.dataTransfer.setData('text', column.field || 'b'); // Firefox requires this to make dragging possible
         },
         onColumnHeaderDragOver(e) {
             const { originalEvent: event, column } = e;


### PR DESCRIPTION
My use case:
I would like to be able to drag column headers to my own drag zone to group by column, however for the moment I have no method of identifying which column was dragged into my drag zone.

Note: I have no idea what the column object looks like in this context, it has type `any` at this location. I don't know if it can be undefined or null, or if it even has the `field` property or what type that is, so that probably needs correction.