### PR TITLE
Splitter: Fix keyboard repeat behavior

### DIFF
--- a/components/lib/splitter/Splitter.vue
+++ b/components/lib/splitter/Splitter.vue
@@ -158,14 +158,16 @@ export default {
             this.onResize(event, step, true);
         },
         setTimer(event, index, step) {
-            this.clearTimer();
-            this.timer = setTimeout(() => {
-                this.repeat(event, index, step);
-            }, 40);
+            if (!this.timer) {
+                this.timer = setInterval(() => {
+                    this.repeat(event, index, step);
+                }, 40);
+            }
         },
         clearTimer() {
             if (this.timer) {
-                clearTimeout(this.timer);
+                clearInterval(this.timer);
+                this.timer = null;
             }
         },
         onGutterKeyUp() {


### PR DESCRIPTION
Similar to a fix just made in PrimeReact: https://github.com/primefaces/primereact/pull/5884/files

The keyboard was using `setTimeout` instead of `setInterval`