### PR TITLE
fix: fix the unexpected joggle state when `dialog` component non-fixed

### DIFF
--- a/components/lib/dialog/Dialog.vue
+++ b/components/lib/dialog/Dialog.vue
@@ -1,7 +1,7 @@
 <template>
     <Portal :appendTo="appendTo">
         <div v-if="containerVisible" :ref="maskRef" :class="cx('mask')" :style="sx('mask', true, { position, modal })" @click="onMaskClick" v-bind="ptm('mask')">
-            <transition name="p-dialog" @before-enter="onBeforeEnter" @enter="onEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
+            <transition name="p-dialog" @before-enter="onBeforeEnter" @enter="onEnter" @after-enter="onAfterEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
                 <div v-if="visible" :ref="containerRef" v-focustrap="{ disabled: !modal }" :class="cx('root')" :style="sx('root')" role="dialog" :aria-labelledby="ariaLabelledById" :aria-modal="modal" v-bind="ptmi('root')">
                     <slot v-if="$slots.container" name="container" :onClose="close" :onMaximize="(event) => maximize(event)" :closeCallback="close" :maximizeCallback="(event) => maximize(event)"></slot>
                     <template v-else>
@@ -141,13 +141,15 @@ export default {
         onEnter() {
             this.$emit('show');
             this.target = document.activeElement;
-            this.focus();
             this.enableDocumentSettings();
             this.bindGlobalListeners();
 
             if (this.autoZIndex) {
                 ZIndexUtils.set('modal', this.mask, this.baseZIndex + this.$primevue.config.zIndex.modal);
             }
+        },
+        onAfterEnter() {
+            this.focus();
         },
         onBeforeLeave() {
             if (this.modal) {


### PR DESCRIPTION
### Defect Fixes
For fixing the issue in `primevue v3`: https://github.com/primefaces/primevue/issues/6162

When the dom is not fully `entered`, triggering the `focus` event will cause the browser force to settle the doms. So we may need to postpone the `focus` event.