### PR TITLE
fix(Stepper): include panel value in activateCallback signature

### DIFF
--- a/packages/primevue/src/steppanel/StepPanel.d.ts
+++ b/packages/primevue/src/steppanel/StepPanel.d.ts
@@ -117,7 +117,7 @@ export interface StepPanelSlots {
         /**
          * Click function.
          */
-        activateCallback: () => void;
+        activateCallback: (value?: string | number) => void;
     }): VNode[];
 }
 


### PR DESCRIPTION
This removes the need to add a wrapper function that changes the type of activateCallback to any before calling it.

###Defect Fixes

Fixes issue in #6225.