### PR TITLE
Fix documented default for emptyMessage on several components

### DIFF
--- a/components/lib/dropdown/Dropdown.d.ts
+++ b/components/lib/dropdown/Dropdown.d.ts
@@ -484,7 +484,7 @@ export interface DropdownProps {
     emptyFilterMessage?: string | undefined;
     /**
      * Text to display when there are no options available. Defaults to value from PrimeVue locale configuration.
-     * @defaultValue No results found
+     * @defaultValue No available options
      */
     emptyMessage?: string | undefined;
     /**

--- a/components/lib/listbox/Listbox.d.ts
+++ b/components/lib/listbox/Listbox.d.ts
@@ -333,7 +333,7 @@ export interface ListboxProps {
     emptyFilterMessage?: string | undefined;
     /**
      * Text to display when there are no options available. Defaults to value from PrimeVue locale configuration.
-     * @defaultValue No results found
+     * @defaultValue No available options
      */
     emptyMessage?: string | undefined;
     /**

--- a/components/lib/multiselect/MultiSelect.d.ts
+++ b/components/lib/multiselect/MultiSelect.d.ts
@@ -520,7 +520,7 @@ export interface MultiSelectProps {
     emptyFilterMessage?: string | undefined;
     /**
      * Text to display when there are no options available. Defaults to value from PrimeVue locale configuration.
-     * @defaultValue No results found'
+     * @defaultValue No available options
      */
     emptyMessage?: string | undefined;
     /**

--- a/components/lib/treeselect/TreeSelect.d.ts
+++ b/components/lib/treeselect/TreeSelect.d.ts
@@ -213,7 +213,7 @@ export interface TreeSelectProps {
     appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
     /**
      * Text to display when there are no options available. Defaults to value from PrimeVue locale configuration.
-     * @defaultValue No results found
+     * @defaultValue No available options
      */
     emptyMessage?: string | undefined;
     /**

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -25101,7 +25101,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No results found",
+                            "default": "No available options",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -34532,7 +34532,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No results found",
+                            "default": "No available options",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -38729,7 +38729,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No results found'",
+                            "default": "No available options",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -58396,7 +58396,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No results found",
+                            "default": "No available options",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {

--- a/doc/common/apidoc/index.json
+++ b/doc/common/apidoc/index.json
@@ -25101,7 +25101,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No available options",
+                            "default": "No results found",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -34532,7 +34532,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No available options",
+                            "default": "No results found",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -38729,7 +38729,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No available options",
+                            "default": "No results found'",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {
@@ -58396,7 +58396,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "No available options",
+                            "default": "No results found",
                             "description": "Text to display when there are no options available. Defaults to value from PrimeVue locale configuration."
                         },
                         {


### PR DESCRIPTION
Fixed the documented default value for the "emptyMessage" property for the Dropdown, Listbox, MultiSelect and TreeSelect components. They were all incorrectly documented as having a default value of "No results found". I changed each one to "No available options".