### PR TITLE
fix: change transition movement and target dom(Accordion)

### DIFF
--- a/components/lib/accordion/Accordion.vue
+++ b/components/lib/accordion/Accordion.vue
@@ -33,13 +33,13 @@
                     <component v-if="tab.children && tab.children.header" :is="tab.children.header"></component>
                 </a>
             </div>
-            <transition name="p-toggleable-content" v-bind="getTabPT(tab, 'transition', i)">
+            <Transition v-bind="transitionProperty({i, tab})">
                 <div
                     v-if="lazy ? isTabActive(i) : true"
-                    v-show="lazy ? true : isTabActive(i)"
+                    v-show="lazy || isTabActive(i)"
                     :id="getTabContentId(i)"
                     :style="getTabProp(tab, 'contentStyle')"
-                    :class="[cx('tab.toggleableContent'), getTabProp(tab, 'contentClass')]"
+                    :class="[cx('tab.toggleableContent', { tab, index: i }), getTabProp(tab, 'contentClass')]"
                     role="region"
                     :aria-labelledby="getTabHeaderActionId(i)"
                     v-bind="{ ...getTabProp(tab, 'contentProps'), ...getTabPT(tab, 'toggleablecontent', i) }"
@@ -48,7 +48,7 @@
                         <component :is="tab"></component>
                     </div>
                 </div>
-            </transition>
+            </Transition>
         </div>
     </div>
 </template>
@@ -84,6 +84,29 @@ export default {
         this.id = this.id || UniqueComponentId();
     },
     methods: {
+        transitionProperty({ i, tab }) {
+            return {
+                onEnter: this.enter,
+                onLeave: this.leave,
+                onAfterEnter: this.afterEnter,
+                ...this.getTabPT(tab, 'transition', i),
+            }
+        },
+        enter(el) {
+            el.style.maxHeight = '0';
+            requestAnimationFrame(() => {
+                el.style.maxHeight = `${el.scrollHeight}px`;
+            });
+        },
+        leave(el) {
+            el.style.maxHeight = `${el.scrollHeight}px`;
+            requestAnimationFrame(() => {
+                el.style.maxHeight = '0';
+            });
+        },
+        afterEnter(el) {
+            el.style.maxHeight = 'fit-content';
+        },
         isAccordionTab(child) {
             return child.type.name === 'AccordionTab';
         },

--- a/components/lib/accordion/style/AccordionStyle.js
+++ b/components/lib/accordion/style/AccordionStyle.js
@@ -19,7 +19,12 @@ const classes = {
         headerAction: 'p-accordion-header-link p-accordion-header-action',
         headerIcon: 'p-accordion-toggle-icon',
         headerTitle: 'p-accordion-header-text',
-        toggleableContent: 'p-toggleable-content',
+        toggleableContent: ({ instance, index }) => [
+            'p-toggleable-content',
+            {
+                'p-toggleable-content-expanded': instance.isTabActive(index)
+            }
+        ],
         content: 'p-accordion-content'
     }
 };

--- a/public/themes/aura-light-green/theme.css
+++ b/public/themes/aura-light-green/theme.css
@@ -393,7 +393,7 @@
 
   /* Toggleable Content */
   .p-toggleable-content-enter-from,
-.p-toggleable-content-leave-to {
+  .p-toggleable-content-leave-to {
     max-height: 0;
   }
 
@@ -5838,6 +5838,15 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
+
+  .p-accordion .p-toggleable-content {
+    overflow: hidden;
+    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
+  }
+  .p-accordion .p-toggleable-content-expanded {
+    transition: max-height 0.45s ease-in-out;
+  }
+
   .p-accordion .p-accordion-tab {
     margin-bottom: 0;
   }


### PR DESCRIPTION
## Suggestion
- If I click a button while an animation is in progress, the animation is interrupted.
- While the accordion is open, when you click the close button, the height of the accordion changes to full height.
- The video reproduces the problem by increasing the animation time of the existing accordion.

![스크린샷 2024-03-18 오후 12 22 06](https://github.com/primefaces/primevue/assets/37934668/0ce9e824-7cf2-4e67-8afb-fbac617d47c7)


https://github.com/primefaces/primevue/assets/37934668/e6703a1c-2efc-4d63-98ad-4692027d787d

<br/>


- current, Accordion animation is only css.
- but css can not resolve temporary animation stop problem.

```css
/* primevue/public/themes/nova/theme.css */

/* Toggleable Content */
.p-toggleable-content-enter-from,
.p-toggleable-content-leave-to {
  max-height: 0;
}

.p-toggleable-content-enter-to,
.p-toggleable-content-leave-from {
  max-height: 1000px;
}

.p-toggleable-content-leave-active {
  overflow: hidden;
  transition: max-height 0.45s cubic-bezier(0, 1, 0, 1);
}

.p-toggleable-content-enter-active {
  overflow: hidden;
  transition: max-height 1s ease-in-out;
}
```

<br/>

## Pull Request Description
> So, i suggest to use requestAnimationFrame and to change transition target dom.

### 1. style change using requestAnimationFrame
- First, use requestAnimationFrame on v-transition event.
```js
enter(el) {
      el.style.maxHeight = '0';
      requestAnimationFrame(() => {
		 // set maxHeight value
          el.style.maxHeight = `${el.scrollHeight}px`;
      });
  },
  leave(el) {
     // change maxHeight to an integer value.(required to apply animation)
      el.style.maxHeight = `${el.scrollHeight}px`;
       // and, change requestAnimationFrame to 0.
      requestAnimationFrame(() => {
          el.style.maxHeight = '0';
      });
  },
  afterEnter(el) {
      // reset maxHeight value to cover resizing
      el.style.maxHeight = 'fit-content';
  },
```

### change transition target to p-toggleable-content
- previous, transition property is set on v-transition-event class.
- but, this case makes transition stop problem.

```css 
// theme.css

 .p-toggleable-content-leave-active {
    overflow: hidden;
    transition: max-height 0.45s cubic-bezier(0, 1, 0, 1);
  }

  .p-toggleable-content-enter-active {
    overflow: hidden;
    transition: max-height 1s ease-in-out;
  }
```

<br/>

- So, i change transition target to p-toggleable-content.
(_i think, this style code should move to Accordion component_)

```css
// theme.css

.p-accordion .p-toggleable-content {
    overflow: hidden;
    transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
  }
  .p-accordion .p-toggleable-content-expanded {
    transition: max-height 0.45s ease-in-out;
  }
```

<br/>

- After changed code applied, We can see the issue is resolved(_This video shows that by increasing the animation time_)

![스크린샷 2024-03-18 오후 12 31 33](https://github.com/primefaces/primevue/assets/37934668/dae0bb8b-e09b-4c5b-883a-8f9e65ded583)




https://github.com/primefaces/primevue/assets/37934668/7af88171-a4e3-4132-88f4-bc027c1af2df


