### PR TITLE
Fix autocomplete when combining dropdown and multiple options

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -512,7 +512,7 @@ export default {
                 this.hide(true);
             } else {
                 focus(this.multiple ? this.$refs.focusInput : this.$refs.focusInput.$el);
-                query = this.$refs.focusInput.$el.value;
+                query = this.multiple ? this.$refs.focusInput.value : this.$refs.focusInput.$el.value;
 
                 if (this.dropdownMode === 'blank') this.search(event, '', 'dropdown');
                 else if (this.dropdownMode === 'current') this.search(event, query, 'dropdown');


### PR DESCRIPTION
Fixes #5881

I followed the pattern from the line above when assigning the query variable, referencing a different property for the query value depending on whether the component is operating in multiple mode. Tested working in my project, though in testing I ran into #5601 a bunch until using the workaround.