### PR TITLE
feat: Password: add strengthFn prop

### DIFF
--- a/packages/primevue/scripts/components/password.js
+++ b/packages/primevue/scripts/components/password.js
@@ -30,6 +30,12 @@ const PasswordProps = [
         description: 'Regex for a strong level password.'
     },
     {
+        name: 'strengthFn',
+        type: 'function',
+        default: 'null',
+        description: 'Custom password strength validator function. It should take password value as a parameter and return a score between 0 and 3.'
+    },
+    {
         name: 'weakLabel',
         type: 'string',
         default: 'null',

--- a/packages/primevue/src/password/BasePassword.vue
+++ b/packages/primevue/src/password/BasePassword.vue
@@ -19,6 +19,10 @@ export default {
             type: [String, RegExp],
             default: '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})' // eslint-disable-line
         },
+        strengthFn: {
+            type: Function,
+            default: null
+        },
         weakLabel: {
             type: String,
             default: null

--- a/packages/primevue/src/password/Password.d.ts
+++ b/packages/primevue/src/password/Password.d.ts
@@ -189,6 +189,12 @@ export interface PasswordProps extends InputHTMLAttributes {
      */
     strongRegex?: string | RegExp | undefined;
     /**
+     * Custom password strength function.
+     * It should take password value as a parameter and return a score between 0 and 3.
+     * @defaultValue null
+     */
+    strengthFn?: (value: string) => 0 | 1 | 2 | 3 | undefined;
+    /**
      * Text for a weak password. Defaults to PrimeVue Locale configuration.
      */
     weakLabel?: string | undefined;

--- a/packages/primevue/src/password/Password.spec.js
+++ b/packages/primevue/src/password/Password.spec.js
@@ -52,4 +52,22 @@ describe('Password.vue', () => {
         expect(wrapper.find('.p-password-toggle-mask-icon.p-password-unmask-icon').exists()).toBe(false);
         expect(wrapper.find('.p-password-toggle-mask-icon.p-password-mask-icon').exists()).toBe(true);
     });
+
+    it('should use custom strengthFn', async () => {
+        const customStrengthFn = vi.fn((str) => {
+            return str === 'AAA' ? 3 : 1;
+        });
+
+        await wrapper.setProps({ strengthFn: customStrengthFn });
+
+        await wrapper.vm.onKeyUp({ target: { value: 'AAA' } });
+
+        expect(wrapper.find('.p-password-content [data-pc-section="info"]').text()).toBe('Strong');
+
+        await wrapper.vm.onKeyUp({ target: { value: 'AAAB' } });
+
+        expect(wrapper.find('.p-password-content [data-pc-section="info"]').text()).toBe('Weak');
+
+        expect(customStrengthFn).toHaveBeenCalledTimes(2);
+    });
 });

--- a/packages/primevue/src/password/Password.vue
+++ b/packages/primevue/src/password/Password.vue
@@ -149,6 +149,16 @@ export default {
             }
         },
         testStrength(str) {
+            if (this.strengthFn) {
+                const strength = this.strengthFn(str);
+
+                if (Array.from(Array(4).keys()).includes(strength)) {
+                    return strength;
+                } else {
+                    console.warn('Password strength function should return a value between 0 and 3. Defaulting to mediumRegex/strongRegex checks.');
+                }
+            }
+
             let level = 0;
 
             if (this.strongCheckRegExp.test(str)) level = 3;


### PR DESCRIPTION
###Defect Fixes
Closes #6216

###Feature Requests
This PR adds a `strengthFn` prop to `Password` component. If provided, it takes a password value as argument and should return a value between 0 and 3. This will enable the users to use custom password validation libraries (ie `zxcvbn`) instead of just regexes for medium and strong passwords.

Example:

```
<template>
  <div class="card flex justify-center">
    <Password v-model="password" :strengthFn="customStrengthFn" placeholder="Password" />
  </div>
</template>

<script setup lang="ts">
import { ref } from 'vue';
import zxcvbn from 'zxcvbn';

const password = ref(null);

const customStrengthFn = (password: string) => {
  const { score } = zxcvbn(password);

  return score >= 3 ? 3 : score
}
</script>

```
