### PR TITLE
Fixed Button in the popover basic doc to be consistent in both the demo and the code section

### DIFF
--- a/apps/showcase/doc/popover/BasicDoc.vue
+++ b/apps/showcase/doc/popover/BasicDoc.vue
@@ -56,7 +56,7 @@ export default {
             ],
             code: {
                 basic: `
-<Button type="button" icon="pi pi-image" label="Image" @click="toggle" />
+<Button type="button" icon="pi pi-share-alt" label="Share" @click="toggle" />
 
 <Popover ref="op">
     <div class="flex flex-col gap-4 w-[25rem]">
@@ -98,7 +98,7 @@ export default {
                 options: `
 <template>
     <div class="card flex justify-center">
-        <Button type="button" icon="pi pi-image" label="Image" @click="toggle" />
+        <Button type="button" icon="pi pi-share-alt" label="Share" @click="toggle" />
 
         <Popover ref="op">
             <div class="flex flex-col gap-4 w-[25rem]">
@@ -161,7 +161,7 @@ export default {
                 composition: `
 <template>
     <div class="card flex justify-center">
-        <Button type="button" icon="pi pi-image" label="Image" @click="toggle" />
+        <Button type="button" icon="pi pi-share-alt" label="Share" @click="toggle" />
 
         <Popover ref="op">
             <div class="flex flex-col gap-4 w-[25rem]">


### PR DESCRIPTION
###Defect Fixes
The Button in the code section of the popover documentation page did not have the same icon and label as the demo section.