### PR TITLE
Update StepPanel.vue with v-show rather than v-if for horizontal steps.

### DIFF
--- a/packages/primevue/src/steppanel/StepPanel.vue
+++ b/packages/primevue/src/steppanel/StepPanel.vue
@@ -14,7 +14,7 @@
     </template>
     <template v-else>
         <template v-if="!asChild">
-            <component v-if="active" :is="as" :id="id" :class="cx('root')" role="tabpanel" :aria-controls="ariaControls" v-bind="getPTOptions('root')">
+            <component v-show="active" :is="as" :id="id" :class="cx('root')" role="tabpanel" :aria-controls="ariaControls" v-bind="getPTOptions('root')">
                 <slot :active="active" :activateCallback="(val) => updateValue(val)" />
             </component>
         </template>


### PR DESCRIPTION
Bug fix for StepPanel.vue so that v-show is used rather than v-if. v-show is desired as the Stepper should not be re-rendering components.

###Defect Fixes
Fixes #6052 
