### PR TITLE
fix(types): augment `GlobalComponent` interface in `vue` module

### DIFF
--- a/components/lib/accordion/Accordion.d.ts
+++ b/components/lib/accordion/Accordion.d.ts
@@ -232,8 +232,8 @@ export interface AccordionEmits {
  */
 declare class Accordion extends ClassComponent<AccordionProps, AccordionSlots, AccordionEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Accordion: GlobalComponentConstructor<Accordion>;
     }
 }

--- a/components/lib/accordiontab/AccordionTab.d.ts
+++ b/components/lib/accordiontab/AccordionTab.d.ts
@@ -226,8 +226,8 @@ export interface AccordionTabEmits {}
  */
 declare class AccordionTab extends ClassComponent<AccordionTabProps, AccordionTabSlots, AccordionTabEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AccordionTab: GlobalComponentConstructor<AccordionTab>;
     }
 }

--- a/components/lib/autocomplete/AutoComplete.d.ts
+++ b/components/lib/autocomplete/AutoComplete.d.ts
@@ -769,8 +769,8 @@ export interface AutoCompleteEmits {
  */
 declare class AutoComplete extends ClassComponent<AutoCompleteProps, AutoCompleteSlots, AutoCompleteEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AutoComplete: GlobalComponentConstructor<AutoComplete>;
     }
 }

--- a/components/lib/avatar/Avatar.d.ts
+++ b/components/lib/avatar/Avatar.d.ts
@@ -163,8 +163,8 @@ export interface AvatarEmits {
  */
 declare class Avatar extends ClassComponent<AvatarProps, AvatarSlots, AvatarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Avatar: GlobalComponentConstructor<Avatar>;
     }
 }

--- a/components/lib/avatargroup/AvatarGroup.d.ts
+++ b/components/lib/avatargroup/AvatarGroup.d.ts
@@ -112,8 +112,8 @@ export interface AvatarGroupEmits {}
  */
 declare class AvatarGroup extends ClassComponent<AvatarGroupProps, AvatarGroupSlots, AvatarGroupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AvatarGroup: GlobalComponentConstructor<AvatarGroup>;
     }
 }

--- a/components/lib/badge/Badge.d.ts
+++ b/components/lib/badge/Badge.d.ts
@@ -120,8 +120,8 @@ export interface BadgeEmits {}
  */
 declare class Badge extends ClassComponent<BadgeProps, BadgeSlots, BadgeEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Badge: GlobalComponentConstructor<Badge>;
     }
 }

--- a/components/lib/blockui/BlockUI.d.ts
+++ b/components/lib/blockui/BlockUI.d.ts
@@ -160,8 +160,8 @@ export interface BlockUIEmits {
  */
 declare class BlockUI extends ClassComponent<BlockUIProps, BlockUISlots, BlockUIEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         BlockUI: GlobalComponentConstructor<BlockUI>;
     }
 }

--- a/components/lib/breadcrumb/Breadcrumb.d.ts
+++ b/components/lib/breadcrumb/Breadcrumb.d.ts
@@ -232,8 +232,8 @@ export interface BreadcrumbEmits {}
  */
 declare class Breadcrumb extends ClassComponent<BreadcrumbProps, BreadcrumbSlots, BreadcrumbEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Breadcrumb: GlobalComponentConstructor<Breadcrumb>;
     }
 }

--- a/components/lib/button/Button.d.ts
+++ b/components/lib/button/Button.d.ts
@@ -243,8 +243,8 @@ export interface ButtonEmits {}
  */
 declare class Button extends ClassComponent<ButtonProps, ButtonSlots, ButtonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Button: GlobalComponentConstructor<Button>;
     }
 }

--- a/components/lib/buttongroup/ButtonGroup.d.ts
+++ b/components/lib/buttongroup/ButtonGroup.d.ts
@@ -104,8 +104,8 @@ export interface ButtonGroupEmits {}
  */
 declare class ButtonGroup extends ClassComponent<ButtonGroupProps, ButtonGroupSlots, ButtonGroupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ButtonGroup: GlobalComponentConstructor<ButtonGroup>;
     }
 }

--- a/components/lib/calendar/Calendar.d.ts
+++ b/components/lib/calendar/Calendar.d.ts
@@ -1008,8 +1008,8 @@ export interface CalendarEmits {
  */
 declare class Calendar extends ClassComponent<CalendarProps, CalendarSlots, CalendarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Calendar: GlobalComponentConstructor<Calendar>;
     }
 }

--- a/components/lib/card/Card.d.ts
+++ b/components/lib/card/Card.d.ts
@@ -152,8 +152,8 @@ export interface CardEmits {}
  */
 declare class Card extends ClassComponent<CardProps, CardSlots, CardEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Card: GlobalComponentConstructor<Card>;
     }
 }

--- a/components/lib/carousel/Carousel.d.ts
+++ b/components/lib/carousel/Carousel.d.ts
@@ -373,8 +373,8 @@ export interface CarouselEmits {
  */
 declare class Carousel extends ClassComponent<CarouselProps, CarouselSlots, CarouselEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Carousel: GlobalComponentConstructor<Carousel>;
     }
 }

--- a/components/lib/cascadeselect/CascadeSelect.d.ts
+++ b/components/lib/cascadeselect/CascadeSelect.d.ts
@@ -528,8 +528,8 @@ export interface CascadeSelectEmits {
  */
 declare class CascadeSelect extends ClassComponent<CascadeSelectProps, CascadeSelectSlots, CascadeSelectEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         CascadeSelect: GlobalComponentConstructor<CascadeSelect>;
     }
 }

--- a/components/lib/chart/Chart.d.ts
+++ b/components/lib/chart/Chart.d.ts
@@ -194,8 +194,8 @@ declare class Chart extends ClassComponent<ChartProps, ChartSlots, ChartEmits> {
     getChart(): any;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Chart: GlobalComponentConstructor<Chart>;
     }
 }

--- a/components/lib/checkbox/Checkbox.d.ts
+++ b/components/lib/checkbox/Checkbox.d.ts
@@ -263,8 +263,8 @@ export interface CheckboxEmits {
  */
 declare class Checkbox extends ClassComponent<CheckboxProps, CheckboxSlots, CheckboxEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Checkbox: GlobalComponentConstructor<Checkbox>;
     }
 }

