### PR TITLE
Fix(DataTable): display groupfooter and groupheader 

### DIFF
--- a/apps/showcase/doc/datatable/rowgroup/SubHeaderRowGroupDoc.vue
+++ b/apps/showcase/doc/datatable/rowgroup/SubHeaderRowGroupDoc.vue
@@ -1,7 +1,7 @@
 <template>
     <DocSectionText v-bind="$attrs">
         <p>
-            Rows are grouped with the <i>groupRowsBy</i> property. When <i>rowGroupMode</i> is set as <i>subheader</i>, a header and footer can be displayed for each group. The content of a group header is provided with <i>groupheader</i> and footer
+            Rows are grouped with the <i>groupRowsBy</i> property. When <i>rowGroupMode</i> is set, a header and footer can be displayed for each group. The content of a group header is provided with <i>groupheader</i> and footer
             with <i>groupfooter</i> slots.
         </p>
     </DocSectionText>

--- a/packages/primevue/src/datatable/BodyRow.vue
+++ b/packages/primevue/src/datatable/BodyRow.vue
@@ -1,7 +1,7 @@
 <template>
     <template v-if="!empty">
-        <tr v-if="templates['groupheader'] && rowGroupMode === 'subheader' && shouldRenderRowGroupHeader" :class="cx('rowGroupHeader')" :style="rowGroupHeaderStyle" role="row" v-bind="ptm('rowGroupHeader')">
-            <td :colspan="columnsLength - 1" v-bind="{ ...getColumnPT('bodycell'), ...ptm('rowGroupHeaderCell') }">
+        <tr v-if="templates['groupheader'] && rowGroupMode && shouldRenderRowGroupHeader" :class="cx('rowGroupHeader')" :style="rowGroupHeaderStyle" role="row" v-bind="ptm('rowGroupHeader')">
+            <td :colspan="columnsLength" v-bind="{ ...getColumnPT('bodycell'), ...ptm('rowGroupHeaderCell') }">
                 <button v-if="expandableRowGroups" :class="cx('rowToggleButton')" @click="onRowGroupToggle" type="button" v-bind="ptm('rowToggleButton')">
                     <component v-if="templates['rowtoggleicon'] || templates['rowgrouptogglericon']" :is="templates['rowtoggleicon'] || templates['rowgrouptogglericon']" :expanded="isRowGroupExpanded" />
                     <template v-else>
@@ -79,8 +79,8 @@
                 <component :is="templates['expansion']" :data="rowData" :index="rowIndex" />
             </td>
         </tr>
-        <tr v-if="templates['groupfooter'] && rowGroupMode === 'subheader' && shouldRenderRowGroupFooter" :class="cx('rowGroupFooter')" role="row" v-bind="ptm('rowGroupFooter')">
-            <td :colspan="columnsLength - 1" v-bind="{ ...getColumnPT('bodycell'), ...ptm('rowGroupFooterCell') }">
+        <tr v-if="templates['groupfooter'] && rowGroupMode && shouldRenderRowGroupFooter" :class="cx('rowGroupFooter')" role="row" v-bind="ptm('rowGroupFooter')">
+            <td :colspan="columnsLength" v-bind="{ ...getColumnPT('bodycell'), ...ptm('rowGroupFooterCell') }">
                 <component :is="templates['groupfooter']" :data="rowData" :index="rowIndex" />
             </td>
         </tr>


### PR DESCRIPTION
###Defect Fixes
This PR adds the ability to display BodyRows templates "groupfooter" and "groupheader" in all rowGroupMode modes
###Feature Requests
Fixes #5946