### PR TITLE
fix: update module to support Nuxt 4

### DIFF
--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -11,7 +11,7 @@ export default defineNuxtModule<ModuleOptions>({
         name: '@primevue/nuxt-module',
         configKey: 'primevue',
         compatibility: {
-            nuxt: '^3.0.0'
+            nuxt: '>=3.0.0'
         }
     },
     defaults: {


### PR DESCRIPTION
Updated `defineNuxtModule` compatibility version to '>=3.0.0'.