### PR TITLE
Dialog: Cherry pick 're-focus original element on close' fix to v4

### DIFF
--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -78,7 +78,8 @@ export default {
             visible: false,
             confirmation: null,
             autoFocusAccept: null,
-            autoFocusReject: null
+            autoFocusReject: null,
+            target: null
         };
     },
     target: null,
@@ -175,6 +176,8 @@ export default {
             this.autoFocusAccept = this.confirmation.defaultFocus === undefined || this.confirmation.defaultFocus === 'accept' ? true : false;
             this.autoFocusReject = this.confirmation.defaultFocus === 'reject' ? true : false;
 
+            this.target = document.activeElement;
+
             this.bindOutsideClickListener();
             this.bindScrollListener();
             this.bindResizeListener();
@@ -187,6 +190,9 @@ export default {
         onLeave() {
             this.autoFocusAccept = null;
             this.autoFocusReject = null;
+
+            DomHandler.focus(this.target);
+            this.target = null;
 
             this.unbindOutsideClickListener();
             this.unbindScrollListener();

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -91,7 +91,8 @@ export default {
             containerVisible: this.visible,
             maximized: false,
             focusableMax: null,
-            focusableClose: null
+            focusableClose: null,
+            target: null,
         };
     },
     watch: {
@@ -146,6 +147,7 @@ export default {
         },
         onEnter() {
             this.$emit('show');
+            this.target = document.activeElement;
             this.focus();
             this.enableDocumentSettings();
             this.bindGlobalListeners();
@@ -161,6 +163,8 @@ export default {
         },
         onLeave() {
             this.$emit('hide');
+            DomHandler.focus(this.target);
+            this.target = null;
             this.focusableClose = null;
             this.focusableMax = null;
         },


### PR DESCRIPTION
Fixes #6139.

Cherry picked 2 commits:
* https://github.com/primefaces/primevue/commit/c7f9b9704f931d8a30daffe27ca22cab3409b8be fix : Dialog/Confirm re-focus original element on close
* https://github.com/primefaces/primevue/commit/760c98f9981683caee4b40adba321d4f385d223a Refactor https://github.com/primefaces/primevue/issues/5577