### PR TITLE
fix(types): DataTable: add function support to DataTableSortMeta field

### DIFF
--- a/components/lib/datatable/DataTable.d.ts
+++ b/components/lib/datatable/DataTable.d.ts
@@ -128,7 +128,7 @@ export interface DataTableSortMeta {
     /**
      * Column field
      */
-    field: string;
+    field: string | ((item: any) => string) | undefined;
     /**
      * Column sort order
      */


### PR DESCRIPTION
Fixes #5862

Change DataTableSortMeta `field` type to match DataTableSortEvent `sortField` type.