### PR TITLE
fix: global vue type augmentation

### DIFF
--- a/packages/core/src/config/PrimeVue.d.ts
+++ b/packages/core/src/config/PrimeVue.d.ts
@@ -161,15 +161,7 @@ export declare function usePrimeVue(): {
 declare const plugin: Plugin;
 export default plugin;
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $primevue: {
-            config: PrimeVueConfiguration;
-        };
-    }
-}
-
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $primevue: {
             config: PrimeVueConfiguration;

--- a/packages/primevue/src/confirmationservice/ConfirmationService.d.ts
+++ b/packages/primevue/src/confirmationservice/ConfirmationService.d.ts
@@ -27,13 +27,7 @@ export interface ConfirmationServiceMethods {
     close(): void;
 }
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $confirm: ConfirmationServiceMethods;
-    }
-}
-
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $confirm: ConfirmationServiceMethods;
     }

--- a/packages/primevue/src/dialogservice/DialogService.d.ts
+++ b/packages/primevue/src/dialogservice/DialogService.d.ts
@@ -26,13 +26,7 @@ export interface DialogServiceMethods {
     open(content: any, options?: DynamicDialogOptions): DynamicDialogInstance;
 }
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $dialog: DialogServiceMethods;
-    }
-}
-
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $dialog: DialogServiceMethods;
     }

--- a/packages/primevue/src/toastservice/ToastService.d.ts
+++ b/packages/primevue/src/toastservice/ToastService.d.ts
@@ -39,13 +39,7 @@ export interface ToastServiceMethods {
     removeAllGroups(): void;
 }
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $toast: ToastServiceMethods;
-    }
-}
-
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $toast: ToastServiceMethods;
     }


### PR DESCRIPTION
### Defect Fixes
Augment vue types instead of 'vue/types/vue' and '@vue/runtime-core' to fix incompatibility with other libraries caused by the current augmentation behavior

Fixes: #6199