### PR TITLE
fix(Dropdown): apply modelValue to label, if the modelValue exist

### DIFF
--- a/components/lib/dropdown/Dropdown.vue
+++ b/components/lib/dropdown/Dropdown.vue
@@ -932,7 +932,13 @@ export default {
         label() {
             const selectedOptionIndex = this.findSelectedOptionIndex();
 
-            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+            if (selectedOptionIndex !== -1) {
+                return this.getOptionLabel(this.visibleOptions[selectedOptionIndex]);
+            } else {
+                const selectedValue = this.getOptionLabel(this.modelValue);
+
+                return selectedValue || this.placeholder || 'p-emptylabel';
+            }
         },
         editableInputValue() {
             const selectedOptionIndex = this.findSelectedOptionIndex();


### PR DESCRIPTION
## Defect Fixes
- fix #4054 

<br/>

## Issue description
### issue condition
1. When an option is selected from the dropdown, the `aria-label` is set to the label value of the selected item (`aria-label="Australia"`).

<img width="1383" alt="스크린샷 2024-06-11 오후 3 01 59" src="https://github.com/primefaces/primevue/assets/37934668/3af7b8ec-308e-40bc-8839-7582da643df4">

<br/><br/>

2. If a search is performed with characters not included in "Australia", the `aria-label` becomes empty.

<img width="1365" alt="스크린샷 2024-06-11 오후 3 02 09" src="https://github.com/primefaces/primevue/assets/37934668/47bf624e-0e50-413e-b0df-4ce513596426">

<br/><br/>

### how to resolve
If there is an already selected value (modelValue), modify it to display the label of the modelValue.