### PR TITLE
doc(Tabs/TabMenu): add missing Tabs component to sample code

### DIFF
--- a/doc/tabs/TabMenuDoc.vue
+++ b/doc/tabs/TabMenuDoc.vue
@@ -30,30 +30,34 @@ export default {
             ],
             code: {
                 basic: `
-<TabList>
-    <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
-        <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
-            <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
-                <i :class="tab.icon" />
-                <span>{{ tab.label }}</span>
-            </a>
-        </router-link>
-    </Tab>
-</TabList>
+<Tabs value="/dashboard">
+    <TabList>
+        <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
+            <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
+                <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
+                    <i :class="tab.icon" />
+                    <span>{{ tab.label }}</span>
+                </a>
+            </router-link>
+        </Tab>
+    </TabList>
+</Tabs>
 `,
                 options: `
 <template>
     <div class="card">
-        <TabList>
-            <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
-                <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
-                    <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
-                        <i :class="tab.icon" />
-                        <span>{{ tab.label }}</span>
-                    </a>
-                </router-link>
-            </Tab>
-        </TabList>
+        <Tabs value="/dashboard">
+            <TabList>
+                <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
+                    <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
+                        <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
+                            <i :class="tab.icon" />
+                            <span>{{ tab.label }}</span>
+                        </a>
+                    </router-link>
+                </Tab>
+            </TabList>
+        </Tabs>
     </div>
 </template>
 
@@ -75,16 +79,18 @@ export default {
                 composition: `
 <template>
     <div class="card">
-        <TabList>
-            <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
-                <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
-                    <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
-                        <i :class="tab.icon" />
-                        <span>{{ tab.label }}</span>
-                    </a>
-                </router-link>
-            </Tab>
-        </TabList>
+        <Tabs value="/dashboard">
+            <TabList>
+                <Tab v-for="tab in items" :key="tab.label" :value="tab.route">
+                    <router-link v-if="tab.route" v-slot="{ href, navigate }" :to="tab.route" custom>
+                        <a v-ripple :href="href" @click="navigate" class="flex items-center gap-2 text-inherit">
+                            <i :class="tab.icon" />
+                            <span>{{ tab.label }}</span>
+                        </a>
+                    </router-link>
+                </Tab>
+            </TabList>
+        </Tabs>
     </div>
 </template>
 


### PR DESCRIPTION
###Defect Fixes
The docs sample code TabMenu in Tabs is currently missing the Tabs component around with. TabList requires to be embedded in a Tabs component. Without the component there will be $pcTabs errors. 

This patch adds the Tabs component to the sample code. The stackblitz has to be updated as well. 