### PR TITLE
fix(Doc): Update DarkModeToggleDoc.vue - class selector needs dot

### DIFF
--- a/doc/theming/styled/DarkModeToggleDoc.vue
+++ b/doc/theming/styled/DarkModeToggleDoc.vue
@@ -32,7 +32,7 @@ app.use(PrimeVue, {
         base: PrimeOne,
         preset: Aura,
         options: {
-            darkModeSelector: 'my-app-dark',
+            darkModeSelector: '.my-app-dark',
         }
     }
  });


### PR DESCRIPTION
The darkModeSelector requires a leading dot for class selectors.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.