### PR TITLE
Fix PrimeVuePTOptions.global.css (missing parenthesis)

### DIFF
--- a/components/lib/config/PrimeVue.d.ts
+++ b/components/lib/config/PrimeVue.d.ts
@@ -222,7 +222,7 @@ export interface PrimeVuePTOptions {
         animate?: AnimateOnScrollDirectivePassThroughOptions;
     };
     global?: {
-        css?: (options: any) => string | string | undefined;
+        css?: ((options: any) => string | undefined) | string | undefined;
     };
 }
 


### PR DESCRIPTION
### Defect Fixes
Fixes typing on the PrimeVuePTOptions.global.css property. Previously it would not accept just a string (had to be a function).
