### PR TITLE
Fix(TreeTable): add rowcheckboxicon slot name in BodyCell

### DIFF
--- a/packages/primevue/src/treetable/BodyCell.vue
+++ b/packages/primevue/src/treetable/BodyCell.vue
@@ -29,7 +29,8 @@
                 :data-p-partialchecked="partialChecked"
             >
                 <template #icon="slotProps">
-                    <component v-if="column.children.rowcheckboxicon" :is="column.children.rowcheckboxicon" :checked="slotProps.checked" :partialChecked="partialChecked" :class="slotProps.class" />
+                    <!-- TODO: It should be decided which slot to use for controlling the checkbox: checkboxicon, rowcheckboxicon -->
+                    <component v-if="templates.checkboxicon || column.children.rowcheckboxicon" :is="templates.checkboxicon || column.children.rowcheckboxicon" :checked="slotProps.checked" :partialChecked="partialChecked" :class="slotProps.class" />
                 </template>
             </Checkbox>
             <component v-if="column.children && column.children.body" :is="column.children.body" :node="node" :column="column" />

--- a/packages/primevue/src/treetable/BodyCell.vue
+++ b/packages/primevue/src/treetable/BodyCell.vue
@@ -29,7 +29,7 @@
                 :data-p-partialchecked="partialChecked"
             >
                 <template #icon="slotProps">
-                    <component v-if="templates['checkboxicon']" :is="templates['checkboxicon']" :checked="slotProps.checked" :partialChecked="partialChecked" :class="slotProps.class" />
+                    <component v-if="column.children.rowcheckboxicon" :is="column.children.rowcheckboxicon" :checked="slotProps.checked" :partialChecked="partialChecked" :class="slotProps.class" />
                 </template>
             </Checkbox>
             <component v-if="column.children && column.children.body" :is="column.children.body" :node="node" :column="column" />
@@ -39,10 +39,10 @@
 </template>
 
 <script>
+import { getNextElementSibling, getOuterWidth, getPreviousElementSibling } from '@primeuix/utils/dom';
+import { resolveFieldData } from '@primeuix/utils/object';
 import BaseComponent from '@primevue/core/basecomponent';
 import { getVNodeProp } from '@primevue/core/utils';
-import { getNextElementSibling, getPreviousElementSibling, getOuterWidth } from '@primeuix/utils/dom';
-import { resolveFieldData } from '@primeuix/utils/object';
 import CheckIcon from '@primevue/icons/check';
 import ChevronDownIcon from '@primevue/icons/chevrondown';
 import ChevronRightIcon from '@primevue/icons/chevronright';


### PR DESCRIPTION
## Defect Fixes
- fix #6130

### Cause
- The treetable provides a slot for customizing checkboxes. 
- However, despite using the `rowcheckboxicon` slot as per the official documentation, the checkbox does not change.

### Solution
- I added the `rowcheckboxicon` slot to `BodyCell.vue`.

### Result

```html
<TreeTable v-model:selectionKeys="selectedKey" :value="nodes" selectionMode="checkbox" tableStyle="min-width: 50rem">
    <Column field="name" header="Name" expander style="width: 34%">
        <!-- here: custom checkbox code -->
        <template #rowcheckboxicon="{ checked }">
            <div v-if="checked" class="pi pi-check"></div> 
            <div v-else class="pi pi-times"></div>
        </template>
    </Column>
    <Column field="size" header="Size" style="width: 33%"></Column>
    <Column field="type" header="Type" style="width: 33%"></Column>
</TreeTable>
```


https://github.com/user-attachments/assets/b2886802-50d0-484e-97d6-ab2216e1835d


