### PR TITLE
types: Make TreeNode.key required

### DIFF
--- a/components/lib/treenode/TreeNode.d.ts
+++ b/components/lib/treenode/TreeNode.d.ts
@@ -13,7 +13,7 @@ export interface TreeNode {
     /**
      * Mandatory unique key of the node.
      */
-    key?: string;
+    key: string;
     /**
      * Label of the node.
      */


### PR DESCRIPTION
This property is documented as mandatory.

Suggesting to remove `?` so that in my own code I no longer have to add not-null assertions like `.node.key!`.