### PR TITLE
fix: avoid `v-ripple` missing warn when Ripple is not been registered

### DIFF
--- a/packages/primevue/src/tablist/TabList.vue
+++ b/packages/primevue/src/tablist/TabList.vue
@@ -40,6 +40,7 @@ import { getWidth, findSingle, getHeight, getOuterHeight, getOuterWidth, getOffs
 import ChevronLeftIcon from '@primevue/icons/chevronleft';
 import ChevronRightIcon from '@primevue/icons/chevronright';
 import BaseTabList from './BaseTabList.vue';
+import Ripple from 'primevue/ripple';
 
 export default {
     name: 'TabList',
@@ -160,6 +161,9 @@ export default {
     components: {
         ChevronLeftIcon,
         ChevronRightIcon
+    },
+    directives: {
+        ripple: Ripple
     }
 };
 </script>


### PR DESCRIPTION
###Defect Fixes
Close #6057 
