### PR TITLE
fix(Dropdown): prevent horizontal scroll, when dropdown item selecting

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -860,7 +860,7 @@ export default {
                 const element = DomHandler.findSingle(this.list, `li[id="${id}"]`);
 
                 if (element) {
-                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
                 } else if (!this.virtualScrollerDisabled) {
                     this.virtualScroller && this.virtualScroller.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex);
                 }


### PR DESCRIPTION
## Defect Fixes
- fixed #4488 

<br/>

## Testing & Resolve method
### Issue generation condition
- Horizontal scrolling occurs at the top-level element.
- There is a dropdown inside a dialog modal.
- When opening the modal and trying to select from the dropdown, the horizontal scroll shifts.

<br/>

### How to Issue Generation
- If you want to reproduce the issue, you can add the following code in the master branch and test it.
> assets/styles/layout/_core.scss
```scss
// overflow-x: hidden;
```
> pages/sample/index.vue
```vue
<template>
    <div>
        <div :style="{ backgroundColor: 'red', width: '200vw', height: '20px' }"></div>
        <Dialog v-model:visible="visible" modal header="My modal" :style="{ width: '50vw' }">
            <Dropdown v-model="selected" :options="items" placeholder="Select an item" />
        </Dialog>
        <Button label="Open Modal" @click="visible = true" />
    </div>
</template>

<script>
import Dropdown from 'primevue/dropdown';
import Dialog from 'primevue/dialog';
import Button from 'primevue/button';
export default {
    setup() {
        definePageMeta({
            layout: ''
        });
    },
    data() {
        return {
            visible: false,
            selected: null,
            items: [
                { label: 'Item 1', value: 'Item 1' },
                { label: 'Item 2', value: 'Item 2' },
                { label: 'Item 3', value: 'Item 3' }
            ]
        };
    },
    components: {
        Dropdown,
        Dialog,
        Button
    }
};
</script>
```

<br/>

- And, as shown in the video below, horizontal scrolling occurs when trying to select a dropdown item. ( http://localhost:3000/sample)
```
npm run dev
```

https://github.com/primefaces/primevue/assets/37934668/33b48075-b510-4065-bb6f-ef84144d5b3a


<br/>

### How to resolve
- The reason for the horizontal scrolling is that the logic for moving the horizontal scroll of the dropdown is triggered when trying to select a dropdown item.
- Therefore, preventing the horizontal scroll movement will stop the issue from occurring.
```js
// before
 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' }); // cause: "inline: start"
```
```js
// after
 element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
```