### PR TITLE
fix(Calendar): when inline, do not apply fixed width to overlay

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -617,10 +617,6 @@ export default {
             if (!this.disabled) {
                 this.preventFocus = true;
                 this.initFocusableCell();
-
-                if (this.numberOfMonths === 1) {
-                    this.overlay.style.width = DomHandler.getOuterWidth(this.$el) + 'px';
-                }
             }
         } else {
             this.input.value = this.formatValue(this.modelValue);


### PR DESCRIPTION
resolves https://github.com/primefaces/primevue/issues/5294

(I have tested this change with reproduction in the attached issue and can confirm that applying a fixed width is the exact reason why the enter transition is broken.)