### PR TITLE
Implement `cellClass` and `cellStyle` Properties for DataTable

### DIFF
--- a/api-generator/components/datatable.js
+++ b/api-generator/components/datatable.js
@@ -313,6 +313,18 @@ const DataTableProps = [
         description: 'A function that takes the row data as a parameter and returns the inline style for the corresponding row.'
     },
     {
+        name: 'cellClass',
+        type: 'function',
+        default: 'null',
+        description: 'A function that takes the row data and column metadata and returns a string to apply a particular class for the cell.'
+    },
+    {
+        name: 'cellStyle',
+        type: 'object',
+        default: 'null',
+        description: 'A function that takes the row data and column metadata as parameters and returns the inline style for the corresponding cell.'
+    },
+    {
         name: 'scrollable',
         type: 'boolean',
         default: 'false',

--- a/components/lib/datatable/BaseDataTable.vue
+++ b/components/lib/datatable/BaseDataTable.vue
@@ -215,7 +215,7 @@ export default {
             default: null
         },
         rowStyle: {
-            type: Object,
+            type: Function,
             default: null
         },
         scrollable: {

--- a/components/lib/datatable/BaseDataTable.vue
+++ b/components/lib/datatable/BaseDataTable.vue
@@ -211,7 +211,7 @@ export default {
             default: null
         },
         rowClass: {
-            type: [Function],
+            type: Function,
             default: null
         },
         rowStyle: {

--- a/components/lib/datatable/BaseDataTable.vue
+++ b/components/lib/datatable/BaseDataTable.vue
@@ -218,6 +218,14 @@ export default {
             type: Function,
             default: null
         },
+        cellClass: {
+            type: Function,
+            default: null
+        },
+        cellStyle: {
+            type: Function,
+            default: null
+        },
         scrollable: {
             type: Boolean,
             default: false

--- a/components/lib/datatable/BaseDataTable.vue
+++ b/components/lib/datatable/BaseDataTable.vue
@@ -211,7 +211,7 @@ export default {
             default: null
         },
         rowClass: {
-            type: [String, Object],
+            type: [Function],
             default: null
         },
         rowStyle: {

--- a/components/lib/datatable/BodyRow.vue
+++ b/components/lib/datatable/BodyRow.vue
@@ -44,6 +44,8 @@
                     :key="columnProp(col, 'columnKey') || columnProp(col, 'field') || i"
                     :rowData="rowData"
                     :column="col"
+                    :class="cellClasses(col)"
+                    :style="cellStyles(col)"
                     :rowIndex="rowIndex"
                     :index="i"
                     :selected="isSelected"
@@ -501,6 +503,28 @@ export default {
             }
 
             return [this.cx('row', { rowData: this.rowData, index: this.rowIndex, columnSelectionMode }), rowStyleClass];
+        },
+        cellStyles(column) {
+            if (this.cellStyle) {
+                const field = this.columnProp(column, 'field');
+                return this.cellStyle(this.rowData, field);
+            }
+
+            return null;
+        },
+        cellClasses(column) {
+            let cellStyleClass = [];
+
+            if (this.cellClass) {
+                const field = this.columnProp(column, 'field');
+                let cellClassValue = this.cellClass(this.rowData, field);
+
+                if (cellClassValue) {
+                    cellStyleClass.push(cellClassValue);
+                }
+            }
+
+            return [this.cx('cell', { rowData: this.rowData, index: this.rowIndex, columnSelectionMode, column }), cellStyleClass];
         },
         rowTabindex() {
             if (this.selection === null && (this.selectionMode === 'single' || this.selectionMode === 'multiple')) {

--- a/components/lib/datatable/DataTable.d.ts
+++ b/components/lib/datatable/DataTable.d.ts
@@ -251,14 +251,14 @@ export interface DataTableRowClickEvent {
  * @see {@link DataTableEmits['row-dblclick']]}
  * @extends DataTableRowClickEvent
  */
-export interface DataTableRowDoubleClickEvent extends DataTableRowClickEvent {}
+export interface DataTableRowDoubleClickEvent extends DataTableRowClickEvent { }
 
 /**
  * Custom row context menu event.
  * @see {@link DataTableEmits['row-contextmenu']}
  * @extends DataTableRowClickEvent
  */
-export interface DataTableRowContextMenuEvent extends DataTableRowClickEvent {}
+export interface DataTableRowContextMenuEvent extends DataTableRowClickEvent { }
 
 /**
  * Custom row select event.
@@ -288,7 +288,7 @@ export interface DataTableRowSelectEvent {
  * @see {@link DataTableEmits['row-unselect']}
  * @extends DataTableRowSelectEvent
  */
-export interface DataTableRowUnselectEvent extends DataTableRowSelectEvent {}
+export interface DataTableRowUnselectEvent extends DataTableRowSelectEvent { }
 
 /**
  * Custom row select all event.
@@ -408,7 +408,7 @@ export interface DataTableRowExpandEvent {
  * @see {@link DataTableEmits['row-expand']}
  * @extends DataTableRowExpandEvent
  */
-export interface DataTableRowCollapseEvent extends DataTableRowExpandEvent {}
+export interface DataTableRowCollapseEvent extends DataTableRowExpandEvent { }
 
 /**
  * Custom cell edit init event.
@@ -438,7 +438,7 @@ export interface DataTableCellEditInitEvent {
  * @see {@link DataTableEmits['cell-edit-cancel']}
  * @extends DataTableCellEditInitEvent
  */
-export interface DataTableCellEditCancelEvent extends DataTableCellEditInitEvent {}
+export interface DataTableCellEditCancelEvent extends DataTableCellEditInitEvent { }
 
 /**
  * Custom cell edit complete event.
@@ -511,14 +511,14 @@ export interface DataTableRowEditInitEvent {
  * @see {@link DataTableEmits['row-edit-save']}
  * @extends DataTableRowEditInitEvent
  */
-export interface DataTableRowEditSaveEvent extends DataTableRowEditInitEvent {}
+export interface DataTableRowEditSaveEvent extends DataTableRowEditInitEvent { }
 
 /**
  *  Custom row edit cancel event.
  * @see {@link DataTableEmits['row-edit-cancel']}
  * @extends DataTableRowEditCancelEvent
  */
-export interface DataTableRowEditCancelEvent extends DataTableRowEditInitEvent {}
+export interface DataTableRowEditCancelEvent extends DataTableRowEditInitEvent { }
 
 /**
  * Custom state event.
@@ -1072,6 +1072,14 @@ export interface DataTableProps {
      * A function that takes the row data as a parameter and returns the inline style for the corresponding row.
      */
     rowStyle?: (data: any) => object | undefined;
+    /**
+     * A function that takes the row data and column field as parameters and returns a string to apply a particular class for the cell.
+     */
+    cellClass?: (data: any, field: string) => object | string | undefined;
+    /**
+     * A function that takes the row data and column field as parameters and returns the inline style for the corresponding cell.
+     */
+    cellStyle?: (data: any, field: string) => object | undefined;
     /**
      * When specified, enables horizontal and/or vertical scrolling.
      * @defaultValue false

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -20332,6 +20332,20 @@
                             "default": ""
                         },
                         {
+                            "name": "cellClass",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "Function",
+                            "default": ""
+                        },
+                        {
+                            "name": "cellStyle",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "Function",
+                            "default": ""
+                        },
+                        {
                             "name": "scrollable",
                             "optional": true,
                             "readonly": false,


### PR DESCRIPTION
#### Summary
This pull request introduces two new properties, `cellClass` and `cellStyle`, to the `DataTable` component in PrimeVue. These properties are designed to provide dynamic styling capabilities at the cell level within tables, offering developers enhanced control over the appearance and conditional formatting of cells.

#### Implementation Details
- **`cellClass`**: This property accepts a function that returns a class or an array of classes to be applied to a cell, based on the cell's data and field name.
- **`cellStyle`**: Similar to `cellClass`, this property takes a function that returns an inline style object for a cell, allowing for detailed styling based on the cell's content and field name.

The addition of these properties aims to complement the existing row-level styling options (`rowClass` and `rowStyle`), filling in the gap for cell-specific styling needs.

#### Request for Documentation and Example Guidance
While I have successfully implemented the functionality for `cellClass` and `cellStyle`, I have not yet updated the documentation or provided usage examples. I am seeking guidance and assistance from the PrimeVue community and maintainers on how best to document these new properties and illustrate their usage through meaningful examples. Your insights and suggestions will be invaluable in ensuring that these features are accessible and understandable to all users.

### Implementation Notes
The core implementation involves modifications to the `DataTable` component's rendering logic to apply classes and styles returned by `cellClass` and `cellStyle` functions. These functions are invoked with the row data and field name as arguments, enabling context-aware styling decisions.

### Contributions Needed
- **Documentation Updates**: Assistance in describing the new properties within the existing PrimeVue documentation framework, including parameter details and potential return values.
- **Example Scenarios**: Suggestions for common or illustrative use cases that these properties could address, which can be developed into examples for inclusion in the documentation.

### How to Assist
If you're interested in contributing to the documentation and examples for `cellClass` and `cellStyle`, please reach out through this PR or contribute directly by adding to this branch. Your expertise and contributions will help ensure these new features are well understood and utilized to their full potential.