### PR TITLE
Fixed #5596 - Calendar: Hours are set to 00 when clicking the "Today" button

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -1162,9 +1162,9 @@ export default {
             let date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
 
             if (this.showTime) {
-                if (this.hourFormat === '12' && this.currentHour !== 12) {
-                    this.pm ? date.setHours(this.currentHour + 12) : date.setHours(this.currentHour);
-                }
+                (this.hourFormat === '12' && this.currentHour !== 12 && this.pm) ? 
+                    date.setHours(this.currentHour + 12) : 
+                    date.setHours(this.currentHour);
 
                 date.setMinutes(this.currentMinute);
                 date.setSeconds(this.currentSecond);


### PR DESCRIPTION
When the "Today" button is clicked, the hours field is set to 00 instead of the current hour. The minutes field is populated correctly.