### PR TITLE
FilterService `noop` filter

### DIFF
--- a/packages/core/src/api/Api.d.ts
+++ b/packages/core/src/api/Api.d.ts
@@ -16,6 +16,7 @@ export interface FilterMatchModeOptions {
     readonly DATE_IS_NOT: string;
     readonly DATE_BEFORE: string;
     readonly DATE_AFTER: string;
+    readonly NOOP: string;
 }
 
 export declare const FilterMatchMode: FilterMatchModeOptions;

--- a/packages/core/src/api/FilterMatchMode.js
+++ b/packages/core/src/api/FilterMatchMode.js
@@ -14,7 +14,8 @@ const FilterMatchMode = {
     DATE_IS: 'dateIs',
     DATE_IS_NOT: 'dateIsNot',
     DATE_BEFORE: 'dateBefore',
-    DATE_AFTER: 'dateAfter'
+    DATE_AFTER: 'dateAfter',
+    NOOP: 'noop',
 };
 
 export default FilterMatchMode;

--- a/packages/core/src/api/FilterService.js
+++ b/packages/core/src/api/FilterService.js
@@ -225,7 +225,10 @@ const FilterService = {
             }
 
             return value.getTime() > filter.getTime();
-        }
+        },
+        noop(value, filter) {
+            return true;
+        },
     },
     register(rule, fn) {
         this.filters[rule] = fn;


### PR DESCRIPTION
## Motivation 
It would be nice to have a Filter Container inside `ListBox` which does not execute any filtering logic on options, leaving `filter` emit  handler to be in charge of filtering.

Example: if options array is being fed from an API with filtering support.

## Results
This PR adds `noop` filter to FilterService.
