### PR TITLE
fix(Checkbox): use correct design token for checkbox height

### DIFF
--- a/packages/primevue/src/checkbox/style/CheckboxStyle.js
+++ b/packages/primevue/src/checkbox/style/CheckboxStyle.js
@@ -35,7 +35,7 @@ const theme = ({ dt }) => `
     border: 1px solid ${dt('checkbox.border.color')};
     background: ${dt('checkbox.background')};
     width: ${dt('checkbox.width')};
-    height: ${dt('checkbox.width')};
+    height: ${dt('checkbox.height')};
     transition: background ${dt('checkbox.transition.duration')}, color ${dt('checkbox.transition.duration')}, border-color ${dt('checkbox.transition.duration')}, box-shadow ${dt('checkbox.transition.duration')}, outline-color ${dt(
     'checkbox.transition.duration'
 )};


### PR DESCRIPTION
###Defect Fixes
The checkbox box currently uses the width design token for the height property. This fix changes it to the height token.
