### PR TITLE
feat(Select): add closeOnSelect prop

### DIFF
--- a/packages/primevue/src/select/BaseSelect.vue
+++ b/packages/primevue/src/select/BaseSelect.vue
@@ -181,6 +181,10 @@ export default {
         ariaLabelledby: {
             type: String,
             default: null
+        },
+        closeOnSelect: {
+            type: Boolean,
+            default: true
         }
     },
     style: SelectStyle,

--- a/packages/primevue/src/select/Select.d.ts
+++ b/packages/primevue/src/select/Select.d.ts
@@ -421,6 +421,11 @@ export interface SelectProps {
      */
     overlayClass?: string | object | undefined;
     /**
+     * Closes the dropdown when option is selected.
+     * @defaultValue true
+     */
+    closeOnSelect?: boolean;
+    /**
      * A valid query selector or an HTMLElement to specify where the overlay gets attached.
      * @defaultValue body
      */

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -468,7 +468,7 @@ export default {
 
             DomHandler.focus(focusableEl);
         },
-        onOptionSelect(event, option, isHide = true) {
+        onOptionSelect(event, option, isHide = this.closeOnSelect) {
             const value = this.getOptionValue(option);
 
             this.updateModel(event, value);
@@ -570,7 +570,7 @@ export default {
                     this.onOptionSelect(event, this.visibleOptions[this.focusedOptionIndex]);
                 }
 
-                this.overlayVisible && this.hide();
+                this.closeOnSelect && this.overlayVisible && this.hide();
                 event.preventDefault();
             } else {
                 const optionIndex = this.focusedOptionIndex !== -1 ? this.findPrevOptionIndex(this.focusedOptionIndex) : this.clicked ? this.findLastOptionIndex() : this.findLastFocusedOptionIndex();
@@ -639,7 +639,7 @@ export default {
                     this.onOptionSelect(event, this.visibleOptions[this.focusedOptionIndex]);
                 }
 
-                this.hide();
+                this.closeOnSelect && this.hide();
             }
 
             event.preventDefault();


### PR DESCRIPTION
**What was done**
closeOnSelect prop was added to the Select component. By activating it, the dropdown won't be closed after the option is selected.

**Motivation:**
it's crucial to have control over this to load more data when the option is selected or the user should confirm the choice.

**Help needed**
I couldn't find a way to update the docs, so please guide me on how to do that.