### PR TITLE
fix: multiselect concat the value

### DIFF
--- a/components/lib/multiselect/MultiSelect.vue
+++ b/components/lib/multiselect/MultiSelect.vue
@@ -804,9 +804,10 @@ export default {
             if (this.selectAll !== null) {
                 this.$emit('selectall-change', { originalEvent: event, checked: !this.allSelected });
             } else {
-                const value = this.allSelected ? [] : this.visibleOptions.filter((option) => this.isValidOption(option)).map((option) => this.getOptionValue(option));
-
-                this.updateModel(event, value);
+                let currentSelectedValues = this.modelValue || [];
+                let visibleOptionsValues = this.visibleOptions.filter(option => this.isValidOption(option)).map(option => this.getOptionValue(option));
+                let mergedValues = [...new Set([...currentSelectedValues, ...visibleOptionsValues])];
+                this.updateModel(event, mergedValues);
             }
         },
         removeOption(event, optionValue) {


### PR DESCRIPTION
When i select some value and after this i filter some specific value and click to select all, this lost first selection only show the selected with filter value.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
My ISSUE about the PR.
https://github.com/primefaces/primevue/issues/5873

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.