### PR TITLE
Fixed execution of a context menu action on the Enter key when the "item" template has been redefined

### DIFF
--- a/components/lib/contextmenu/ContextMenu.vue
+++ b/components/lib/contextmenu/ContextMenu.vue
@@ -321,7 +321,7 @@ export default {
         onEnterKey(event) {
             if (this.focusedItemInfo.index !== -1) {
                 const element = DomHandler.findSingle(this.list, `li[id="${`${this.focusedItemIdx}`}"]`);
-                const anchorElement = element && DomHandler.findSingle(element, 'a[data-pc-section="action"]');
+                const anchorElement = element && DomHandler.findSingle(element, '[data-pc-section="action"]');
 
                 anchorElement ? anchorElement.click() : element && element.click();
                 const processedItem = this.visibleItems[this.focusedItemInfo.index];


### PR DESCRIPTION
The selector for the anchor element of the Enter key event is not the same on the `ContextMenu` and `TieredMenu` components :
* TieredMenu : `[data-pc-section="action"]`
* ContextMenu : `a[data-pc-section="action"]`

The problem with the `ContextMenu` selector is that the Enter key does nothing once the item template has been redefined : 
```html
<ContextMenu :model="items">
  <template #item="{ item, props }">
      <div v-bind="{ ...props.action, ...item.attributes }">
        <span>{{ item.label }}</span>
      </div>
  </template>
</ContextMenu>
```

There's no such problem with the `TieredMenu` component.

This PR changes the selector to use the same one as the `TieredMenu` component.
