### PR TITLE
Add itemicon slot similar to the one in the breadcrumbs component

### DIFF
--- a/packages/primevue/src/speeddial/SpeedDial.vue
+++ b/packages/primevue/src/speeddial/SpeedDial.vue
@@ -49,7 +49,9 @@
                             :pt="getPTOptions(`${id}_${index}`, 'pcAction')"
                         >
                             <template v-if="item.icon" #icon="slotProps">
-                                <span :class="[item.icon, slotProps.class]" v-bind="getPTOptions(`${id}_${index}`, 'actionIcon')"></span>
+                                <slot name="itemicon" :item="item" :class="[slotProps.class]">
+                                    <span :class="[item.icon, slotProps.class]" v-bind="getPTOptions(`${id}_${index}`, 'actionIcon')"></span>
+                                </slot>
                             </template>
                         </Button>
                     </template>


### PR DESCRIPTION
This PR adds a slot wrapped around the icon in the speed dial sub items. 