### PR TITLE
Fix IconField when icons should appear at beginning and end.

### DIFF
--- a/packages/primevue/src/iconfield/style/IconFieldStyle.js
+++ b/packages/primevue/src/iconfield/style/IconFieldStyle.js
@@ -20,11 +20,11 @@ const theme = ({ dt }) => `
     right: ${dt('form.field.padding.x')};
 }
 
-.p-iconfield .p-inputtext:last-child {
+.p-iconfield .p-inputtext:not(:first-child) {
     padding-left: calc((${dt('form.field.padding.x')} * 2) + ${dt('icon.size')});
 }
 
-.p-iconfield .p-inputtext:first-child {
+.p-iconfield .p-inputtext:not(:last-child) {
     padding-right: calc((${dt('form.field.padding.x')} * 2) + ${dt('icon.size')});
 }
 `;


### PR DESCRIPTION
Fixes #6034 

This changes the css selector to select all inputs, except the leading/trailing ones. While this does allow icons to be placed at both sides of an input, it might not work properly when there are other decorations or html elements inside of the `IconField`.