### PR TITLE
Make DynamicDialog more flexible, fix docs

### DIFF
--- a/components/lib/dialogservice/DialogService.d.ts
+++ b/components/lib/dialogservice/DialogService.d.ts
@@ -18,11 +18,10 @@ export default plugin;
 export interface DialogServiceMethods {
     /**
      * Displays the dialog using the dynamic dialog object options.
-     * @param {*} content - Dynamic component for content template
      * @param {DynamicDialogOptions} options - DynamicDialog Object
      * @return {@link DynamicDialogInstance}
      */
-    open(content: any, options?: DynamicDialogOptions): DynamicDialogInstance;
+    open(options?: DynamicDialogOptions): DynamicDialogInstance;
 }
 
 declare module 'vue/types/vue' {

--- a/components/lib/dialogservice/DialogService.js
+++ b/components/lib/dialogservice/DialogService.js
@@ -5,9 +5,9 @@ import { markRaw } from 'vue';
 export default {
     install: (app) => {
         const DialogService = {
-            open: (content, options) => {
+            open: (options) => {
                 const instance = {
-                    content: content && markRaw(content),
+                    content: options && options.content && markRaw(options.content),
                     options: options || {},
                     data: options && options.data,
                     close: (params) => {

--- a/components/lib/dynamicdialog/DynamicDialog.vue
+++ b/components/lib/dynamicdialog/DynamicDialog.vue
@@ -1,12 +1,15 @@
 <template>
     <template v-for="(instance, key) in instanceMap" :key="key">
-        <DDialog v-model:visible="instance.visible" :_instance="instance" v-bind="instance.options.props" @hide="onDialogHide(instance)" @after-hide="onDialogAfterHide">
+        <DDialog v-model:visible="instance.visible" :_instance="instance" v-bind="instance.options.dialogProps" @hide="onDialogHide(instance)" @after-hide="onDialogAfterHide">
             <template v-if="instance.options.templates && instance.options.templates.header" #header>
-                <component v-for="(header, index) in getTemplateItems(instance.options.templates.header)" :is="header" :key="index + '_header'" v-bind="instance.options.emits"></component>
+                <component v-for="(header, index) in getTemplateItems(instance.options.templates.header)" :is="header" :key="index + '_header'" v-on="instance.options.emits"></component>
             </template>
-            <component :is="instance.content" v-bind="instance.options.emits"></component>
+            <template v-if="instance.options.templates && instance.options.templates.container" #container="{ closeCallback }">
+                <component v-for="(container, index) in getTemplateItems(instance.options.templates.container)" :is="container" :key="index + '_container'" v-bind="{ ...instance.options.props, closeCallback }" v-on="instance.options.emits"></component>
+            </template>
+            <component v-if="instance.content" :is="instance.content" v-bind="instance.options.props" v-on="instance.options.emits"></component>
             <template v-if="instance.options.templates && instance.options.templates.footer" #footer>
-                <component v-for="(footer, index) in getTemplateItems(instance.options.templates.footer)" :is="footer" :key="index + '_footer'" v-bind="instance.options.emits"></component>
+                <component v-for="(footer, index) in getTemplateItems(instance.options.templates.footer)" :is="footer" :key="index + '_footer'" v-on="instance.options.emits"></component>
             </template>
         </DDialog>
     </template>

--- a/components/lib/dynamicdialogoptions/DynamicDialogOptions.d.ts
+++ b/components/lib/dynamicdialogoptions/DynamicDialogOptions.d.ts
@@ -18,6 +18,10 @@ export interface DynamicDialogTemplates {
      */
     header?: any;
     /**
+     * Custom container template.
+     */
+    container?: any;
+    /**
      * Custom footer template.
      */
     footer?: any;
@@ -46,9 +50,13 @@ export interface DynamicDialogCloseOptions {
  */
 export interface DynamicDialogOptions {
     /**
+     * Dynamic component for content template
+    */
+    content?: any;
+    /**
      * Dialog Props
      */
-    props?: DialogProps;
+    dialogProps?: DialogProps;
     /**
      * Dialog Slots
      */
@@ -57,6 +65,14 @@ export interface DynamicDialogOptions {
      * Custom data object
      */
     data?: any;
+    /**
+     * Custom props object
+     */
+    props?: any;
+    /**
+     * Custom emits object
+     */
+    emits?: any;
     /**
      * Closes the dialog.
      */

--- a/doc/dynamicdialog/CustomizationDoc.vue
+++ b/doc/dynamicdialog/CustomizationDoc.vue
@@ -17,8 +17,9 @@ import { useDialog } from 'primevue/usedialog';
 const dialog = useDialog();
 
 const showProducts = () => {
-    dialog.open(ProductListDemo, {
-        props: {
+    dialog.open({
+        content: ProductListDemo,
+        dialogProps: {
             header: 'Product List',
             style: {
                 width: '50vw',

--- a/doc/dynamicdialog/EventsDoc.vue
+++ b/doc/dynamicdialog/EventsDoc.vue
@@ -19,9 +19,12 @@ import { useDialog } from 'primevue/usedialog';
 const dialog = useDialog();
 
 const showProducts = () => {
-    dialog.open(ProductListDemo, {
-        onCancel: (e) => {
-            console.log(e);  // {user: 'primetime'}
+    dialog.open({
+        content: ProductListDemo,
+        emits: {
+            cancel: (e) => {
+                console.log(e);  // {user: 'primetime'}
+            }
         }
     });
 }
@@ -31,10 +34,10 @@ const showProducts = () => {
                 basic: `
 <script setup>
 /* ProductListDemo.vue */
-const emit = defineEmits(['onCancel', 'onSave'])
+const emit = defineEmits(['cancel', 'save'])
 
 function buttonClick() {
-    emit('onCancel', {user: 'primetime'});
+    emit('cancel', {user: 'primetime'});
 }
 <\/script>
 `

--- a/doc/dynamicdialog/ExampleDoc.vue
+++ b/doc/dynamicdialog/ExampleDoc.vue
@@ -42,8 +42,9 @@ const FooterDemo = defineAsyncComponent(() => import('./components/FooterDemo.vu
 export default {
     methods: {
         showProducts() {
-            const dialogRef = this.$dialog.open(ProductListDemo, {
-                props: {
+            const dialogRef = this.$dialog.open({
+                content: ProductListDemo,
+                dialogProps: {
                     header: 'Product List',
                     style: {
                         width: '50vw'
@@ -94,8 +95,9 @@ const dialog = useDialog();
 const toast = useToast();
 
 const showProducts = () => {
-    const dialogRef = dialog.open(ProductListDemo, {
-        props: {
+    const dialogRef = dialog.open({
+        content: ProductListDemo,
+        dialogProps: {
             header: 'Product List',
             style: {
                 width: '50vw',
@@ -123,7 +125,7 @@ const showProducts = () => {
 <\/script>
 `,
                 data: `
-/* ProductService */        
+/* ProductService */
 {
     id: '1000',
     code: 'f230fh0g3',
@@ -186,8 +188,9 @@ export default {
             this.dialogRef.close(data);
         },
         showInfo() {
-            this.$dialog.open(InfoDemo, {
-                props: {
+            this.$dialog.open({
+                content: InfoDemo,
+                dialogProps: {
                     header: 'Information',
                     modal: true,
                     dismissableMask: true
@@ -301,8 +304,9 @@ const selectProduct = (data) => {
 };
 
 const showInfo = () => {
-    dialog.open(InfoDemo, {
-        props: {
+    dialog.open({
+        content: InfoDemo,
+        dialogProps: {
             header: "Information",
             modal: true,
             dismissableMask: true,
@@ -365,8 +369,9 @@ const closeDialog = (e) => {
     },
     methods: {
         showProducts() {
-            const dialogRef = this.$dialog.open(ProductListDemo, {
-                props: {
+            const dialogRef = this.$dialog.open({
+                content: ProductListDemo,
+                dialogProps: {
                     header: 'Product List',
                     style: {
                         width: '50vw'

--- a/doc/dynamicdialog/OpenDialogDoc.vue
+++ b/doc/dynamicdialog/OpenDialogDoc.vue
@@ -19,7 +19,7 @@ import { useDialog } from 'primevue/usedialog';
 const dialog = useDialog();
 
 const showProducts = () => {
-    dialog.open(ProductListDemo, {});
+    dialog.open({ content: ProductListDemo });
 }
 `
             },
@@ -32,7 +32,7 @@ const dialog = useDialog();
 const dynamicComponent = defineAsyncComponent(() => import('./ProductListDemo.vue'));
 
 const showProducts = () => {
-    dialog.open(dynamicComponent, {});
+    dialog.open({ content: dynamicComponent });
 }
 `
             }

--- a/doc/dynamicdialog/PassingDataDoc.vue
+++ b/doc/dynamicdialog/PassingDataDoc.vue
@@ -20,7 +20,8 @@ export default {
 const dialog = useDialog();
 
 const showProducts = () => {
-    dialog.open(ProductListDemo, {
+    dialog.open({
+        content: ProductListDemo,
         data: {
             user: 'primetime'
         }
@@ -44,7 +45,8 @@ onMounted(() => {
 const dialog = useDialog();
 
 const showProducts = () => {
-    dialog.open(ProductListDemo, {
+    dialog.open({
+        content: ProductListDemo,
         onClose: (opt) => {
             const callbackParams = opt.data; // {selectedId: 12}
         }

--- a/doc/dynamicdialog/demo/ProductListDemo.vue
+++ b/doc/dynamicdialog/demo/ProductListDemo.vue
@@ -41,8 +41,9 @@ export default {
             this.dialogRef.close(data);
         },
         showInfo() {
-            this.$dialog.open(InfoDemo, {
-                props: {
+            this.$dialog.open({
+                content: InfoDemo,
+                dialogProps: {
                     header: 'Information',
                     modal: true,
                     dismissableMask: true


### PR DESCRIPTION
This pull request aims to improve the DynamicDialog by making it a bit more flexible to use and also fix a few annoying gripes i've found with it (especially with handling emits and props):

Here's a quick summary:
- **Allow for `container` template**
Pretty self explanatary, it will allow the dynamicDialog to also have a "headless" mode similar to the Dialog component itself.

- **Move content component into obj**
This is caused by the point above, since you don't need a content component if you're declaring the container directly.

- **Seperate child component props & emits**
I've noticed that there's no official documented way to send props to the child component so i've dug deeper and found out that emits just v-bind's directly to the child component. Theoretically you could use `options.emits` to pass props but i've found it kinda weird to use and not logical.

- **Rename dialogProps to seperate from child component props**
Since the dialog also has it own props i've reused the `options.props` for the child component (similar to `options.emits`) and moved the dialog props into `options.dialogProps`.

The changes i've made are **❗BREAKING❗** but i think they offer enough value to justify the additional migration step when updating the library.
