### PR TITLE
Fix #5320 – Carousel blocking touch scroll

### DIFF
--- a/components/lib/carousel/Carousel.vue
+++ b/components/lib/carousel/Carousel.vue
@@ -409,7 +409,12 @@ export default {
             };
         },
         onTouchMove(e) {
-            if (e.cancelable) {
+            const touchobj = e.changedTouches[0];
+            const diff = this.isVertical()
+                ? touchobj.pageY - this.startPos.y
+                : touchobj.pageX - this.startPos.x;
+
+            if (Math.abs(diff) > this.swipeThreshold && e.cancelable) {
                 e.preventDefault();
             }
         },


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/5320 (and address the actual issue with https://github.com/primefaces/primevue/issues/1837) blocking touch scrolling  by only cancelling the touchmove event if we detect a swipe that would change the carousel rather than blocking all touchmove events.