### PR TITLE
(fix)Tree: Pass class to TreeNodes nodeIcon slot

### DIFF
--- a/components/lib/tree/Tree.d.ts
+++ b/components/lib/tree/Tree.d.ts
@@ -361,6 +361,10 @@ export interface TreeSlots {
          * Tree node instance
          */
         node: TreeNode;
+        /**
+         * Style class of the icon.
+         */
+        class: string;
     }): VNode[];
     /**
      * Custom checkbox icon

--- a/components/lib/tree/Tree.spec.js
+++ b/components/lib/tree/Tree.spec.js
@@ -63,7 +63,7 @@ describe('Tree.vue', () => {
     it('should render icon slot', ({ expect }) => {
         let wrapper = mount(Tree, {
             slots: {
-                nodeIcon: `<i data-node-icon/>`
+                nodeicon: `<i data-node-icon/>`
             },
             props: {
                 value: [

--- a/components/lib/tree/TreeNode.vue
+++ b/components/lib/tree/TreeNode.vue
@@ -32,7 +32,7 @@
                     <component v-else :is="checked ? 'CheckIcon' : partialChecked ? 'MinusIcon' : null" :class="slotProps.class" v-bind="getPTOptions('nodeCheckbox.icon')" />
                 </template>
             </Checkbox>
-            <component v-if="templates['nodeicon']" :is="templates['nodeicon']" :node="node"></component>
+            <component v-if="templates['nodeicon']" :is="templates['nodeicon']" :node="node" :class="[cx('nodeIcon')]"></component>
             <span v-else :class="[cx('nodeIcon'), node.icon]" v-bind="getPTOptions('nodeIcon')"></span>
             <span :class="cx('label')" v-bind="getPTOptions('label')" @keydown.stop>
                 <component v-if="templates[node.type] || templates['default']" :is="templates[node.type] || templates['default']" :node="node" />


### PR DESCRIPTION
###Defect Fixes
See #5452 

Pass the given classes down to the slot, so they can be used as usual.