--- a/components/lib/chip/Chip.d.ts
+++ b/components/lib/chip/Chip.d.ts
@@ -204,8 +204,8 @@ export interface ChipEmits {
  */
 declare class Chip extends ClassComponent<ChipProps, ChipSlots, ChipEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Chip: GlobalComponentConstructor<Chip>;
     }
 }

--- a/components/lib/chips/Chips.d.ts
+++ b/components/lib/chips/Chips.d.ts
@@ -302,8 +302,8 @@ export interface ChipsEmits {
  */
 declare class Chips extends ClassComponent<ChipsProps, ChipsSlots, ChipsEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Chips: GlobalComponentConstructor<Chips>;
     }
 }

--- a/components/lib/colorpicker/ColorPicker.d.ts
+++ b/components/lib/colorpicker/ColorPicker.d.ts
@@ -239,8 +239,8 @@ export interface ColorPickerEmits {
  */
 declare class ColorPicker extends ClassComponent<ColorPickerProps, ColorPickerSlots, ColorPickerEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ColorPicker: GlobalComponentConstructor<ColorPicker>;
     }
 }

--- a/components/lib/column/Column.d.ts
+++ b/components/lib/column/Column.d.ts
@@ -983,8 +983,8 @@ declare class Column extends ClassComponent<ColumnProps, ColumnSlots, ColumnEmit
 
 export type ColumnNode = Column & { props: Column['$props'] };
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Column: GlobalComponentConstructor<Column>;
     }
 }

--- a/components/lib/columngroup/ColumnGroup.d.ts
+++ b/components/lib/columngroup/ColumnGroup.d.ts
@@ -127,8 +127,8 @@ export interface ColumnGroupEmits {}
  */
 declare class ColumnGroup extends ClassComponent<ColumnGroupProps, ColumnGroupSlots, ColumnGroupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ColumnGroup: GlobalComponentConstructor<ColumnGroup>;
     }
 }

--- a/components/lib/confirmdialog/ConfirmDialog.d.ts
+++ b/components/lib/confirmdialog/ConfirmDialog.d.ts
@@ -290,8 +290,8 @@ export interface ConfirmDialogEmits {}
  */
 declare class ConfirmDialog extends ClassComponent<ConfirmDialogProps, ConfirmDialogSlots, ConfirmDialogEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ConfirmDialog: GlobalComponentConstructor<ConfirmDialog>;
     }
 }

--- a/components/lib/confirmpopup/ConfirmPopup.d.ts
+++ b/components/lib/confirmpopup/ConfirmPopup.d.ts
@@ -235,8 +235,8 @@ export interface ConfirmPopupEmits {}
  */
 declare class ConfirmPopup extends ClassComponent<ConfirmPopupProps, ConfirmPopupSlots, ConfirmPopupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ConfirmPopup: GlobalComponentConstructor<ConfirmPopup>;
     }
 }

--- a/components/lib/contextmenu/ContextMenu.d.ts
+++ b/components/lib/contextmenu/ContextMenu.d.ts
@@ -402,8 +402,8 @@ declare class ContextMenu extends ClassComponent<ContextMenuProps, ContextMenuSl
     hide(): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ContextMenu: GlobalComponentConstructor<ContextMenu>;
     }
 }

--- a/components/lib/datatable/DataTable.d.ts
+++ b/components/lib/datatable/DataTable.d.ts
@@ -1517,8 +1517,8 @@ declare class DataTable extends ClassComponent<DataTableProps, DataTableSlots, D
     exportCSV(options?: DataTableExportCSVOptions, data?: any[]): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         DataTable: GlobalComponentConstructor<DataTable>;
     }
 }

--- a/components/lib/dataview/DataView.d.ts
+++ b/components/lib/dataview/DataView.d.ts
@@ -341,8 +341,8 @@ export interface DataViewEmits {
  */
 declare class DataView extends ClassComponent<DataViewProps, DataViewSlots, DataViewEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         DataView: GlobalComponentConstructor<DataView>;
     }
 }

--- a/components/lib/dataviewlayoutoptions/DataViewLayoutOptions.d.ts
+++ b/components/lib/dataviewlayoutoptions/DataViewLayoutOptions.d.ts
@@ -168,8 +168,8 @@ export interface DataViewLayoutOptionsEmits {
  */
 declare class DataViewLayoutOptions extends ClassComponent<DataViewLayoutOptionsProps, DataViewLayoutOptionsSlots, DataViewLayoutOptionsEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         DataViewLayoutOptions: GlobalComponentConstructor<DataViewLayoutOptions>;
     }
 }

--- a/components/lib/deferredcontent/DeferredContent.d.ts
+++ b/components/lib/deferredcontent/DeferredContent.d.ts
@@ -132,8 +132,8 @@ export interface DeferredContentEmits {
  */
 declare class DeferredContent extends ClassComponent<DeferredContentProps, DeferredContentSlots, DeferredContentEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         DeferredContent: GlobalComponentConstructor<DeferredContent>;
     }
 }

--- a/components/lib/dialog/Dialog.d.ts
+++ b/components/lib/dialog/Dialog.d.ts
@@ -415,8 +415,8 @@ export interface DialogEmits {
  */
 declare class Dialog extends ClassComponent<DialogProps, DialogSlots, DialogEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Dialog: GlobalComponentConstructor<Dialog>;
     }
 }

--- a/components/lib/divider/Divider.d.ts
+++ b/components/lib/divider/Divider.d.ts
@@ -128,8 +128,8 @@ export interface DividerEmits {}
  */
 declare class Divider extends ClassComponent<DividerProps, DividerSlots, DividerEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Divider: GlobalComponentConstructor<Divider>;
     }
 }

--- a/components/lib/dock/Dock.d.ts
+++ b/components/lib/dock/Dock.d.ts
@@ -311,8 +311,8 @@ export interface DockEmits {
  */
 declare class Dock extends ClassComponent<DockProps, DockSlots, DockEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Dock: GlobalComponentConstructor<Dock>;
     }
 }

--- a/components/lib/dropdown/Dropdown.d.ts
+++ b/components/lib/dropdown/Dropdown.d.ts
@@ -758,8 +758,8 @@ declare class Dropdown extends ClassComponent<DropdownProps, DropdownSlots, Drop
     hide: (isFocus?: boolean) => void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Dropdown: GlobalComponentConstructor<Dropdown>;
     }
 }

