### PR TITLE
Fix arrow positioning of Popover and ConfirmPopup

### DIFF
--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -204,7 +204,7 @@ export default {
                 arrowLeft = targetOffset.left - containerOffset.left;
             }
 
-            this.container.style.setProperty($dt('overlay.arrow.left').name, `${arrowLeft}px`);
+            this.container.style.setProperty($dt('confirmpopup.arrow.offset').name, `${arrowLeft}px`);
 
             if (containerOffset.top < targetOffset.top) {
                 this.container.setAttribute('data-p-confirmpopup-flipped', 'true');

--- a/packages/primevue/src/confirmpopup/style/ConfirmPopupStyle.js
+++ b/packages/primevue/src/confirmpopup/style/ConfirmPopupStyle.js
@@ -67,7 +67,7 @@ const theme = ({ dt }) => `
 .p-confirmpopup:after,
 .p-confirmpopup:before {
     bottom: 100%;
-    left: ${dt('confirmpopup.arrow.offset')};
+    left: calc(${dt('confirmpopup.arrow.offset')} + 1.25rem);
     content: " ";
     height: 0;
     width: 0;

--- a/packages/primevue/src/popover/Popover.vue
+++ b/packages/primevue/src/popover/Popover.vue
@@ -155,7 +155,7 @@ export default {
                 arrowLeft = targetOffset.left - containerOffset.left;
             }
 
-            this.container.style.setProperty($dt('popover.arrow.left').name, `${arrowLeft}px`);
+            this.container.style.setProperty($dt('popover.arrow.offset').name, `${arrowLeft}px`);
 
             if (containerOffset.top < targetOffset.top) {
                 this.container.setAttribute('data-p-popover-flipped', 'true');

--- a/packages/primevue/src/popover/style/PopoverStyle.js
+++ b/packages/primevue/src/popover/style/PopoverStyle.js
@@ -39,7 +39,7 @@ const theme = ({ dt }) => `
 .p-popover:after,
 .p-popover:before {
     bottom: 100%;
-    left: ${dt('popover.arrow.offset')};
+    left: calc(${dt('popover.arrow.offset')} + 1.25rem);
     content: " ";
     height: 0;
     width: 0;


### PR DESCRIPTION
## Before change

With the last release candidate, confirmpopup and popover arrows are misplaced:

![341348772-6e3a5809-754a-4306-80c2-476f0b481f89](https://github.com/primefaces/primevue/assets/5047140/7025f043-df0f-4fdb-accd-02683039bbbc)

## After change

![342495257-91c975a8-dc4a-4eb0-ba19-8c72b655bc7e](https://github.com/primefaces/primevue/assets/5047140/51b38a99-b9dc-48ea-ae7a-7dc486e0b96a)

This change fixes a regression introduced by refactoring the calc variable into dt for the 4.0.0 release. This change pretty much reverts to the behavior of the previous release:
- the CSS correctly uses the declared `confirmpopup.arrow.offset` design token
- the component programmatically updates a different design token: `overlay.arrow.left`, [which causes misplaced arrows](https://github.com/primefaces/primevue/issues/5915#issuecomment-2180192639)
- the arrow is missing an offset, which [was there in the previous release](https://github.com/primefaces/primevue/blob/3.52.0/public/themes/arya-blue/theme.css#L6559)

Fix #5915