### PR TITLE
fix: prevent autocomplete from jumping to next autocomplete and opening…

### DIFF
--- a/components/lib/autocomplete/AutoComplete.vue
+++ b/components/lib/autocomplete/AutoComplete.vue
@@ -632,6 +632,7 @@ export default {
         },
         onTabKey(event) {
             if (this.focusedOptionIndex !== -1) {
+                event.preventDefault();
                 this.onOptionSelect(event, this.visibleOptions[this.focusedOptionIndex]);
             }
 


### PR DESCRIPTION
When an option is focused while the dropdown is open and pressing the tab key it jumps to the next autocomplete input component and opens the options dropdown and then jumps back to the previous autocomplete input leaving the other one haning. 

This fix prevents jumping to the next input when an option is focused, it selects the value instead like a native dropdown and then pressing tab again jumps to the next input. Fixes dangling dropdown issue.