### PR TITLE
[BaseStepItem] Allow for Number to be passed in as value prop

### DIFF
--- a/packages/primevue/src/stepitem/BaseStepItem.vue
+++ b/packages/primevue/src/stepitem/BaseStepItem.vue
@@ -7,7 +7,7 @@ export default {
     extends: BaseComponent,
     props: {
         value: {
-            type: String,
+            type: [String, Number],
             default: undefined
         }
     },


### PR DESCRIPTION
This will match the functionality of BaseStepPanel and should fix type check error when using numbers