### PR TITLE
fix for #5997

### DIFF
--- a/packages/primevue/src/accordion/style/AccordionStyle.js
+++ b/packages/primevue/src/accordion/style/AccordionStyle.js
@@ -86,7 +86,7 @@ const theme = ({ dt }) => `
     border-style: solid;
     border-width: ${dt('accordion.content.border.width')};
     border-color: ${dt('accordion.content.border.color')};
-    background: color: ${dt('accordion.content.background')};
+    background: ${dt('accordion.content.background')};
     color: ${dt('accordion.content.color')};
     padding: ${dt('accordion.content.padding')}
 }


### PR DESCRIPTION
This is a fix for #5997 - it removes `color: ` from the `background` declaration.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.