### PR TITLE
Refference miss fix

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -746,7 +746,7 @@ export default {
 
                 return start === year || end === year || (start < year && end > year);
             } else {
-                return value.getFullYear() === year;
+                return this.modelValue.getFullYear() === year;
             }
         },
         isDateEquals(value, dateMeta) {


### PR DESCRIPTION
An attempt to reference undefined `value` variable. Probably some code migration issue from 2 to 3 Vue version.
