### PR TITLE
fix(DataTable): allow control c key for copy a table content. (#5757)

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -869,8 +869,9 @@ export default {
                             const data = this.dataToRender(slotProps.rows);
 
                             this.$emit('update:selection', data);
-                            event.preventDefault();
                         }
+
+                        if (event.code === 'KeyA' && metaKey) event.preventDefault();
 
                         break;
                 }

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -871,7 +871,9 @@ export default {
                             this.$emit('update:selection', data);
                         }
 
-                        if (event.code === 'KeyA' && metaKey) event.preventDefault();
+                        const isCopyShortcut = event.code === 'KeyC' && metaKey;
+
+                        if (!isCopyShortcut) event.preventDefault();
 
                         break;
                 }

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -871,8 +871,6 @@ export default {
                             this.$emit('update:selection', data);
                         }
 
-                        event.preventDefault();
-
                         break;
                 }
             }

--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -869,6 +869,7 @@ export default {
                             const data = this.dataToRender(slotProps.rows);
 
                             this.$emit('update:selection', data);
+                            event.preventDefault();
                         }
 
                         break;


### PR DESCRIPTION
### Defect Fixes
- fixed #5757

### Solution Direction
- I have modified the code to meet the following conditions :)
		- `control + c` is working
		- when multiple select mode, `control + a` is working and outer content of table is not select.
		- when single select mode, `control + a` is not working and outer content of table is not select.


https://github.com/primefaces/primevue/assets/37934668/91732b7e-4472-4acc-8f48-ceb23a5a2bbe

