### PR TITLE
refactor: update Badge URL of packages version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ PrimeVue is a rich set of open source UI Components for Vue. See [PrimeVue homep
 | Name | Version |
 | --- | --- |
 | [primevue](https://github.com/primefaces/primevue/tree/master/packages/primevue) | [![npm version](https://badge.fury.io/js/primevue.svg)](https://badge.fury.io/js/primevue) |
-| [@primevue/core](https://github.com/primefaces/primevue/tree/master/packages/core) | [![npm version](https://badge.fury.io/js/@primevue/core.svg)](https://badge.fury.io/js/@primevue/core) |
-| [@primevue/icons](https://github.com/primefaces/primevue/tree/master/packages/icons) | [![npm version](https://badge.fury.io/js/@primevue/icons.svg)](https://badge.fury.io/js/@primevue/icons) |
-| [@primevue/themes](https://github.com/primefaces/primevue/tree/master/packages/themes) | [![npm version](https://badge.fury.io/js/@primevue/themes.svg)](https://badge.fury.io/js/@primevue/themes) |
-| [@primevue/nuxt-module](https://github.com/primefaces/primevue/tree/master/packages/nuxt-module) | [![npm version](https://badge.fury.io/js/@primevue/nuxt-module.svg)](https://badge.fury.io/js/@primevue/nuxt-module) |
-| [@primevue/auto-import-resolver](https://github.com/primefaces/primevue/tree/master/packages/auto-import-resolver) | [![npm version](https://badge.fury.io/js/@primevue/auto-import-resolver.svg)](https://badge.fury.io/js/@primevue/auto-import-resolver) |
-| [@primevue/metadata](https://github.com/primefaces/primevue/tree/master/packages/metadata) | [![npm version](https://badge.fury.io/js/@primevue/metadata.svg)](https://badge.fury.io/js/@primevue/metadata) |
+| [@primevue/core](https://github.com/primefaces/primevue/tree/master/packages/core) | [![npm version](https://badge.fury.io/js/@primevue%2Fcore.svg)](https://badge.fury.io/js/@primevue%2Fcore) |
+| [@primevue/icons](https://github.com/primefaces/primevue/tree/master/packages/icons) | [![npm version](https://badge.fury.io/js/@primevue%2Ficons.svg)](https://badge.fury.io/js/@primevue%2Ficons) |
+| [@primevue/themes](https://github.com/primefaces/primevue/tree/master/packages/themes) | [![npm version](https://badge.fury.io/js/@primevue%2Fthemes.svg)](https://badge.fury.io/js/@primevue%2Fthemes) |
+| [@primevue/nuxt-module](https://github.com/primefaces/primevue/tree/master/packages/nuxt-module) | [![npm version](https://badge.fury.io/js/@primevue%2Fnuxt-module.svg)](https://badge.fury.io/js/@primevue%2Fnuxt-module) |
+| [@primevue/auto-import-resolver](https://github.com/primefaces/primevue/tree/master/packages/auto-import-resolver) | [![npm version](https://badge.fury.io/js/@primevue%2Fauto-import-resolver.svg)](https://badge.fury.io/js/@primevue%2Fauto-import-resolver) |
+| [@primevue/metadata](https://github.com/primefaces/primevue/tree/master/packages/metadata) | [![npm version](https://badge.fury.io/js/@primevue%2Fmetadata.svg)](https://badge.fury.io/js/@primevue%2Fmetadata) |
 
 ## Contributors
 


### PR DESCRIPTION
@mertsincan
## Issue
The package version not showing.
![version not showing](https://github.com/primefaces/primevue/assets/60002195/61c83ba4-ef52-48fe-b579-8ea470f696d8)

## Solution
The URL of the icon has been changed
![URL updated](https://github.com/primefaces/primevue/assets/60002195/8a9530f2-7b5a-4a61-b1e2-8be77cade288)
