### PR TITLE
Popover: use correct design token for arrow positioning, fixes #5755

### DIFF
--- a/components/lib/popover/Popover.vue
+++ b/components/lib/popover/Popover.vue
@@ -155,7 +155,7 @@ export default {
                 arrowLeft = targetOffset.left - containerOffset.left;
             }
 
-            this.container.style.setProperty($dt('overlay.arrow.left').name, `${arrowLeft}px`);
+            this.container.style.setProperty($dt('popover.arrow.left').name, `${arrowLeft}px`);
 
             if (containerOffset.top < targetOffset.top) {
                 this.container.setAttribute('data-p-popover-flipped', 'true');


### PR DESCRIPTION
###Defect Fixes
This fixes the problem of using an incorrect design token namen for arrow positioning, described in #5755

