### PR TITLE
#5335

### DIFF
--- a/components/lib/inputotp/InputOtp.vue
+++ b/components/lib/inputotp/InputOtp.vue
@@ -137,6 +137,7 @@ export default {
 
             if (this.integerOnly && !this.isNumericKey(key)) {
                 event.preventDefault();
+
                 return;
             }
 
@@ -157,6 +158,7 @@ export default {
                 if (key === 'Delete') {
                     target.value = '';
                 }
+
                 this.tokens[index] = '';
                 this.updateModel(event);
                 event.preventDefault();
@@ -167,7 +169,6 @@ export default {
             let paste = event.clipboardData
                 .getData('text')
                 .split('')
-                .filter((char) => this.isNumericKey(char))
                 .join('');
 
             if (paste.length) {


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/5335
Fix https://github.com/primefaces/primevue/issues/5329
Fix https://github.com/primefaces/primevue/issues/5422

Previously, the `integerOnly` property did not allow the use of the numeric keypad.

**Implemented Solution:**
The `onKeyDown` method has been updated to utilize `event.key`, ensuring compatibility with numeric keypads and improving consistency for users.

### Paste Event Enhancement
The component permitted the pasting of non-numeric content, even when `integerOnly` was enabled.

**Implemented Solution:**
The `onPaste` event has been optimized to filter and accept only numeric characters in `integerOnly` mode.

### Additional Improvement: Adoption of `event.key`
In an effort to refine the codebase, we have phased out the deprecated `event.keyCode` in favor of `event.key`. This not only adheres to modern recommendations for keyboard event compatibility and standardization but also enhances the code's readability and maintainability, setting it up for future extensions and modifications.
