### PR TITLE
Fix #5508: InputNumber allow AZERTY keyboards

### DIFF
--- a/components/lib/inputnumber/InputNumber.vue
+++ b/components/lib/inputnumber/InputNumber.vue
@@ -376,7 +376,7 @@ export default {
                 return;
             }
 
-            if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) {
+            if (event.altKey || event.ctrlKey || event.metaKey) {
                 this.isSpecialChar = true;
 
                 return;


### PR DESCRIPTION
Fix #5508: InputNumber allow AZERTY keyboards

Same fix was already implemented and confirmed in PrimeReact