### PR TITLE
fix(Autocomplete): Cannot set properties of null (setting 'value')

### DIFF
--- a/components/lib/autocomplete/AutoComplete.vue
+++ b/components/lib/autocomplete/AutoComplete.vue
@@ -432,7 +432,7 @@ export default {
                 }
 
                 if (!valid) {
-                    this.$refs.focusInput.value = '';
+                    this.$refs.focusInput?.value = '';
                     this.$emit('clear');
                     !this.multiple && this.updateModel(event, null);
                 }

--- a/components/lib/autocomplete/AutoComplete.vue
+++ b/components/lib/autocomplete/AutoComplete.vue
@@ -431,8 +431,8 @@ export default {
                     }
                 }
 
-                if (!valid) {
-                    this.$refs.focusInput?.value = '';
+                if (!valid && this.$refs.focusInput) {
+                    this.$refs.focusInput.value = '';
                     this.$emit('clear');
                     !this.multiple && this.updateModel(event, null);
                 }


### PR DESCRIPTION
Added a nullable check to fix an issue that was causing app crashes when clicking on `Esc` during search

Fixes https://github.com/primefaces/primevue/issues/5746
