### PR TITLE
feat(Dropdown):Added the resetFilterOnAlreadySelectedOption prop

### DIFF
--- a/api-generator/components/dropdown.js
+++ b/api-generator/components/dropdown.js
@@ -204,6 +204,12 @@ const DropdownProps = [
         description: 'Clears the filter value when clicking on the clear icon.'
     },
     {
+        name: 'resetFilterOnAlreadySelectedOption',
+        type: 'boolean',
+        default: 'false',
+        description: 'Clears the filter value when clicking on the already selected option.'
+    },
+    {
         name: 'virtualScrollerOptions',
         type: 'object',
         default: 'null',

--- a/components/lib/dropdown/BaseDropdown.vue
+++ b/components/lib/dropdown/BaseDropdown.vue
@@ -118,6 +118,10 @@ export default {
             type: Boolean,
             default: false
         },
+        resetFilterOnAlreadySelectedOption: {
+            type: Boolean,
+            default: false
+        },
         virtualScrollerOptions: {
             type: Object,
             default: null

--- a/components/lib/dropdown/Dropdown.d.ts
+++ b/components/lib/dropdown/Dropdown.d.ts
@@ -421,6 +421,11 @@ export interface DropdownProps {
      */
     resetFilterOnClear?: boolean;
     /**
+     * Clears the filter value when clicking on the already selected option.
+     * @defaultValue false
+     */
+        resetFilterOnAlreadySelectedOption?: boolean;
+    /**
      * Whether to use the virtualScroller feature. The properties of VirtualScroller component can be used like an object in it.
      */
     virtualScrollerOptions?: VirtualScrollerProps;

--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -455,9 +455,14 @@ export default {
             DomHandler.focus(focusableEl);
         },
         onOptionSelect(event, option, isHide = true) {
-            const value = this.getOptionValue(option);
+            if (this.resetFilterOnAlreadySelectedOption && this.isSelected(option)) {
+                this.onClearClick(event);
+            } else {
+                const value = this.getOptionValue(option);
+    
+                this.updateModel(event, value);
+            }
 
-            this.updateModel(event, value);
             isHide && this.hide(true);
         },
         onOptionMouseMove(event, index) {

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -24616,6 +24616,14 @@
                             "description": "Clears the filter value when clicking on the clear icon."
                         },
                         {
+                            "name": "resetFilterOnAlreadySelectedOption",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "false",
+                            "description": "Clears the filter value when clicking on the already selected option."
+                        },
+                        {
                             "name": "virtualScrollerOptions",
                             "optional": true,
                             "readonly": false,


### PR DESCRIPTION
Added the resetFilterOnAlreadySelectedOption prop to the Dropdown component. By activating it, the currently selected option is deselected, and the modelValue cleaned up (as if clicking in the clearIcon).