### PR TITLE
Fix event parameter type declartion of Tabs value

### DIFF
--- a/packages/primevue/src/tabs/Tabs.d.ts
+++ b/packages/primevue/src/tabs/Tabs.d.ts
@@ -161,7 +161,7 @@ export interface TabsEmitsOptions {
      * Emitted when the value changes.
      * @param {string} value - Current value.
      */
-    'update:value'(value: number): void;
+    'update:value'(value: string): void;
 }
 
 export declare type TabsEmits = EmitFn<TabsEmitsOptions>;


### PR DESCRIPTION
Fixed a simple mistake in defining the update:value event type of the Tabs component.