### PR TITLE
Fixed #1027 - Knob: Allow a label function for greater flexibility

### DIFF
--- a/api-generator/components/knob.js
+++ b/api-generator/components/knob.js
@@ -73,9 +73,9 @@ const KnobProps = [
     },
     {
         name: 'valueTemplate',
-        type: 'string',
-        default: '{value}',
-        description: 'Template string of the value.'
+        type: 'function | string',
+        default: 'val => val',
+        description: 'Controls how the knob is labeled.'
     },
     {
         name: 'tabindex',

--- a/components/lib/knob/BaseKnob.vue
+++ b/components/lib/knob/BaseKnob.vue
@@ -55,8 +55,8 @@ export default {
             default: true
         },
         valueTemplate: {
-            type: String,
-            default: '{value}'
+            type: [String, Function],
+            default: () => (val) => val
         },
         tabindex: {
             type: Number,

--- a/components/lib/knob/Knob.d.ts
+++ b/components/lib/knob/Knob.d.ts
@@ -176,9 +176,9 @@ export interface KnobProps {
     showValue?: boolean | undefined;
     /**
      * Template string of the value.
-     * @defaultValue '{value}'
+     * @defaultValue 'val => val'
      */
-    valueTemplate?: string | undefined;
+    valueTemplate?: (val: number) => string | string | undefined;
     /**
      * Index of the element in tabbing order.
      * @defaultValue 0

--- a/components/lib/knob/Knob.spec.js
+++ b/components/lib/knob/Knob.spec.js
@@ -44,4 +44,16 @@ describe('Knob.vue', () => {
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([30]);
     });
+
+    it('should work with string valueTemplate', async () => {
+        await wrapper.setProps({ valueTemplate: '{value}%' });
+
+        expect(wrapper.find('.p-knob-text').text()).toBe('20%');
+    });
+
+    it('should work with function valueTemplate', async () => {
+        await wrapper.setProps({ valueTemplate: (val) => val * 10 });
+
+        expect(wrapper.find('.p-knob-text').text()).toBe('200');
+    });
 });

--- a/components/lib/knob/Knob.vue
+++ b/components/lib/knob/Knob.vue
@@ -215,7 +215,11 @@ export default {
             return this.valueRadians > this.zeroRadians ? 0 : 1;
         },
         valueToDisplay() {
-            return this.valueTemplate.replace(/{value}/g, this.modelValue);
+            if (typeof this.valueTemplate === 'string') {
+                return this.valueTemplate.replace(/{value}/g, this.modelValue);
+            } else {
+                return this.valueTemplate(this.modelValue);
+            }
         }
     }
 };

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -33423,9 +33423,8 @@
                             "name": "valueTemplate",
                             "optional": true,
                             "readonly": false,
-                            "type": "string",
-                            "default": "'{value}'",
-                            "description": "Template string of the value."
+                            "type": "Function",
+                            "default": ""
                         },
                         {
                             "name": "tabindex",

--- a/doc/knob/TemplateDoc.vue
+++ b/doc/knob/TemplateDoc.vue
@@ -1,9 +1,10 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>Label is a string template that can be customized with the <i>valueTemplate</i> property having <i>60</i> as the placeholder .</p>
+        <p>The label can be customized with the <i>valueTemplate</i> property using either a template string or a function.</p>
     </DocSectionText>
-    <div class="card flex justify-content-center">
+    <div class="card flex justify-content-center gap-4">
         <Knob v-model="value" valueTemplate="{value}%" />
+        <Knob v-model="value" :valueTemplate="(val) => val / 100" />
     </div>
     <DocSectionCode :code="code" />
 </template>
@@ -16,11 +17,13 @@ export default {
             code: {
                 basic: `
 <Knob v-model="value" valueTemplate="{value}%" />
+<Knob v-model="value" :valueTemplate="val => val / 100" />
 `,
                 options: `
 <template>
-    <div class="card flex justify-content-center">
+    <div class="card flex justify-content-center gap-4">
         <Knob v-model="value" valueTemplate="{value}%" />
+        <Knob v-model="value" :valueTemplate="val => val / 100" />
     </div>
 </template>
 
@@ -36,8 +39,9 @@ export default {
 `,
                 composition: `
 <template>
-    <div class="card flex justify-content-center">
+    <div class="card flex justify-content-center gap-4">
         <Knob v-model="value" valueTemplate="{value}%" />
+        <Knob v-model="value" :valueTemplate="val => val / 100" />
     </div>
 </template>
 


### PR DESCRIPTION
## Background

Though #1027 is closed, I had a use case for more flexible labeling and decided to see if I could make this happen. My use case is that I am using the `Knob` component to show progress toward a goal; the data is kept in minutes, but the display should format it to show hours and minutes. There's no way to do that with a template string, so I hope that this PR gets accepted soon.

## Approach

To be honest, this PR isn't doing much that isn't already implemented in https://github.com/kramer99/vue-knob-control/blob/master/src/KnobControl.vue. I retained the ability to pass a template string for backward compatibility. I also specifically checked to make sure that reactivity still works when a function was passed, since that was the original reason to reject #1027.

I also added tests for both a string template and passing a function. Those tests pass, but it looks like `InputNumber` has a couple of failing tests (which were failing before I started work on this - I didn't want to delve into fixing those because it seemed irrelevant to this PR).

I also modified the docs, though the doc structure is a bit confusing and there are no contributing docs or other instructions I could find, so I apologize in advance if I've missed something. Happy to make any changes needed or take any feedback.

Thank you for your hard work! I've been enjoying using PrimeVue to power my app [TrackBear](https://trackbear.dev).