### PR TITLE
fix pasting on readonly InputNumber

### DIFF
--- a/components/lib/inputnumber/InputNumber.vue
+++ b/components/lib/inputnumber/InputNumber.vue
@@ -550,6 +550,9 @@ export default {
         },
         onPaste(event) {
             event.preventDefault();
+
+            if(this.readonly) return
+
             let data = (event.clipboardData || window['clipboardData']).getData('Text');
 
             if (data) {


### PR DESCRIPTION
This PR addresses the issue mentioned in #5726 . It prevents pasting into readonly inputs, while also fixing the bug where readonly status became irrelevant after pasting.