### PR TITLE
Feat: extract the default fontSize of components to themes.

### DIFF
--- a/packages/primevue/src/autocomplete/style/AutoCompleteStyle.js
+++ b/packages/primevue/src/autocomplete/style/AutoCompleteStyle.js
@@ -217,7 +217,7 @@ const theme = ({ dt }) => `
     width: 100%;
     font-family: inherit;
     font-feature-settings: inherit;
-    font-size: 1rem;
+    font-size: ${dt('autocomplete.font.size')};
     color: inherit;
 }
 

--- a/packages/primevue/src/button/style/ButtonStyle.js
+++ b/packages/primevue/src/button/style/ButtonStyle.js
@@ -13,7 +13,7 @@ const theme = ({ dt }) => `
     background: ${dt('button.primary.background')};
     border: 1px solid ${dt('button.primary.border.color')};
     padding: ${dt('button.padding.y')} ${dt('button.padding.x')};
-    font-size: 1rem;
+    font-size: ${dt('button.font.size')};
     font-family: inherit;
     font-feature-settings: inherit;
     transition: background ${dt('button.transition.duration')}, color ${dt('button.transition.duration')}, border-color ${dt('button.transition.duration')},

--- a/packages/primevue/src/button/style/ButtonStyle.js
+++ b/packages/primevue/src/button/style/ButtonStyle.js
@@ -52,6 +52,10 @@ const theme = ({ dt }) => `
     width: 0;
 }
 
+.p-button .p-button-icon {
+    font-size: ${dt('button.font.size')};
+}
+
 .p-button-sm {
     font-size: ${dt('button.sm.font.size')};
     padding: ${dt('button.sm.padding.y')} ${dt('button.sm.padding.x')};

--- a/packages/primevue/src/datepicker/style/DatePickerStyle.js
+++ b/packages/primevue/src/datepicker/style/DatePickerStyle.js
@@ -85,6 +85,7 @@ const theme = ({ dt }) => `
 
 .p-datepicker-panel {
     width: auto;
+    font-size: ${dt('datepicker.panel.font.size')};
     padding: ${dt('datepicker.panel.padding')};
     background: ${dt('datepicker.panel.background')};
     color: ${dt('datepicker.panel.color')};
@@ -124,6 +125,7 @@ const theme = ({ dt }) => `
     background: transparent;
     margin: 0;
     cursor: pointer;
+    font-size: inherit;
     font-weight: inherit;
     transition: background ${dt('datepicker.transition.duration')}, color ${dt('datepicker.transition.duration')}, border-color ${dt('datepicker.transition.duration')}, outline-color ${dt('datepicker.transition.duration')}, box-shadow ${dt(
     'datepicker.transition.duration'
@@ -175,7 +177,6 @@ const theme = ({ dt }) => `
 .p-datepicker-day-view {
     width: 100%;
     border-collapse: collapse;
-    font-size: 1rem;
     margin: ${dt('datepicker.day.view.margin')};
 }
 
@@ -354,10 +355,6 @@ const theme = ({ dt }) => `
     align-items: center;
     flex-direction: column;
     gap: ${dt('datepicker.time.picker.button.gap')};
-}
-
-.p-datepicker-time-picker span {
-    font-size: 1rem;
 }
 
 .p-datepicker-timeonly .p-datepicker-time-picker {

--- a/packages/primevue/src/inputchips/style/InputChipsStyle.js
+++ b/packages/primevue/src/inputchips/style/InputChipsStyle.js
@@ -91,7 +91,7 @@ const theme = ({ dt }) => `
     width: 100%;
     font-family: inherit;
     font-feature-settings: inherit;
-    font-size: 1rem;
+    font-size: ${dt('inputchips.font.size')};
     color: inherit;
 }
 

--- a/packages/primevue/src/inputtext/style/InputTextStyle.js
+++ b/packages/primevue/src/inputtext/style/InputTextStyle.js
@@ -4,7 +4,7 @@ const theme = ({ dt }) => `
 .p-inputtext {
     font-family: inherit;
     font-feature-settings: inherit;
-    font-size: 1rem;
+    font-size: ${dt('inputtext.font.size')};
     color: ${dt('inputtext.color')};
     background: ${dt('inputtext.background')};
     padding: ${dt('inputtext.padding.y')} ${dt('inputtext.padding.x')};

--- a/packages/primevue/src/knob/style/KnobStyle.js
+++ b/packages/primevue/src/knob/style/KnobStyle.js
@@ -13,7 +13,7 @@ const theme = ({ dt }) => `
 }
 
 .p-knob-text {
-    font-size: 1.3rem;
+    font-size: ${dt('knob.text.font.size')};
     text-align: center;
 }
 