--- a/components/lib/dynamicdialog/DynamicDialog.d.ts
+++ b/components/lib/dynamicdialog/DynamicDialog.d.ts
@@ -43,8 +43,8 @@ export interface DynamicDialogSlots {}
  */
 declare class DynamicDialog extends ClassComponent<DynamicDialogProps, DynamicDialogSlots, DynamicDialogEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         DynamicDialog: GlobalComponentConstructor<DynamicDialog>;
     }
 }

--- a/components/lib/editor/Editor.d.ts
+++ b/components/lib/editor/Editor.d.ts
@@ -305,8 +305,8 @@ export interface EditorEmits {
  */
 declare class Editor extends ClassComponent<EditorProps, EditorSlots, EditorEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Editor: GlobalComponentConstructor<Editor>;
     }
 }

--- a/components/lib/fieldset/Fieldset.d.ts
+++ b/components/lib/fieldset/Fieldset.d.ts
@@ -211,8 +211,8 @@ export interface FieldsetEmits {
  */
 declare class Fieldset extends ClassComponent<FieldsetProps, FieldsetSlots, FieldsetEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Fieldset: GlobalComponentConstructor<Fieldset>;
     }
 }

--- a/components/lib/fileupload/FileUpload.d.ts
+++ b/components/lib/fileupload/FileUpload.d.ts
@@ -624,8 +624,8 @@ export interface FileUploadEmits {
  */
 declare class FileUpload extends ClassComponent<FileUploadProps, FileUploadSlots, FileUploadEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         FileUpload: GlobalComponentConstructor<FileUpload>;
     }
 }

--- a/components/lib/floatlabel/FloatLabel.d.ts
+++ b/components/lib/floatlabel/FloatLabel.d.ts
@@ -115,8 +115,8 @@ export interface FloatLabelEmits {}
  */
 declare class FloatLabel extends ClassComponent<FloatLabelProps, FloatLabelSlots, FloatLabelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         FloatLabel: GlobalComponentConstructor<FloatLabel>;
     }
 }

--- a/components/lib/galleria/Galleria.d.ts
+++ b/components/lib/galleria/Galleria.d.ts
@@ -526,8 +526,8 @@ export interface GalleriaEmits {
  */
 declare class Galleria extends ClassComponent<GalleriaProps, GalleriaSlots, GalleriaEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Galleria: GlobalComponentConstructor<Galleria>;
     }
 }

--- a/components/lib/iconfield/IconField.d.ts
+++ b/components/lib/iconfield/IconField.d.ts
@@ -118,8 +118,8 @@ export interface IconFieldEmits {}
  */
 declare class IconField extends ClassComponent<IconFieldProps, IconFieldSlots, IconFieldEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         IconField: GlobalComponentConstructor<IconField>;
     }
 }

--- a/components/lib/icons/angledoubledown/index.d.ts
+++ b/components/lib/icons/angledoubledown/index.d.ts
@@ -3,8 +3,8 @@ import { Icon } from '../index';
 
 declare class AngleDoubleDownIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleDoubleDownIcon: GlobalComponentConstructor<AngleDoubleDownIcon>;
     }
 }

--- a/components/lib/icons/angledoubleleft/index.d.ts
+++ b/components/lib/icons/angledoubleleft/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleDoubleLeftIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleDoubleLeftIcon: GlobalComponentConstructor<AngleDoubleLeftIcon>;
     }
 }

--- a/components/lib/icons/angledoubleright/index.d.ts
+++ b/components/lib/icons/angledoubleright/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleDoubleRightIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleDoubleRightIcon: GlobalComponentConstructor<AngleDoubleRightIcon>;
     }
 }

--- a/components/lib/icons/angledoubleup/index.d.ts
+++ b/components/lib/icons/angledoubleup/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleDoubleUpIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleDoubleUpIcon: GlobalComponentConstructor<AngleDoubleUpIcon>;
     }
 }

--- a/components/lib/icons/angledown/index.d.ts
+++ b/components/lib/icons/angledown/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleDownIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleDownIcon: GlobalComponentConstructor<AngleDownIcon>;
     }
 }

--- a/components/lib/icons/angleleft/index.d.ts
+++ b/components/lib/icons/angleleft/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleLeftIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleLeftIcon: GlobalComponentConstructor<AngleLeftIcon>;
     }
 }

--- a/components/lib/icons/angleright/index.d.ts
+++ b/components/lib/icons/angleright/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleRightIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleRightIcon: GlobalComponentConstructor<AngleRightIcon>;
     }
 }

--- a/components/lib/icons/angleup/index.d.ts
+++ b/components/lib/icons/angleup/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class AngleUpIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         AngleUpIcon: GlobalComponentConstructor<AngleUpIcon>;
     }
 }

--- a/components/lib/icons/arrowdown/index.d.ts
+++ b/components/lib/icons/arrowdown/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ArrowDownIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ArrowDownIcon: GlobalComponentConstructor<ArrowDownIcon>;
     }
 }

--- a/components/lib/icons/arrowup/index.d.ts
+++ b/components/lib/icons/arrowup/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ArrowUpIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ArrowUpIcon: GlobalComponentConstructor<ArrowUpIcon>;
     }
 }

--- a/components/lib/icons/ban/index.d.ts
+++ b/components/lib/icons/ban/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class BanIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         BanIcon: GlobalComponentConstructor<BanIcon>;
     }
 }

--- a/components/lib/icons/bars/index.d.ts
+++ b/components/lib/icons/bars/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class BarsIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         BarsIcon: GlobalComponentConstructor<BarsIcon>;
     }
 }

--- a/components/lib/icons/blank/index.d.ts
+++ b/components/lib/icons/blank/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class BlankIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         BlankIcon: GlobalComponentConstructor<BlankIcon>;
     }
 }

--- a/components/lib/icons/calendar/index.d.ts
+++ b/components/lib/icons/calendar/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class CalendarIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         CalendarIcon: GlobalComponentConstructor<CalendarIcon>;
     }
 }

--- a/components/lib/icons/check/index.d.ts
+++ b/components/lib/icons/check/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class CheckIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         CheckIcon: GlobalComponentConstructor<CheckIcon>;
     }
 }

