### PR TITLE
fix(auto-import-resolver): options will never be null or undefined, but options.resolve may be

### DIFF
--- a/packages/auto-import-resolver/index.ts
+++ b/packages/auto-import-resolver/index.ts
@@ -32,7 +32,7 @@ export function PrimeVueResolver(options: PrimeVueResolverOptions = {}): Compone
 
                 if (cMeta) {
                     return (
-                        options?.resolve(cMeta, 'component') ?? {
+                        options.resolve?(cMeta, 'component') ?? {
                             from: cMeta.from
                         }
                     );
@@ -48,7 +48,7 @@ export function PrimeVueResolver(options: PrimeVueResolverOptions = {}): Compone
 
                 if (dMeta) {
                     return (
-                        options?.resolve(dMeta, 'directive') ?? {
+                        options.resolve?(dMeta, 'directive') ?? {
                             as: dMeta.as,
                             from: dMeta.from
                         }


### PR DESCRIPTION
### Defect Fixes

With rc.3, auto-import-resolver fails with:

```
error during build:
[unplugin-vue-components] options.resolve is not a function
```

This was occurring in two separate projects when just passing in `resolvers: [PrimeVueResolver()]` .