--- a/packages/primevue/src/terminal/style/TerminalStyle.js
+++ b/packages/primevue/src/terminal/style/TerminalStyle.js
@@ -9,6 +9,7 @@ const theme = ({ dt }) => `
     border: 1px solid ${dt('terminal.border.color')};
     padding: ${dt('terminal.padding')};
     border-radius: ${dt('terminal.border.radius')};
+    font-size: ${dt('terminal.font.size')};
 }
 
 .p-terminal-prompt {
@@ -25,7 +26,7 @@ const theme = ({ dt }) => `
     outline: 0 none;
     font-family: inherit;
     font-feature-settings: inherit;
-    font-size: 1rem;
+    font-size: inherit;
 }
 
 .p-terminal-prompt-label {

--- a/packages/primevue/src/textarea/style/TextareaStyle.js
+++ b/packages/primevue/src/textarea/style/TextareaStyle.js
@@ -4,7 +4,7 @@ const theme = ({ dt }) => `
 .p-textarea {
     font-family: inherit;
     font-feature-settings: inherit;
-    font-size: 1rem;
+    font-size: ${dt('textarea.font.size')};
     color: ${dt('textarea.color')};
     background: ${dt('textarea.background')};
     padding: ${dt('textarea.padding.y')} ${dt('textarea.padding.x')};

--- a/packages/primevue/src/togglebutton/style/ToggleButtonStyle.js
+++ b/packages/primevue/src/togglebutton/style/ToggleButtonStyle.js
@@ -13,7 +13,7 @@ const theme = ({ dt }) => `
     background: ${dt('togglebutton.background')};
     border: 1px solid ${dt('togglebutton.border.color')};
     padding: ${dt('togglebutton.padding')};
-    font-size: 1rem;
+    font-size: ${dt('togglebutton.font.size')};
     font-family: inherit;
     font-feature-settings: inherit;
     transition: background ${dt('togglebutton.transition.duration')}, color ${dt('togglebutton.transition.duration')}, border-color ${dt('togglebutton.transition.duration')},

--- a/packages/themes/src/presets/aura/autocomplete/index.js
+++ b/packages/themes/src/presets/aura/autocomplete/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/aura/button/index.js
+++ b/packages/themes/src/presets/aura/button/index.js
@@ -3,6 +3,7 @@ export default {
         borderRadius: '{form.field.border.radius}',
         roundedBorderRadius: '2rem',
         gap: '0.5rem',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         iconOnlyWidth: '2.5rem',

--- a/packages/themes/src/presets/aura/datepicker/index.js
+++ b/packages/themes/src/presets/aura/datepicker/index.js
@@ -8,6 +8,7 @@ export default {
         color: '{content.color}',
         borderRadius: '{content.border.radius}',
         shadow: '{overlay.popover.shadow}',
+        fontSize: '1rem',
         padding: '{overlay.popover.padding}'
     },
     header: {

--- a/packages/themes/src/presets/aura/inputchips/index.js
+++ b/packages/themes/src/presets/aura/inputchips/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/aura/inputtext/index.js
+++ b/packages/themes/src/presets/aura/inputtext/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/aura/knob/index.js
+++ b/packages/themes/src/presets/aura/knob/index.js
@@ -16,6 +16,7 @@ export default {
         background: '{content.border.color}'
     },
     text: {
+        fontSize: '1.3rem',
         color: '{text.muted.color}'
     }
 };

--- a/packages/themes/src/presets/aura/terminal/index.js
+++ b/packages/themes/src/presets/aura/terminal/index.js
@@ -4,6 +4,7 @@ export default {
         borderColor: '{form.field.border.color}',
         color: '{form.field.color}',
         height: '18rem',
+        fontSize: '1rem',
         padding: '{form.field.padding.y} {form.field.padding.x}',
         borderRadius: '{form.field.border.radius}'
     },

--- a/packages/themes/src/presets/aura/textarea/index.js
+++ b/packages/themes/src/presets/aura/textarea/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/aura/togglebutton/index.js
+++ b/packages/themes/src/presets/aura/togglebutton/index.js
@@ -3,6 +3,7 @@ export default {
         padding: '0.5rem 1rem',
         borderRadius: '{content.border.radius}',
         gap: '0.5rem',
+        fontSize: '1rem',
         fontWeight: '500',
         disabledBackground: '{form.field.disabled.background}',
         disabledBorderColor: '{form.field.disabled.background}',

--- a/packages/themes/src/presets/lara/autocomplete/index.js
+++ b/packages/themes/src/presets/lara/autocomplete/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/lara/button/index.js
+++ b/packages/themes/src/presets/lara/button/index.js
@@ -3,6 +3,7 @@ export default {
         borderRadius: '{form.field.border.radius}',
         roundedBorderRadius: '2rem',
         gap: '0.5rem',
+        fontSize: '1rem',
         paddingX: '1rem',
         paddingY: '{form.field.padding.y}',
         iconOnlyWidth: '2.75rem',

--- a/packages/themes/src/presets/lara/datepicker/index.js
+++ b/packages/themes/src/presets/lara/datepicker/index.js
@@ -8,6 +8,7 @@ export default {
         color: '{content.color}',
         borderRadius: '{content.border.radius}',
         shadow: '{overlay.popover.shadow}',
+        fontSize: '1rem',
         padding: '{overlay.popover.padding}'
     },
     header: {

--- a/packages/themes/src/presets/lara/inputchips/index.js
+++ b/packages/themes/src/presets/lara/inputchips/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/lara/inputtext/index.js
+++ b/packages/themes/src/presets/lara/inputtext/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/lara/knob/index.js
+++ b/packages/themes/src/presets/lara/knob/index.js
@@ -16,6 +16,7 @@ export default {
         background: '{content.border.color}'
     },
     text: {
+        fontSize: '1.3rem',
         color: '{text.muted.color}'
     }
 };

--- a/packages/themes/src/presets/lara/terminal/index.js
+++ b/packages/themes/src/presets/lara/terminal/index.js
@@ -4,6 +4,7 @@ export default {
         borderColor: '{form.field.border.color}',
         color: '{form.field.color}',
         height: '18rem',
+        fontSize: '1rem',
         padding: '{form.field.padding.y} {form.field.padding.x}',
         borderRadius: '{form.field.border.radius}'
     },

--- a/packages/themes/src/presets/lara/textarea/index.js
+++ b/packages/themes/src/presets/lara/textarea/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/lara/togglebutton/index.js
+++ b/packages/themes/src/presets/lara/togglebutton/index.js
@@ -3,6 +3,7 @@ export default {
         padding: '0.625rem 1rem',
         borderRadius: '{content.border.radius}',
         gap: '0.5rem',
+        fontSize: '1rem',
         fontWeight: '500',
         background: '{form.field.background}',
         borderColor: '{form.field.border.color}',

--- a/packages/themes/src/presets/nora/autocomplete/index.js
+++ b/packages/themes/src/presets/nora/autocomplete/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/nora/button/index.js
+++ b/packages/themes/src/presets/nora/button/index.js
@@ -3,6 +3,7 @@ export default {
         borderRadius: '{form.field.border.radius}',
         roundedBorderRadius: '2rem',
         gap: '0.5rem',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         iconOnlyWidth: '2.5rem',

--- a/packages/themes/src/presets/nora/datepicker/index.js
+++ b/packages/themes/src/presets/nora/datepicker/index.js
@@ -8,6 +8,7 @@ export default {
         color: '{content.color}',
         borderRadius: '{content.border.radius}',
         shadow: '{overlay.popover.shadow}',
+        fontSize: '1rem',
         padding: '{overlay.popover.padding}'
     },
     header: {

--- a/packages/themes/src/presets/nora/inputchips/index.js
+++ b/packages/themes/src/presets/nora/inputchips/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/nora/inputtext/index.js
+++ b/packages/themes/src/presets/nora/inputtext/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/nora/knob/index.js
+++ b/packages/themes/src/presets/nora/knob/index.js
@@ -13,6 +13,7 @@ export default {
         background: '{primary.color}'
     },
     text: {
+        fontSize: '1.3rem',
         color: '{text.muted.color}'
     },
     colorScheme: {

--- a/packages/themes/src/presets/nora/terminal/index.js
+++ b/packages/themes/src/presets/nora/terminal/index.js
@@ -4,6 +4,7 @@ export default {
         borderColor: '{form.field.border.color}',
         color: '{form.field.color}',
         height: '18rem',
+        fontSize: '1rem',
         padding: '{form.field.padding.y} {form.field.padding.x}',
         borderRadius: '{form.field.border.radius}'
     },

--- a/packages/themes/src/presets/nora/textarea/index.js
+++ b/packages/themes/src/presets/nora/textarea/index.js
@@ -12,6 +12,7 @@ export default {
         disabledColor: '{form.field.disabled.color}',
         placeholderColor: '{form.field.placeholder.color}',
         shadow: '{form.field.shadow}',
+        fontSize: '1rem',
         paddingX: '{form.field.padding.x}',
         paddingY: '{form.field.padding.y}',
         borderRadius: '{form.field.border.radius}',

--- a/packages/themes/src/presets/nora/togglebutton/index.js
+++ b/packages/themes/src/presets/nora/togglebutton/index.js
@@ -3,6 +3,7 @@ export default {
         padding: '0.5rem 0.75rem',
         borderRadius: '{content.border.radius}',
         gap: '0.5rem',
+        fontSize: '1rem',
         fontWeight: '500',
         background: '{form.field.background}',
         borderColor: '{form.field.border.color}',

--- a/packages/themes/types/autocomplete/index.d.ts
+++ b/packages/themes/types/autocomplete/index.d.ts
@@ -88,6 +88,12 @@ export interface AutoCompleteDesignTokens extends ColorSchemeDesignToken<AutoCom
          */
         shadow?: string;
         /**
+         * Font size of root
+         *
+         * @designToken autocomplete.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding x of root
          *
          * @designToken autocomplete.padding.x

--- a/packages/themes/types/button/index.d.ts
+++ b/packages/themes/types/button/index.d.ts
@@ -34,6 +34,12 @@ export interface ButtonDesignTokens extends ColorSchemeDesignToken<ButtonDesignT
          */
         gap?: string;
         /**
+         * Font size of root
+         *
+         * @designToken button.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding x of root
          *
          * @designToken button.padding.x

--- a/packages/themes/types/datepicker/index.d.ts
+++ b/packages/themes/types/datepicker/index.d.ts
@@ -57,6 +57,12 @@ export interface DatePickerDesignTokens extends ColorSchemeDesignToken<DatePicke
          */
         shadow?: string;
         /**
+         * Font size of panel
+         *
+         * @designToken datepicker.panel.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding of panel
          *
          * @designToken datepicker.panel.padding

--- a/packages/themes/types/inputchips/index.d.ts
+++ b/packages/themes/types/inputchips/index.d.ts
@@ -88,6 +88,12 @@ export interface InputChipsDesignTokens extends ColorSchemeDesignToken<InputChip
          */
         shadow?: string;
         /**
+         * Font size of root
+         *
+         * @designToken inputchips.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding x of root
          *
          * @designToken inputchips.padding.x

--- a/packages/themes/types/inputtext/index.d.ts
+++ b/packages/themes/types/inputtext/index.d.ts
@@ -88,6 +88,12 @@ export interface InputTextDesignTokens extends ColorSchemeDesignToken<InputTextD
          */
         shadow?: string;
         /**
+         * Font size of root
+         *
+         * @designToken inputtext.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding x of root
          *
          * @designToken inputtext.padding.x

--- a/packages/themes/types/knob/index.d.ts
+++ b/packages/themes/types/knob/index.d.ts
@@ -84,6 +84,12 @@ export interface KnobDesignTokens extends ColorSchemeDesignToken<KnobDesignToken
      */
     text?: {
         /**
+         * Font size of text
+         *
+         * @designToken knob.text.font.size
+         */
+        fontSize?: string;
+        /**
          * Color of text
          *
          * @designToken knob.text.color

--- a/packages/themes/types/terminal/index.d.ts
+++ b/packages/themes/types/terminal/index.d.ts
@@ -40,6 +40,12 @@ export interface TerminalDesignTokens extends ColorSchemeDesignToken<TerminalDes
          */
         height?: string;
         /**
+         * Font size of root
+         *
+         * @designToken terminal.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding of root
          *
          * @designToken terminal.padding

--- a/packages/themes/types/textarea/index.d.ts
+++ b/packages/themes/types/textarea/index.d.ts
@@ -88,6 +88,12 @@ export interface TextareaDesignTokens extends ColorSchemeDesignToken<TextareaDes
          */
         shadow?: string;
         /**
+         * Font size of root
+         *
+         * @designToken textarea.font.size
+         */
+        fontSize?: string;
+        /**
          * Padding x of root
          *
          * @designToken textarea.padding.x

--- a/packages/themes/types/togglebutton/index.d.ts
+++ b/packages/themes/types/togglebutton/index.d.ts
@@ -34,6 +34,12 @@ export interface ToggleButtonDesignTokens extends ColorSchemeDesignToken<ToggleB
          */
         gap?: string;
         /**
+         * Font size of root
+         *
+         * @designToken togglebutton.font.size
+         */
+        fontSize?: string;
+        /**
          * Font weight of root
          *
          * @designToken togglebutton.font.weight


### PR DESCRIPTION
我想自定义一个 preset, 但是发现无法设置组件默认 font-size 样式

---

I want to customize a preset, but I've found that I can't set the default font-size style for the components.