### PR TITLE
[FileUpload] Remove incorrect sentence in customUpload prop docs

### DIFF
--- a/api-generator/components/fileupload.js
+++ b/api-generator/components/fileupload.js
@@ -99,7 +99,7 @@ const FileUploadProps = [
         name: 'customUpload',
         type: 'boolean',
         default: 'false',
-        description: 'Whether to use the default upload or a manual implementation defined in uploadHandler callback. Defaults to PrimeVue Locale configuration.'
+        description: 'Whether to use the default upload or a manual implementation defined in uploadHandler callback.'
     },
     {
         name: 'showUploadButton',


### PR DESCRIPTION
This prop is a boolean, not a string, so I was unable to see why the locale was relevant. Seems like a copy/paste artifact.