### PR TITLE
feat(toast): make on hover sticky until stop hovering

### DIFF
--- a/components/lib/toast/ToastMessage.vue
+++ b/components/lib/toast/ToastMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')" @enter="entered" @leave="onLeave">
+    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')" @enter="onEnter" @leave="onLeave">
         <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick" :closeCallback="onCloseClick" />
         <div v-else :class="[cx('content'), message.contentStyleClass]" v-bind="ptm('content')">
             <template v-if="!templates.message">

--- a/components/lib/toast/ToastMessage.vue
+++ b/components/lib/toast/ToastMessage.vue
@@ -1,13 +1,9 @@
 <template>
-    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true"
-        v-bind="ptm('container')" @enter="entered" @leave="onLeave">
-        <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick"
-            :closeCallback="onCloseClick" />
+    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')" @enter="entered" @leave="onLeave">
+        <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick" :closeCallback="onCloseClick" />
         <div v-else :class="[cx('content'), message.contentStyleClass]" v-bind="ptm('content')">
             <template v-if="!templates.message">
-                <component
-                    :is="templates.icon ? templates.icon : iconComponent && iconComponent.name ? iconComponent : 'span'"
-                    :class="cx('icon')" v-bind="ptm('icon')" />
+                <component :is="templates.icon ? templates.icon : iconComponent && iconComponent.name ? iconComponent : 'span'" :class="cx('icon')" v-bind="ptm('icon')" />
                 <div :class="cx('text')" v-bind="ptm('text')">
                     <span :class="cx('summary')" v-bind="ptm('summary')">{{ message.summary }}</span>
                     <div :class="cx('detail')" v-bind="ptm('detail')">{{ message.detail }}</div>
@@ -15,10 +11,8 @@
             </template>
             <component v-else :is="templates.message" :message="message"></component>
             <div v-if="message.closable !== false" v-bind="ptm('buttonContainer')">
-                <button v-ripple :class="cx('closeButton')" type="button" :aria-label="closeAriaLabel" @click="onCloseClick"
-                    autofocus v-bind="{ ...closeButtonProps, ...ptm('button'), ...ptm('closeButton') }">
-                    <component :is="templates.closeicon || 'TimesIcon'" :class="[cx('closeIcon'), closeIcon]"
-                        v-bind="{ ...ptm('buttonIcon'), ...ptm('closeIcon') }" />
+                <button v-ripple :class="cx('closeButton')" type="button" :aria-label="closeAriaLabel" @click="onCloseClick" autofocus v-bind="{ ...closeButtonProps, ...ptm('button'), ...ptm('closeButton') }">
+                    <component :is="templates.closeicon || 'TimesIcon'" :class="[cx('closeIcon'), closeIcon]" v-bind="{ ...ptm('buttonIcon'), ...ptm('closeIcon') }" />
                 </button>
             </div>
         </div>
@@ -75,7 +69,7 @@ export default {
         }
     },
     mounted() {
-        this.startCloseTimeout()
+        this.startCloseTimeout();
     },
     beforeUnmount() {
         this.clearCloseTimeout();
@@ -89,10 +83,10 @@ export default {
             this.close({ message: this.message, type: 'close' });
         },
         onEnter() {
-            this.clearCloseTimeout()
+            this.clearCloseTimeout();
         },
         onLeave() {
-            this.startCloseTimeout()
+            this.startCloseTimeout();
         },
         clearCloseTimeout() {
             if (this.closeTimeout) {

--- a/components/lib/toast/ToastMessage.vue
+++ b/components/lib/toast/ToastMessage.vue
@@ -1,9 +1,13 @@
 <template>
-    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')">
-        <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick" :closeCallback="onCloseClick" />
+    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true"
+        v-bind="ptm('container')" @enter="entered" @leave="onLeave">
+        <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick"
+            :closeCallback="onCloseClick" />
         <div v-else :class="[cx('content'), message.contentStyleClass]" v-bind="ptm('content')">
             <template v-if="!templates.message">
-                <component :is="templates.icon ? templates.icon : iconComponent && iconComponent.name ? iconComponent : 'span'" :class="cx('icon')" v-bind="ptm('icon')" />
+                <component
+                    :is="templates.icon ? templates.icon : iconComponent && iconComponent.name ? iconComponent : 'span'"
+                    :class="cx('icon')" v-bind="ptm('icon')" />
                 <div :class="cx('text')" v-bind="ptm('text')">
                     <span :class="cx('summary')" v-bind="ptm('summary')">{{ message.summary }}</span>
                     <div :class="cx('detail')" v-bind="ptm('detail')">{{ message.detail }}</div>
@@ -11,8 +15,10 @@
             </template>
             <component v-else :is="templates.message" :message="message"></component>
             <div v-if="message.closable !== false" v-bind="ptm('buttonContainer')">
-                <button v-ripple :class="cx('closeButton')" type="button" :aria-label="closeAriaLabel" @click="onCloseClick" autofocus v-bind="{ ...closeButtonProps, ...ptm('button'), ...ptm('closeButton') }">
-                    <component :is="templates.closeicon || 'TimesIcon'" :class="[cx('closeIcon'), closeIcon]" v-bind="{ ...ptm('buttonIcon'), ...ptm('closeIcon') }" />
+                <button v-ripple :class="cx('closeButton')" type="button" :aria-label="closeAriaLabel" @click="onCloseClick"
+                    autofocus v-bind="{ ...closeButtonProps, ...ptm('button'), ...ptm('closeButton') }">
+                    <component :is="templates.closeicon || 'TimesIcon'" :class="[cx('closeIcon'), closeIcon]"
+                        v-bind="{ ...ptm('buttonIcon'), ...ptm('closeIcon') }" />
                 </button>
             </div>
         </div>
@@ -69,11 +75,7 @@ export default {
         }
     },
     mounted() {
-        if (this.message.life) {
-            this.closeTimeout = setTimeout(() => {
-                this.close({ message: this.message, type: 'life-end' });
-            }, this.message.life);
-        }
+        this.startCloseTimeout()
     },
     beforeUnmount() {
         this.clearCloseTimeout();
@@ -86,10 +88,23 @@ export default {
             this.clearCloseTimeout();
             this.close({ message: this.message, type: 'close' });
         },
+        onEnter() {
+            this.clearCloseTimeout()
+        },
+        onLeave() {
+            this.startCloseTimeout()
+        },
         clearCloseTimeout() {
             if (this.closeTimeout) {
                 clearTimeout(this.closeTimeout);
                 this.closeTimeout = null;
+            }
+        },
+        startCloseTimeout() {
+            if (this.message.life) {
+                this.closeTimeout = setTimeout(() => {
+                    this.close({ message: this.message, type: 'life-end' });
+                }, this.message.life);
             }
         }
     },

--- a/components/lib/toast/ToastMessage.vue
+++ b/components/lib/toast/ToastMessage.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')" @enter="onEnter" @leave="onLeave">
+    <div :class="[cx('container'), message.styleClass]" role="alert" aria-live="assertive" aria-atomic="true" v-bind="ptm('container')" @mouseenter="onEnter" @mouseleave="onLeave">
         <component v-if="templates.container" :is="templates.container" :message="message" :onClose="onCloseClick" :closeCallback="onCloseClick" />
         <div v-else :class="[cx('content'), message.contentStyleClass]" v-bind="ptm('content')">
             <template v-if="!templates.message">


### PR DESCRIPTION
As discussed on Discord, in my experience, Toasts should remain open while hovering on them, even when they have a timeout.
This PR addresses that requirement.