### PR TITLE
Fix(DatePicker): allow to type the end date equal to the start date

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1731,7 +1731,7 @@ export default {
                 }
             } else if (value.every((v) => this.isSelectable(v.getDate(), v.getMonth(), v.getFullYear(), false))) {
                 if (this.isRangeSelection()) {
-                    isValid = value.length > 1 && value[1] > value[0] ? true : false;
+                    isValid = value.length > 1 && value[1] >= value[0];
                 }
             }
 


### PR DESCRIPTION
### Defect Fixes
- fix #6081

### result
- I modified the isValid value to allow the start date and end date to be the same.
```js
if (this.isRangeSelection()) {
    isValid = value.length > 1 && value[1] > value[0] ? true : false; // before
}
```
```js
if (this.isRangeSelection()) {
    isValid = value.length > 1 && value[1] >= value[0]; // after
}
```

https://github.com/user-attachments/assets/e8ae6d4c-7ba2-4dc0-95f4-e9bae955b1e1



