### PR TITLE
fix(sidebar): dismissable property should still be reactive after mount

### DIFF
--- a/components/lib/sidebar/BaseSidebar.vue
+++ b/components/lib/sidebar/BaseSidebar.vue
@@ -52,6 +52,15 @@ export default {
         return {
             $parentInstance: this
         };
-    }
+    },
+    watch: {
+        dismissable(newValue) {
+            if (newValue) {
+                this.bindOutsideClickListener();
+            } else {
+                this.unbindOutsideClickListener();
+            }
+        }
+    },
 };
 </script>

--- a/components/lib/sidebar/Sidebar.spec.js
+++ b/components/lib/sidebar/Sidebar.spec.js
@@ -119,4 +119,12 @@ describe('Sidebar.vue', () => {
 
         expect(wrapper.vm.containerVisible).toBeFalsy();
     });
+
+    it('When component is mounted , dismissable property should still be reactive', async () => {
+        await wrapper.setProps({ dismissable: false, visible: true });
+
+        await wrapper.setProps({ dismissable: true });
+
+        expect(wrapper.vm.containerVisible).toBeTruthy();
+    });
 });


### PR DESCRIPTION
### Defect Fixes

After a `Sidebar` component is already mounted, changing the `dismissable` prop has no effect. The initial value is the one that affects until hiding and re-showing the sidebar.

#### Expected behavior
Even after the sidebar is shown, changing the value of `dismissable` prop should change the dismissability of the component.


Close: #5563 