--- a/components/lib/icons/chevrondown/index.d.ts
+++ b/components/lib/icons/chevrondown/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ChevronDownIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ChevronDownIcon: GlobalComponentConstructor<ChevronDownIcon>;
     }
 }

--- a/components/lib/icons/chevronleft/index.d.ts
+++ b/components/lib/icons/chevronleft/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ChevronLeftIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ChevronLeftIcon: GlobalComponentConstructor<ChevronLeftIcon>;
     }
 }

--- a/components/lib/icons/chevronright/index.d.ts
+++ b/components/lib/icons/chevronright/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ChevronRightIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ChevronRightIcon: GlobalComponentConstructor<ChevronRightIcon>;
     }
 }

--- a/components/lib/icons/chevronup/index.d.ts
+++ b/components/lib/icons/chevronup/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ChevronUpIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ChevronUpIcon: GlobalComponentConstructor<ChevronUpIcon>;
     }
 }

--- a/components/lib/icons/exclamationtriangle/index.d.ts
+++ b/components/lib/icons/exclamationtriangle/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ExclamationTriangleIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ExclamationTriangleIcon: GlobalComponentConstructor<ExclamationTriangleIcon>;
     }
 }

--- a/components/lib/icons/eye/index.d.ts
+++ b/components/lib/icons/eye/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class EyeIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         EyeIcon: GlobalComponentConstructor<EyeIcon>;
     }
 }

--- a/components/lib/icons/eyeslash/index.d.ts
+++ b/components/lib/icons/eyeslash/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class EyeSlashIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         EyeSlashIcon: GlobalComponentConstructor<EyeSlashIcon>;
     }
 }

--- a/components/lib/icons/filter/index.d.ts
+++ b/components/lib/icons/filter/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class FilterIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         FilterIcon: GlobalComponentConstructor<FilterIcon>;
     }
 }

--- a/components/lib/icons/filterslash/index.d.ts
+++ b/components/lib/icons/filterslash/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class FilterSlashIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         FilterSlashIcon: GlobalComponentConstructor<FilterSlashIcon>;
     }
 }

--- a/components/lib/icons/infocircle/index.d.ts
+++ b/components/lib/icons/infocircle/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class InfoCircleIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InfoCircleIcon: GlobalComponentConstructor<InfoCircleIcon>;
     }
 }

--- a/components/lib/icons/minus/index.d.ts
+++ b/components/lib/icons/minus/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class MinusIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         MinusIcon: GlobalComponentConstructor<MinusIcon>;
     }
 }

--- a/components/lib/icons/pencil/index.d.ts
+++ b/components/lib/icons/pencil/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class PencilIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         PencilIcon: GlobalComponentConstructor<PencilIcon>;
     }
 }

--- a/components/lib/icons/plus/index.d.ts
+++ b/components/lib/icons/plus/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class PlusIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         PlusIcon: GlobalComponentConstructor<PlusIcon>;
     }
 }

--- a/components/lib/icons/refresh/index.d.ts
+++ b/components/lib/icons/refresh/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class RefreshIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         RefreshIcon: GlobalComponentConstructor<RefreshIcon>;
     }
 }

--- a/components/lib/icons/search/index.d.ts
+++ b/components/lib/icons/search/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SearchIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SearchIcon: GlobalComponentConstructor<SearchIcon>;
     }
 }

--- a/components/lib/icons/searchminus/index.d.ts
+++ b/components/lib/icons/searchminus/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SearchMinusIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SearchMinusIcon: GlobalComponentConstructor<SearchMinusIcon>;
     }
 }

--- a/components/lib/icons/searchplus/index.d.ts
+++ b/components/lib/icons/searchplus/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SearchPlusIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SearchPlusIcon: GlobalComponentConstructor<SearchPlusIcon>;
     }
 }

--- a/components/lib/icons/sortalt/index.d.ts
+++ b/components/lib/icons/sortalt/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SortAltIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SortAltIcon: GlobalComponentConstructor<SortAltIcon>;
     }
 }

--- a/components/lib/icons/sortamountdown/index.d.ts
+++ b/components/lib/icons/sortamountdown/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SortAmountDownIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SortAmountDownIcon: GlobalComponentConstructor<SortAmountDownIcon>;
     }
 }

--- a/components/lib/icons/sortamountupalt/index.d.ts
+++ b/components/lib/icons/sortamountupalt/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SortAmountUpAltIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SortAmountUpAltIcon: GlobalComponentConstructor<SortAmountUpAltIcon>;
     }
 }

--- a/components/lib/icons/spinner/index.d.ts
+++ b/components/lib/icons/spinner/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class SpinnerIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SpinnerIcon: GlobalComponentConstructor<SpinnerIcon>;
     }
 }

--- a/components/lib/icons/star/index.d.ts
+++ b/components/lib/icons/star/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class StarIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         StarIcon: GlobalComponentConstructor<StarIcon>;
     }
 }

--- a/components/lib/icons/starfill/index.d.ts
+++ b/components/lib/icons/starfill/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class StarFillIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         StarFillIcon: GlobalComponentConstructor<StarFillIcon>;
     }
 }

--- a/components/lib/icons/thlarge/index.d.ts
+++ b/components/lib/icons/thlarge/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class ThLargeIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ThLargeIcon: GlobalComponentConstructor<ThLargeIcon>;
     }
 }

--- a/components/lib/icons/times/index.d.ts
+++ b/components/lib/icons/times/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class TimesIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TimesIcon: GlobalComponentConstructor<TimesIcon>;
     }
 }

--- a/components/lib/icons/timescircle/index.d.ts
+++ b/components/lib/icons/timescircle/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class TimesCircleIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TimesCircleIcon: GlobalComponentConstructor<TimesCircleIcon>;
     }
 }

--- a/components/lib/icons/trash/index.d.ts
+++ b/components/lib/icons/trash/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class TrashIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TrashIcon: GlobalComponentConstructor<TrashIcon>;
     }
 }

--- a/components/lib/icons/undo/index.d.ts
+++ b/components/lib/icons/undo/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class UndoIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         UndoIcon: GlobalComponentConstructor<UndoIcon>;
     }
 }

--- a/components/lib/icons/upload/index.d.ts
+++ b/components/lib/icons/upload/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class UploadIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         UploadIcon: GlobalComponentConstructor<UploadIcon>;
     }
 }

--- a/components/lib/icons/windowmaximize/index.d.ts
+++ b/components/lib/icons/windowmaximize/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class WindowMaximizeIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         WindowMaximizeIcon: GlobalComponentConstructor<WindowMaximizeIcon>;
     }
 }

--- a/components/lib/icons/windowminimize/index.d.ts
+++ b/components/lib/icons/windowminimize/index.d.ts
@@ -3,8 +3,8 @@ import { GlobalComponentConstructor } from '../../ts-helpers';
 
 declare class WindowMinimizeIcon extends Icon {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         WindowMinimizeIcon: GlobalComponentConstructor<WindowMinimizeIcon>;
     }
 }

--- a/components/lib/image/Image.d.ts
+++ b/components/lib/image/Image.d.ts
@@ -327,8 +327,8 @@ declare class Image extends ClassComponent<ImageProps, ImageSlots, ImageEmits> {
     error(): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Image: GlobalComponentConstructor<Image>;
     }
 }

--- a/components/lib/inlinemessage/InlineMessage.d.ts
+++ b/components/lib/inlinemessage/InlineMessage.d.ts
@@ -146,8 +146,8 @@ export interface InlineMessageEmits {}
  */
 declare class InlineMessage extends ClassComponent<InlineMessageProps, InlineMessageSlots, InlineMessageEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InlineMessage: GlobalComponentConstructor<InlineMessage>;
     }
 }

--- a/components/lib/inplace/Inplace.d.ts
+++ b/components/lib/inplace/Inplace.d.ts
@@ -208,8 +208,8 @@ export interface InplaceEmits {
  */
 declare class Inplace extends ClassComponent<InplaceProps, InplaceSlots, InplaceEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Inplace: GlobalComponentConstructor<Inplace>;
     }
 }

--- a/components/lib/inputgroup/InputGroup.d.ts
+++ b/components/lib/inputgroup/InputGroup.d.ts
@@ -113,8 +113,8 @@ export interface InputGroupEmits {}
  */
 declare class InputGroup extends ClassComponent<InputGroupProps, InputGroupSlots, InputGroupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputGroup: GlobalComponentConstructor<InputGroup>;
     }
 }

--- a/components/lib/inputgroupaddon/InputGroupAddon.d.ts
+++ b/components/lib/inputgroupaddon/InputGroupAddon.d.ts
@@ -113,8 +113,8 @@ export interface InputGroupAddonEmits {}
  */
 declare class InputGroupAddon extends ClassComponent<InputGroupAddonProps, InputGroupAddonSlots, InputGroupAddonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputGroupAddon: GlobalComponentConstructor<InputGroupAddon>;
     }
 }

--- a/components/lib/inputicon/InputIcon.d.ts
+++ b/components/lib/inputicon/InputIcon.d.ts
@@ -108,8 +108,8 @@ export interface InputIconEmits {}
  */
 declare class InputIcon extends ClassComponent<InputIconProps, InputIconSlots, InputIconEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputIcon: GlobalComponentConstructor<InputIcon>;
     }
 }

--- a/components/lib/inputmask/InputMask.d.ts
+++ b/components/lib/inputmask/InputMask.d.ts
@@ -195,8 +195,8 @@ export interface InputMaskEmits {
  */
 declare class InputMask extends ClassComponent<InputMaskProps, InputMaskSlots, InputMaskEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputMask: GlobalComponentConstructor<InputMask>;
     }
 }

--- a/components/lib/inputnumber/InputNumber.d.ts
+++ b/components/lib/inputnumber/InputNumber.d.ts
@@ -395,8 +395,8 @@ declare class InputNumber extends ClassComponent<InputNumberProps, InputNumberSl
     getFormatter: () => Intl.NumberFormat | undefined;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputNumber: GlobalComponentConstructor<InputNumber>;
     }
 }

--- a/components/lib/inputotp/InputOtp.d.ts
+++ b/components/lib/inputotp/InputOtp.d.ts
@@ -266,8 +266,8 @@ export interface InputOtpEmits {
  */
 declare class InputOtp extends ClassComponent<InputOtpProps, InputOtpSlots, InputOtpEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputOtp: GlobalComponentConstructor<InputOtp>;
     }
 }

--- a/components/lib/inputswitch/InputSwitch.d.ts
+++ b/components/lib/inputswitch/InputSwitch.d.ts
@@ -207,8 +207,8 @@ export interface InputSwitchEmits {
  */
 declare class InputSwitch extends ClassComponent<InputSwitchProps, InputSwitchSlots, InputSwitchEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputSwitch: GlobalComponentConstructor<InputSwitch>;
     }
 }

--- a/components/lib/inputtext/InputText.d.ts
+++ b/components/lib/inputtext/InputText.d.ts
@@ -147,8 +147,8 @@ export interface InputTextEmits {
  */
 declare class InputText extends ClassComponent<InputTextProps, InputTextSlots, InputTextEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         InputText: GlobalComponentConstructor<InputText>;
     }
 }

--- a/components/lib/knob/Knob.d.ts
+++ b/components/lib/knob/Knob.d.ts
@@ -242,8 +242,8 @@ export interface KnobEmits {
  */
 declare class Knob extends ClassComponent<KnobProps, KnobSlots, KnobEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Knob: GlobalComponentConstructor<Knob>;
     }
 }

--- a/components/lib/listbox/Listbox.d.ts
+++ b/components/lib/listbox/Listbox.d.ts
@@ -530,8 +530,8 @@ export interface ListboxEmits {
  */
 declare class Listbox extends ClassComponent<ListboxProps, ListboxSlots, ListboxEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Listbox: GlobalComponentConstructor<Listbox>;
     }
 }

--- a/components/lib/megamenu/MegaMenu.d.ts
+++ b/components/lib/megamenu/MegaMenu.d.ts
@@ -405,8 +405,8 @@ export interface MegaMenuEmits {
  */
 declare class MegaMenu extends ClassComponent<MegaMenuProps, MegaMenuSlots, MegaMenuEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         MegaMenu: GlobalComponentConstructor<MegaMenu>;
     }
 }

--- a/components/lib/menu/Menu.d.ts
+++ b/components/lib/menu/Menu.d.ts
@@ -359,8 +359,8 @@ declare class Menu extends ClassComponent<MenuProps, MenuSlots, MenuEmits> {
     hide(): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Menu: GlobalComponentConstructor<Menu>;
     }
 }

--- a/components/lib/menubar/Menubar.d.ts
+++ b/components/lib/menubar/Menubar.d.ts
@@ -390,8 +390,8 @@ export interface MenubarEmits {}
  */
 declare class Menubar extends ClassComponent<MenubarProps, MenubarSlots, MenubarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Menubar: GlobalComponentConstructor<Menubar>;
     }
 }

--- a/components/lib/message/Message.d.ts
+++ b/components/lib/message/Message.d.ts
@@ -238,8 +238,8 @@ export interface MessageEmits {
  */
 declare class Message extends ClassComponent<MessageProps, MessageSlots, MessageEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Message: GlobalComponentConstructor<Message>;
     }
 }

--- a/components/lib/metergroup/MeterGroup.d.ts
+++ b/components/lib/metergroup/MeterGroup.d.ts
@@ -293,8 +293,8 @@ export interface MeterGroupEmits {}
  */
 declare class MeterGroup extends ClassComponent<MeterGroupProps, MeterGroupSlots, MeterGroupEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         MeterGroup: GlobalComponentConstructor<MeterGroup>;
     }
 }

--- a/components/lib/multiselect/MultiSelect.d.ts
+++ b/components/lib/multiselect/MultiSelect.d.ts
@@ -862,8 +862,8 @@ declare class MultiSelect extends ClassComponent<MultiSelectProps, MultiSelectSl
     hide(isFocus?: boolean): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         MultiSelect: GlobalComponentConstructor<MultiSelect>;
     }
 }

--- a/components/lib/orderlist/OrderList.d.ts
+++ b/components/lib/orderlist/OrderList.d.ts
@@ -389,8 +389,8 @@ export interface OrderListEmits {
  */
 declare class OrderList extends ClassComponent<OrderListProps, OrderListSlots, OrderListEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         OrderList: GlobalComponentConstructor<OrderList>;
     }
 }

--- a/components/lib/organizationchart/OrganizationChart.d.ts
+++ b/components/lib/organizationchart/OrganizationChart.d.ts
@@ -341,8 +341,8 @@ export interface OrganizationChartEmits {
  */
 declare class OrganizationChart extends ClassComponent<OrganizationChartProps, OrganizationChartSlots, OrganizationChartEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         OrganizationChart: GlobalComponentConstructor<OrganizationChart>;
     }
 }

--- a/components/lib/overlaypanel/OverlayPanel.d.ts
+++ b/components/lib/overlaypanel/OverlayPanel.d.ts
@@ -272,8 +272,8 @@ declare class OverlayPanel extends ClassComponent<OverlayPanelProps, OverlayPane
     hide(): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         OverlayPanel: GlobalComponentConstructor<OverlayPanel>;
     }
 }

--- a/components/lib/paginator/Paginator.d.ts
+++ b/components/lib/paginator/Paginator.d.ts
@@ -376,8 +376,8 @@ export interface PaginatorEmits {
  */
 declare class Paginator extends ClassComponent<PaginatorProps, PaginatorSlots, PaginatorEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Paginator: GlobalComponentConstructor<Paginator>;
     }
 }

--- a/components/lib/panel/Panel.d.ts
+++ b/components/lib/panel/Panel.d.ts
@@ -243,8 +243,8 @@ export interface PanelEmits {
  */
 declare class Panel extends ClassComponent<PanelProps, PanelSlots, PanelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Panel: GlobalComponentConstructor<Panel>;
     }
 }

--- a/components/lib/panelmenu/PanelMenu.d.ts
+++ b/components/lib/panelmenu/PanelMenu.d.ts
@@ -405,8 +405,8 @@ export interface PanelMenuEmits {
  */
 declare class PanelMenu extends ClassComponent<PanelMenuProps, PanelMenuSlots, PanelMenuEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         PanelMenu: GlobalComponentConstructor<PanelMenu>;
     }
 }

--- a/components/lib/password/Password.d.ts
+++ b/components/lib/password/Password.d.ts
@@ -379,8 +379,8 @@ export interface PasswordEmits {
  */
 declare class Password extends ClassComponent<PasswordProps, PasswordSlots, PasswordEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Password: GlobalComponentConstructor<Password>;
     }
 }

--- a/components/lib/picklist/PickList.d.ts
+++ b/components/lib/picklist/PickList.d.ts
@@ -606,8 +606,8 @@ export interface PickListEmits {
  */
 declare class PickList extends ClassComponent<PickListProps, PickListSlots, PickListEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         PickList: GlobalComponentConstructor<PickList>;
     }
 }

--- a/components/lib/portal/Portal.d.ts
+++ b/components/lib/portal/Portal.d.ts
@@ -28,8 +28,8 @@ export declare type PortalEmits = {};
 
 declare class Portal extends ClassComponent<PortalProps, PortalSlots, PortalEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Portal: GlobalComponentConstructor<Portal>;
     }
 }

--- a/components/lib/progressbar/ProgressBar.d.ts
+++ b/components/lib/progressbar/ProgressBar.d.ts
@@ -130,8 +130,8 @@ export interface ProgressBarEmits {}
  */
 declare class ProgressBar extends ClassComponent<ProgressBarProps, ProgressBarSlots, ProgressBarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ProgressBar: GlobalComponentConstructor<ProgressBar>;
     }
 }

--- a/components/lib/progressspinner/ProgressSpinner.d.ts
+++ b/components/lib/progressspinner/ProgressSpinner.d.ts
@@ -128,8 +128,8 @@ export interface ProgressSpinnerEmits {}
  */
 declare class ProgressSpinner extends ClassComponent<ProgressSpinnerProps, ProgressSpinnerSlots, ProgressSpinnerEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ProgressSpinner: GlobalComponentConstructor<ProgressSpinner>;
     }
 }

--- a/components/lib/radiobutton/RadioButton.d.ts
+++ b/components/lib/radiobutton/RadioButton.d.ts
@@ -229,8 +229,8 @@ export interface RadioButtonEmits {
  */
 declare class RadioButton extends ClassComponent<RadioButtonProps, RadioButtonSlots, RadioButtonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         RadioButton: GlobalComponentConstructor<RadioButton>;
     }
 }

--- a/components/lib/rating/Rating.d.ts
+++ b/components/lib/rating/Rating.d.ts
@@ -299,8 +299,8 @@ export interface RatingEmits {
  */
 declare class Rating extends ClassComponent<RatingProps, RatingSlots, RatingEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Rating: GlobalComponentConstructor<Rating>;
     }
 }

--- a/components/lib/row/Row.d.ts
+++ b/components/lib/row/Row.d.ts
@@ -107,8 +107,8 @@ export interface RowEmits {}
  */
 declare class Row extends ClassComponent<RowProps, RowSlots, RowEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Row: GlobalComponentConstructor<Row>;
     }
 }

--- a/components/lib/scrollpanel/ScrollPanel.d.ts
+++ b/components/lib/scrollpanel/ScrollPanel.d.ts
@@ -160,8 +160,8 @@ export interface ScrollPanelEmits {}
  */
 declare class ScrollPanel extends ClassComponent<ScrollPanelProps, ScrollPanelSlots, ScrollPanelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ScrollPanel: GlobalComponentConstructor<ScrollPanel>;
     }
 }

--- a/components/lib/scrolltop/ScrollTop.d.ts
+++ b/components/lib/scrolltop/ScrollTop.d.ts
@@ -157,8 +157,8 @@ export interface ScrollTopEmits {}
  */
 declare class ScrollTop extends ClassComponent<ScrollTopProps, ScrollTopSlots, ScrollTopEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ScrollTop: GlobalComponentConstructor<ScrollTop>;
     }
 }

--- a/components/lib/selectbutton/SelectButton.d.ts
+++ b/components/lib/selectbutton/SelectButton.d.ts
@@ -257,8 +257,8 @@ export interface SelectButtonEmits {
  */
 declare class SelectButton extends ClassComponent<SelectButtonProps, SelectButtonSlots, SelectButtonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SelectButton: GlobalComponentConstructor<SelectButton>;
     }
 }

--- a/components/lib/sidebar/Sidebar.d.ts
+++ b/components/lib/sidebar/Sidebar.d.ts
@@ -255,8 +255,8 @@ export interface SidebarEmits {
  */
 declare class Sidebar extends ClassComponent<SidebarProps, SidebarSlots, SidebarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Sidebar: GlobalComponentConstructor<Sidebar>;
     }
 }

--- a/components/lib/skeleton/Skeleton.d.ts
+++ b/components/lib/skeleton/Skeleton.d.ts
@@ -134,8 +134,8 @@ export interface SkeletonEmits {}
  */
 declare class Skeleton extends ClassComponent<SkeletonProps, SkeletonSlots, SkeletonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Skeleton: GlobalComponentConstructor<Skeleton>;
     }
 }

--- a/components/lib/slider/Slider.d.ts
+++ b/components/lib/slider/Slider.d.ts
@@ -200,8 +200,8 @@ export interface SliderEmits {
  */
 declare class Slider extends ClassComponent<SliderProps, SliderSlots, SliderEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Slider: GlobalComponentConstructor<Slider>;
     }
 }

--- a/components/lib/speeddial/SpeedDial.d.ts
+++ b/components/lib/speeddial/SpeedDial.d.ts
@@ -383,8 +383,8 @@ export interface SpeedDialEmits {
  */
 declare class SpeedDial extends ClassComponent<SpeedDialProps, SpeedDialSlots, SpeedDialEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SpeedDial: GlobalComponentConstructor<SpeedDial>;
     }
 }

--- a/components/lib/splitbutton/SplitButton.d.ts
+++ b/components/lib/splitbutton/SplitButton.d.ts
@@ -313,8 +313,8 @@ export interface SplitButtonEmits {
  */
 declare class SplitButton extends ClassComponent<SplitButtonProps, SplitButtonSlots, SplitButtonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SplitButton: GlobalComponentConstructor<SplitButton>;
     }
 }

--- a/components/lib/splitter/Splitter.d.ts
+++ b/components/lib/splitter/Splitter.d.ts
@@ -234,8 +234,8 @@ export interface SplitterEmits {
  */
 declare class Splitter extends ClassComponent<SplitterProps, SplitterSlots, SplitterEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Splitter: GlobalComponentConstructor<Splitter>;
     }
 }

--- a/components/lib/splitterpanel/SplitterPanel.d.ts
+++ b/components/lib/splitterpanel/SplitterPanel.d.ts
@@ -132,8 +132,8 @@ export interface SplitterPanelEmits {}
  */
 declare class SplitterPanel extends ClassComponent<SplitterPanelProps, SplitterPanelSlots, SplitterPanelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         SplitterPanel: GlobalComponentConstructor<SplitterPanel>;
     }
 }

--- a/components/lib/stepper/Stepper.d.ts
+++ b/components/lib/stepper/Stepper.d.ts
@@ -188,8 +188,8 @@ export interface StepperEmits {
  */
 declare class Stepper extends ClassComponent<StepperProps, StepperSlots, StepperEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Stepper: GlobalComponentConstructor<Stepper>;
     }
 }

--- a/components/lib/stepperpanel/StepperPanel.d.ts
+++ b/components/lib/stepperpanel/StepperPanel.d.ts
@@ -277,8 +277,8 @@ export interface StepperPanelEmits {}
  */
 declare class StepperPanel extends ClassComponent<StepperPanelProps, StepperPanelSlots, StepperPanelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         StepperPanel: GlobalComponentConstructor<StepperPanel>;
     }
 }

--- a/components/lib/steps/Steps.d.ts
+++ b/components/lib/steps/Steps.d.ts
@@ -226,8 +226,8 @@ export interface StepsEmits {}
  */
 declare class Steps extends ClassComponent<StepsProps, StepsSlots, StepsEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Steps: GlobalComponentConstructor<Steps>;
     }
 }

--- a/components/lib/tabmenu/TabMenu.d.ts
+++ b/components/lib/tabmenu/TabMenu.d.ts
@@ -269,8 +269,8 @@ export interface TabMenuEmits {
  */
 declare class TabMenu extends ClassComponent<TabMenuProps, TabMenuSlots, TabMenuEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TabMenu: GlobalComponentConstructor<TabMenu>;
     }
 }

--- a/components/lib/tabpanel/TabPanel.d.ts
+++ b/components/lib/tabpanel/TabPanel.d.ts
@@ -192,8 +192,8 @@ export interface TabPanelEmits {}
  */
 declare class TabPanel extends ClassComponent<TabPanelProps, TabPanelSlots, TabPanelEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TabPanel: GlobalComponentConstructor<TabPanel>;
     }
 }

