### PR TITLE
feat(Checkbox): add indeterminate state to icon slot, fixes #5942

### DIFF
--- a/packages/primevue/src/checkbox/Checkbox.d.ts
+++ b/packages/primevue/src/checkbox/Checkbox.d.ts
@@ -226,6 +226,10 @@ export interface CheckboxSlots {
          */
         checked: boolean;
         /**
+         * Indeterminate state of the checkbox.
+         */
+        indeterminate?: boolean | undefined;
+        /**
          * Style class of the icon.
          */
         class: string;

--- a/packages/primevue/src/checkbox/Checkbox.vue
+++ b/packages/primevue/src/checkbox/Checkbox.vue
@@ -22,7 +22,7 @@
             v-bind="getPTOptions('input')"
         />
         <div :class="cx('box')" v-bind="getPTOptions('box')">
-            <slot name="icon" :checked="checked" :class="cx('icon')">
+            <slot name="icon" :checked="checked" :indeterminate="d_indeterminate" :class="cx('icon')">
                 <CheckIcon v-if="checked" :class="cx('icon')" v-bind="getPTOptions('icon')" />
                 <MinusIcon v-else-if="d_indeterminate" :class="cx('icon')" v-bind="getPTOptions('icon')" />
             </slot>


### PR DESCRIPTION
###Defect Fixes
This PR adds the indeterminate state to the icon slot so it will be possible to customize the indeterminate icon as well as customize the unchecked icon when using indeterminate. 

Fixes #5942