### PR TITLE
fix: TreeNode selectable not being used when in checkbox selectionMode

### DIFF
--- a/components/lib/tree/TreeNode.vue
+++ b/components/lib/tree/TreeNode.vue
@@ -142,7 +142,9 @@ export default {
             }
 
             if (this.isCheckboxSelectionMode()) {
-                this.toggleCheckbox();
+                if (this.node.selectable != false) {
+                    this.toggleCheckbox();
+                }                
             } else {
                 this.$emit('node-click', {
                     originalEvent: event,
@@ -336,7 +338,7 @@ export default {
             });
         },
         propagateDown(node, check, selectionKeys) {
-            if (check) selectionKeys[node.key] = { checked: true, partialChecked: false };
+            if (check && node.selectable != false) selectionKeys[node.key] = { checked: true, partialChecked: false };
             else delete selectionKeys[node.key];
 
             if (node.children && node.children.length) {


### PR DESCRIPTION
If node selectable is false then clicking the node shouldn't add the node to selectedKeys.

added selectable != false because selectable can be null | undefined | true to show the checkbox.

###Defect Fixes
Fix for #5330 
