### PR TITLE
fix(Dialog): prevent unblock of scroll when even one dialog is open

### DIFF
--- a/components/lib/dialog/Dialog.vue
+++ b/components/lib/dialog/Dialog.vue
@@ -226,7 +226,7 @@ export default {
         },
         unblockScroll() {
             // TODO: refactor this to use a better way to check if there are any dialogs opened
-            const dialogMap = this.$parentInstance.instanceMap;
+            const dialogMap = this.$parentInstance?.instanceMap || {};
             const isDialogsOpened = Object.values(dialogMap).some((instance) => instance.visible);
 
             if (!isDialogsOpened) DomHandler.unblockBodyScroll();

--- a/components/lib/dialog/Dialog.vue
+++ b/components/lib/dialog/Dialog.vue
@@ -211,7 +211,7 @@ export default {
             }
 
             if (!this.modal) {
-                this.maximized ? DomHandler.blockBodyScroll() : DomHandler.unblockBodyScroll();
+                this.maximized ? DomHandler.blockBodyScroll() : this.unblockScroll();
             }
         },
         enableDocumentSettings() {
@@ -221,8 +221,15 @@ export default {
         },
         unbindDocumentState() {
             if (this.modal || (!this.modal && this.blockScroll) || (this.maximizable && this.maximized)) {
-                DomHandler.unblockBodyScroll();
+                this.unblockScroll();
             }
+        },
+        unblockScroll() {
+            // TODO: refactor this to use a better way to check if there are any dialogs opened
+            const dialogMap = this.$parentInstance.instanceMap;
+            const isDialogsOpened = Object.values(dialogMap).some((instance) => instance.visible);
+
+            if (!isDialogsOpened) DomHandler.unblockBodyScroll();
         },
         onKeyDown(event) {
             if (event.code === 'Escape' && this.closeOnEscape) {

--- a/components/lib/utils/DomHandler.js
+++ b/components/lib/utils/DomHandler.js
@@ -849,11 +849,19 @@ export default {
     },
 
     blockBodyScroll(className = 'p-overflow-hidden') {
+        const isBlocked = document.body.classList.contains(className);
+
+        if (isBlocked) return;
+
         document.body.style.setProperty('--scrollbar-width', this.calculateBodyScrollbarWidth() + 'px');
         this.addClass(document.body, className);
     },
 
     unblockBodyScroll(className = 'p-overflow-hidden') {
+        const isBlocked = document.body.classList.contains(className);
+
+        if (!isBlocked) return;
+
         document.body.style.removeProperty('--scrollbar-width');
         this.removeClass(document.body, className);
     }


### PR DESCRIPTION
### Defect Fixes
- fixed #4563

|Commit|description |
|---|---|
|[99441eb](https://github.com/primefaces/primevue/pull/5854/commits/99441eb233c645c5b6a1ef2266beeb75d42ab079)|Fix the issue where the scroll width is redundantly removed from the content width when an additional dialog is opened.|
|[bfb4690](https://github.com/primefaces/primevue/pull/5854/commits/bfb46909ba42b7d43e8760184d5d2499100ddcc6)|Keep the scroll disabled as long as at least one dialog is open.|