### PR TITLE
Fix ConfirmPopup placement on stopped events

### DIFF
--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -173,6 +173,8 @@ export default {
             this.autoFocusAccept = this.confirmation.defaultFocus === undefined || this.confirmation.defaultFocus === 'accept' ? true : false;
             this.autoFocusReject = this.confirmation.defaultFocus === 'reject' ? true : false;
 
+            this.alignOverlay();
+
             this.bindOutsideClickListener();
             this.bindScrollListener();
             this.bindResizeListener();
@@ -220,8 +222,6 @@ export default {
                         }
 
                         this.visible = false;
-                    } else {
-                        this.alignOverlay();
                     }
                 };
 


### PR DESCRIPTION
The previous implementation only sets the ConfirmPopup position in bindOutsideClickListener, when a click is registered on the root window that isn't on the popup itself.

This is an issue, as it does not work if the click event that caused the popup to appear does not propagate up to the root window.

Instead, this change always positions the window when it appears. This is already what the Popover component does, which does not exhibits the same bug.


### Defect Fixes

Fix #5929 