### PR TITLE
#6125 Fix (DatePicker, Locale) - deep merge options during install

### DIFF
--- a/packages/core/src/config/PrimeVue.js
+++ b/packages/core/src/config/PrimeVue.js
@@ -3,6 +3,7 @@ import { FilterMatchMode } from '@primevue/core/api';
 import BaseStyle from '@primevue/core/base/style';
 import PrimeVueService from '@primevue/core/service';
 import { inject, reactive, ref, watch } from 'vue';
+import { mergeKeys } from '@primeuix/utils';
 
 export const defaultOptions = {
     ripple: false,
@@ -266,7 +267,7 @@ export function setupConfig(app, PrimeVue) {
 
 export default {
     install: (app, options) => {
-        const configOptions = { ...defaultOptions, ...options };
+        const configOptions = mergeKeys(defaultOptions, options);
 
         setup(app, configOptions);
     }


### PR DESCRIPTION
Fixes #6125 (and possible other locale and custom options via .use related issues)

Custom options were being _shallow_ merged with default options (instead of **deep merge)**, overriding all nested properties. This PR resolves this utilizing _mergeKeys_ from `primeuix/utils`.