### PR TITLE
Fix: DataTable Frozen Columns the headers of fixed columns will overlap.

### DIFF
--- a/packages/primevue/src/datatable/style/DataTableStyle.js
+++ b/packages/primevue/src/datatable/style/DataTableStyle.js
@@ -31,7 +31,7 @@ const theme = ({ dt }) => `
 
 .p-datatable-scrollable .p-datatable-frozen-column {
     position: sticky;
-    background: inherit;
+    background: ${dt('datatable.header.cell.background')};
 }
 
 .p-datatable-scrollable th.p-datatable-frozen-column {


### PR DESCRIPTION
### Defect Fixes
[#6036](https://github.com/primefaces/primevue/issues/6036l)

### Before change

https://github.com/primefaces/primevue/assets/15907064/addf79d8-ab13-4a6e-91d9-2a338d15c5c3

### After change


https://github.com/primefaces/primevue/assets/15907064/de08f40b-4fd4-44cc-83e6-262cdea9cb4a

This modification fixes the bug where the table header overlaps due to the lack of background color when fixed columns are used. It is achieved by modifying CSS.