--- a/components/lib/tabview/TabView.d.ts
+++ b/components/lib/tabview/TabView.d.ts
@@ -278,8 +278,8 @@ export interface TabViewEmits {
  */
 declare class TabView extends ClassComponent<TabViewProps, TabViewSlots, TabViewEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TabView: GlobalComponentConstructor<TabView>;
     }
 }

--- a/components/lib/tag/Tag.d.ts
+++ b/components/lib/tag/Tag.d.ts
@@ -142,8 +142,8 @@ export interface TagEmits {}
  */
 declare class Tag extends ClassComponent<TagProps, TagSlots, TagEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Tag: GlobalComponentConstructor<Tag>;
     }
 }

--- a/components/lib/terminal/Terminal.d.ts
+++ b/components/lib/terminal/Terminal.d.ts
@@ -164,8 +164,8 @@ export interface TerminalEmits {}
  */
 declare class Terminal extends ClassComponent<TerminalProps, TerminalSlots, TerminalEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Terminal: GlobalComponentConstructor<Terminal>;
     }
 }

--- a/components/lib/textarea/Textarea.d.ts
+++ b/components/lib/textarea/Textarea.d.ts
@@ -154,8 +154,8 @@ export interface TextareaEmits {
  */
 declare class Textarea extends ClassComponent<TextareaProps, TextareaSlots, TextareaEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Textarea: GlobalComponentConstructor<Textarea>;
     }
 }

--- a/components/lib/tieredmenu/TieredMenu.d.ts
+++ b/components/lib/tieredmenu/TieredMenu.d.ts
@@ -408,8 +408,8 @@ declare class TieredMenu extends ClassComponent<TieredMenuProps, TieredMenuSlots
     hide(): void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TieredMenu: GlobalComponentConstructor<TieredMenu>;
     }
 }

--- a/components/lib/timeline/Timeline.d.ts
+++ b/components/lib/timeline/Timeline.d.ts
@@ -218,8 +218,8 @@ export interface TimelineEmits {}
  */
 declare class Timeline extends ClassComponent<TimelineProps, TimelineSlots, TimelineEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Timeline: GlobalComponentConstructor<Timeline>;
     }
 }

--- a/components/lib/toast/Toast.d.ts
+++ b/components/lib/toast/Toast.d.ts
@@ -353,8 +353,8 @@ export interface ToastEmits {
  */
 declare class Toast extends ClassComponent<ToastProps, ToastSlots, ToastEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Toast: GlobalComponentConstructor<Toast>;
     }
 }

--- a/components/lib/togglebutton/ToggleButton.d.ts
+++ b/components/lib/togglebutton/ToggleButton.d.ts
@@ -260,8 +260,8 @@ export interface ToggleButtonEmits {
  */
 declare class ToggleButton extends ClassComponent<ToggleButtonProps, ToggleButtonSlots, ToggleButtonEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         ToggleButton: GlobalComponentConstructor<ToggleButton>;
     }
 }

--- a/components/lib/toolbar/Toolbar.d.ts
+++ b/components/lib/toolbar/Toolbar.d.ts
@@ -138,8 +138,8 @@ export interface ToolbarEmits {}
  */
 declare class Toolbar extends ClassComponent<ToolbarProps, ToolbarSlots, ToolbarEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Toolbar: GlobalComponentConstructor<Toolbar>;
     }
 }

--- a/components/lib/tree/Tree.d.ts
+++ b/components/lib/tree/Tree.d.ts
@@ -437,8 +437,8 @@ export interface TreeEmits {
  */
 declare class Tree extends ClassComponent<TreeProps, TreeSlots, TreeEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         Tree: GlobalComponentConstructor<Tree>;
     }
 }

--- a/components/lib/treeselect/TreeSelect.d.ts
+++ b/components/lib/treeselect/TreeSelect.d.ts
@@ -441,8 +441,8 @@ declare class TreeSelect extends ClassComponent<TreeSelectProps, TreeSelectSlots
     hide: () => void;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TreeSelect: GlobalComponentConstructor<TreeSelect>;
     }
 }

--- a/components/lib/treetable/TreeTable.d.ts
+++ b/components/lib/treetable/TreeTable.d.ts
@@ -809,8 +809,8 @@ export interface TreeTableEmits {
  */
 declare class TreeTable extends ClassComponent<TreeTableProps, TreeTableSlots, TreeTableEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TreeTable: GlobalComponentConstructor<TreeTable>;
     }
 }

--- a/components/lib/tristatecheckbox/TriStateCheckbox.d.ts
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.d.ts
@@ -264,8 +264,8 @@ export interface TriStateCheckboxEmits {
  */
 declare class TriStateCheckbox extends ClassComponent<TriStateCheckboxProps, TriStateCheckboxSlots, TriStateCheckboxEmits> {}
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         TriStateCheckbox: GlobalComponentConstructor<TriStateCheckbox>;
     }
 }

--- a/components/lib/virtualscroller/VirtualScroller.d.ts
+++ b/components/lib/virtualscroller/VirtualScroller.d.ts
@@ -519,8 +519,8 @@ declare class VirtualScroller extends ClassComponent<VirtualScrollerProps, Virtu
     getRenderedRange(): VirtualScrollerRangeMethod;
 }
 
-declare module '@vue/runtime-core' {
-    interface GlobalComponents {
+declare module 'vue' {
+    export interface GlobalComponents {
         VirtualScroller: GlobalComponentConstructor<VirtualScroller>;
     }
 }


### PR DESCRIPTION
### Defect Fixes
* Resolves https://github.com/nuxt-modules/i18n/issues/2839
* Related https://github.com/nuxt-modules/i18n/issues/2483
* Related https://github.com/intlify/vue-i18n-next/pull/1628

This fixes the type global component type augmentation which should augment `vue` instead of `@vue/runtime-core` see https://vuejs.org/guide/typescript/options-api#augmenting-global-properties for examples. 

For some reason augmenting `@vue/runtime-core` works fine (specifically `GlobalComponents`) if all vue/nuxt modules do this, but mixing `vue` and `@vue/runtime-core` will break type inference, which is why users suspect the module I help maintaining (Nuxt I18n) as they add it after having a project up and running 😅.