### PR TITLE
fix(Calendar): keep the overlay open when event triggered from panel

### DIFF
--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -993,7 +993,10 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.isOutsideClicked(event)) {
+                     const panelElement = event.target.closest('[data-pc-section="panel"]');
+                     const isElementInPanel = panelElement && panelElement.contains(event.target);
+
+                    if (this.overlayVisible && this.isOutsideClicked(event) && !isElementInPanel) {
                         this.overlayVisible = false;
                     }
                 };

--- a/components/lib/calendar/Calendar.vue
+++ b/components/lib/calendar/Calendar.vue
@@ -993,8 +993,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                     const panelElement = event.target.closest('[data-pc-section="panel"]');
-                     const isElementInPanel = panelElement && panelElement.contains(event.target);
+                    const panelElement = event.target.closest('[data-pc-section="panel"]');
+                    const isElementInPanel = panelElement && panelElement.contains(event.target);
 
                     if (this.overlayVisible && this.isOutsideClicked(event) && !isElementInPanel) {
                         this.overlayVisible = false;


### PR DESCRIPTION
### Defect Fixes
- fix #4240

### how to resolve
- In `panelMenuList.vue`, whether a specific element is a panel is determined by the following code.

https://github.com/primefaces/primevue/blob/38a334a16bae2bfbe6f5d11cfee1a289beb85545/components/lib/panelmenu/PanelMenuList.vue#L235

- The dropdown list appears in the body area, so it's difficult to know if the dropdown belongs to the calendar using the usual methods.
- Therefore, we check if the event occurred within the panel, and if the event occurred within the panel, we keep the overlay open.
