### PR TITLE
fix(#5577): Use event.key instead of event.code for determining digits

### DIFF
--- a/components/lib/inputnumber/InputNumber.vue
+++ b/components/lib/inputnumber/InputNumber.vue
@@ -535,7 +535,7 @@ export default {
                     const isDecimalSign = this.isDecimalSign(char);
                     const isMinusSign = this.isMinusSign(char);
 
-                    if (((event.code.startsWith('Digit') || event.code.startsWith('Numpad')) && Number(char) >= 0 && Number(char) <= 9) || isMinusSign || isDecimalSign) {
+                    if (['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'].includes(char) || isMinusSign || isDecimalSign) {
                         this.insert(event, char, { isDecimalSign, isMinusSign });
                     }
 


### PR DESCRIPTION
event.key could be be used instead of event.code, because event.code doesn't take keyboard layout into account.

This should fix #5577.

"The KeyboardEvent.code property represents a physical key on the keyboard (as opposed to the character generated by pressing the key). In other words, this property returns a value that isn't altered by keyboard layout or the state of the modifier keys."
source: [https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)

"The [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) interface's key read-only property returns the value of the key pressed by the user, taking into consideration the state of modifier keys such as Shift as well as the keyboard locale and layout."
source: [https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)

Thank you for your hard work! I've been enjoying using primevue for my work.