### PR TITLE
Fix typo in bulma documentation

### DIFF
--- a/pages/bulma/index.vue
+++ b/pages/bulma/index.vue
@@ -2,14 +2,14 @@
     <div>
         <Head>
             <Title>Bulma - PrimeVue</Title>
-            <Meta name="description" content="Bulma is a free, open source framework that provides ready-to-use frontend copmponents and utilities.." />
+            <Meta name="description" content="Bulma is a free, open source framework that provides ready-to-use frontend components and utilities.." />
         </Head>
 
         <div class="doc">
             <div class="doc-main">
                 <div class="doc-intro">
                     <h1>Bulma</h1>
-                    <p><a href="https://bulma.io/">Bulma</a> is a free, open source framework that provides ready-to-use frontend copmponents and utilities.</p>
+                    <p><a href="https://bulma.io/">Bulma</a> is a free, open source framework that provides ready-to-use frontend components and utilities.</p>
                 </div>
                 <DocSections :docs="docs" />
             </div>


### PR DESCRIPTION
This PR fixes the misspelling of the word "components" in the docs, as can be seen [here](https://primevue.org/bulma/).