### PR TITLE
Fix #5167 - Dropdown: panel closes while typing Japanese

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -610,6 +610,8 @@ export default {
         },
         onEnterKey(event) {
             if (event.isComposing || event.keyCode === 229) {
+                event.preventDefault();
+
                 return;
             }
 

--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -609,7 +609,7 @@ export default {
             event.preventDefault();
         },
         onEnterKey(event) {
-            if (event.isComposing || event.keyCode === 229) {
+            if (event.isComposing) {
                 event.preventDefault();
 
                 return;

--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -609,6 +609,10 @@ export default {
             event.preventDefault();
         },
         onEnterKey(event) {
+            if (event.isComposing || event.keyCode === 229) {
+                return;
+            }
+
             if (!this.overlayVisible) {
                 this.focusedOptionIndex = -1; // reset
                 this.onArrowDownKey(event);


### PR DESCRIPTION
###Defect Fixes
Fix #5167 - Dropdown: panel closes while typing Japanese

###Feature Requests
Fixed so that the panel does not close even if the Japanese input is confirmed (Enter).