### PR TITLE
Update InputMask.vue

### DIFF
--- a/packages/primevue/src/inputmask/InputMask.vue
+++ b/packages/primevue/src/inputmask/InputMask.vue
@@ -11,7 +11,7 @@
         :placeholder="placeholder"
         :fluid="hasFluid"
         :unstyled="unstyled"
-        @input="onInput"
+        @compositionend="onInput"
         @focus="onFocus"
         @blur="onBlur"
         @keydown="onKeyDown"


### PR DESCRIPTION
###Defect Fixes
Open #3623 

###Feature Requests
Inputmask cannot handle @input correctly.
It may be triggered twice by non-Latin input methods, causing numbers to be duplicated.
It is recommended to use @compositionend to resolve this issue.
https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent