### PR TITLE
Sass, not SASS

### DIFF
--- a/assets/menu/menu.json
+++ b/assets/menu/menu.json
@@ -503,7 +503,7 @@
                             "to": "/colors"
                         },
                         {
-                            "name": "SASS API",
+                            "name": "Sass API",
                             "href": "https://www.primefaces.org/designer/api/primevue/3.9.0"
                         }
                     ]


### PR DESCRIPTION
There are 3 meanings to the word "Sass":

* **The Syntax** - "Sass" or "Indented syntax" is a white-space dependent implementation of the language without curly braces or semi-colons. Since the other syntax, "SCSS", stands for "Sassy Cascading Style Sheets", a *bacronym* was created for "Syntactically Awesome Style Sheets". Despite having an acronym, "Sass" has officially *never* been put in all caps.
* **The Language** - "Sass" is generally used to refer to both syntax options, as they are 100% interchangeable, supporting identical features, in slightly different syntax.
* **The Processor** - A tool to process `.sass` and `.scss` files to valid `.css`. Technically there are many processors that exist to do this task, but when speaking genrally about them, they are often referred to as just "Sass processors" or "Sass" for short.

In all cases, "Sass" is never put in all caps.

* https://SassNotSASS.com
