### PR TITLE
Feat: Tree: Auto expand filtered TreeNodes

### DIFF
--- a/packages/primevue/src/tree/BaseTree.vue
+++ b/packages/primevue/src/tree/BaseTree.vue
@@ -10,10 +10,6 @@ export default {
             type: null,
             default: null
         },
-        displayedNodes: {
-            type: null,
-            default: null
-        },
         expandedKeys: {
             type: null,
             default: null

--- a/packages/primevue/src/tree/BaseTree.vue
+++ b/packages/primevue/src/tree/BaseTree.vue
@@ -10,9 +10,17 @@ export default {
             type: null,
             default: null
         },
+        displayedNodes: {
+            type: null,
+            default: null
+        },
         expandedKeys: {
             type: null,
             default: null
+        },
+        autoExpandOnFilter: {
+            type: Boolean,
+            default: false
         },
         selectionKeys: {
             type: null,

--- a/packages/primevue/src/tree/Tree.spec.js
+++ b/packages/primevue/src/tree/Tree.spec.js
@@ -55,10 +55,11 @@ describe('Tree.vue', () => {
         expect(wrapper.emitted('filter')).toBeTruthy();
     });
 
-    it('expands tree to filtered nodes on filter input', async () => {
+    it('does not expand tree to filtered nodes on filter input less than 3 characters', async () => {
         wrapper = mount(Tree, {
             props: {
                 filter: true,
+                autoExpandOnFilter: true,
                 value: [
                     {
                         key: '0',
@@ -92,12 +93,107 @@ describe('Tree.vue', () => {
             }
         });
 
-        let searchField = wrapper.find('input.p-tree-filter');
+        let searchField = wrapper.find('input.p-inputtext');
 
         await searchField.trigger('keydown.w');
 
-        expect(wrapper.find('span.pi-cog').exists()).toBeTruthy();
+        expect(wrapper.find('span.pi-cog').exists()).toBeFalsy();
         expect(wrapper.find('span.pi-calendar-plus').exists()).toBeFalsy();
+    });
+
+    it('expands tree to filtered nodes on filter input of 3 characters or more', async () => {
+        wrapper = mount(Tree, {
+            props: {
+                filter: true,
+                autoExpandOnFilter: true,
+                value: [
+                    {
+                        key: '0',
+                        label: 'Documents',
+                        data: 'Documents Folder',
+                        icon: 'pi pi-fw pi-inbox',
+                        children: [
+                            {
+                                key: '0-0',
+                                label: 'Work',
+                                data: 'Work Folder',
+                                icon: 'pi pi-fw pi-cog'
+                            }
+                        ]
+                    },
+                    {
+                        key: '1',
+                        label: 'Events',
+                        data: 'Events Folder',
+                        icon: 'pi pi-fw pi-calendar',
+                        children: [
+                            {
+                                key: '1-0',
+                                label: 'Meeting',
+                                icon: 'pi pi-fw pi-calendar-plus',
+                                data: 'Meeting'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let searchField = wrapper.find('input.p-inputtext');
+        await searchField.setValue('work');
+
+        expect(wrapper.find('span.pi-cog').exists()).toBeTruthy();
+        expect(wrapper.vm.$data.d_expandedKeys).toEqual({ 0: true });
+        expect(wrapper.find('span.pi-calendar-plus').exists()).toBeFalsy();
+    });
+
+    it('expands tree to selected nodes on filter input of less than 3 characters', async () => {
+        wrapper = mount(Tree, {
+            props: {
+                filter: true,
+                autoExpandOnFilter: true,
+                selectionMode: 'checkbox',
+                selectionKeys: { 1: { checked: false, partialChecked: true }, '1-0': { checked: true, partialChecked: false } },
+                value: [
+                    {
+                        key: '0',
+                        label: 'Documents',
+                        data: 'Documents Folder',
+                        icon: 'pi pi-fw pi-inbox',
+                        children: [
+                            {
+                                key: '0-0',
+                                label: 'Work',
+                                data: 'Work Folder',
+                                icon: 'pi pi-fw pi-cog'
+                            }
+                        ]
+                    },
+                    {
+                        key: '1',
+                        label: 'Events',
+                        data: 'Events Folder',
+                        icon: 'pi pi-fw pi-calendar',
+                        children: [
+                            {
+                                key: '1-0',
+                                label: 'Meeting',
+                                icon: 'pi pi-fw pi-calendar-plus',
+                                data: 'Meeting'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let searchField = wrapper.find('input.p-inputtext');
+        await searchField.setValue('w');
+        await searchField.setValue('');
+
+        expect(wrapper.find('span.pi-cog').exists()).toBeFalsy();
+        expect(wrapper.vm.$data.d_expandedKeys).toEqual({ 1: true });
+        expect(wrapper.find('span.pi-calendar-plus').exists()).toBeTruthy();
     });
 
     it('should render icon', ({ expect }) => {

--- a/packages/primevue/src/tree/Tree.spec.js
+++ b/packages/primevue/src/tree/Tree.spec.js
@@ -55,6 +55,51 @@ describe('Tree.vue', () => {
         expect(wrapper.emitted('filter')).toBeTruthy();
     });
 
+    it('expands tree to filtered nodes on filter input', async () => {
+        wrapper = mount(Tree, {
+            props: {
+                filter: true,
+                value: [
+                    {
+                        key: '0',
+                        label: 'Documents',
+                        data: 'Documents Folder',
+                        icon: 'pi pi-fw pi-inbox',
+                        children: [
+                            {
+                                key: '0-0',
+                                label: 'Work',
+                                data: 'Work Folder',
+                                icon: 'pi pi-fw pi-cog'
+                            }
+                        ]
+                    },
+                    {
+                        key: '1',
+                        label: 'Events',
+                        data: 'Events Folder',
+                        icon: 'pi pi-fw pi-calendar',
+                        children: [
+                            {
+                                key: '1-0',
+                                label: 'Meeting',
+                                icon: 'pi pi-fw pi-calendar-plus',
+                                data: 'Meeting'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let searchField = wrapper.find('input.p-tree-filter');
+
+        await searchField.trigger('keydown.w');
+
+        expect(wrapper.find('span.pi-cog').exists()).toBeTruthy();
+        expect(wrapper.find('span.pi-calendar-plus').exists()).toBeFalsy();
+    });
+
     it('should render icon', ({ expect }) => {
         expect(wrapper.find('span.pi-inbox').exists()).toBeTruthy();
         expect(wrapper.find('span.pi-inbox').classes('p-tree-node-icon')).toBeTruthy();

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -67,9 +67,9 @@ export default {
             this.d_expandedKeys = newValue;
         },
         filterValue(newValue, oldValue) {
-            if (newValue !== oldValue) {
-                if (this.autoExpandOnFilter) {
-                    for (let node of this.displayedNodes) {
+            if (this.autoExpandOnFilter && newValue !== oldValue) {
+                if (newValue?.length > 3) {
+                    for (let node of this.valueToRender) {
                         this.expandNode(node);
                     }
                     this.d_expandedKeys = { ...this.d_expandedKeys };

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -20,7 +20,7 @@
         <div :class="cx('wrapper')" :style="{ maxHeight: scrollHeight }" v-bind="ptm('wrapper')">
             <ul :class="cx('rootChildren')" role="tree" :aria-labelledby="ariaLabelledby" :aria-label="ariaLabel" v-bind="ptm('rootChildren')">
                 <TreeNode
-                    v-for="(node, index) of valueToRender"
+                    v-for="(node, index) of displayedNodes"
                     :key="node.key"
                     :node="node"
                     :templates="$slots"
@@ -65,6 +65,17 @@ export default {
     watch: {
         expandedKeys(newValue) {
             this.d_expandedKeys = newValue;
+        },
+        filterValue(newValue, oldValue) {
+            if (newValue !== oldValue) {
+                this.displayedNodes = this.getValueToRender();
+                if (this.autoExpandOnFilter) {
+                    for (let node of this.displayedNodes) {
+                        this.expandNode(node);
+                    }
+                    this.d_expandedKeys = { ...this.d_expandedKeys };
+                }
+            }
         }
     },
     methods: {
@@ -217,6 +228,19 @@ export default {
             }
 
             return matched;
+        },
+        getValueToRender() {
+            if (this.filterValue && this.filterValue.trim().length > 0) return this.filteredValue;
+            else return this.value;
+        },
+        expandNode(node) {
+            if (node.children && node.children.length) {
+                this.d_expandedKeys[node.key] = true;
+
+                for (let child of node.children) {
+                    this.expandNode(child);
+                }
+            }
         }
     },
     computed: {
@@ -239,11 +263,10 @@ export default {
             }
 
             return filteredNodes;
-        },
-        valueToRender() {
-            if (this.filterValue && this.filterValue.trim().length > 0) return this.filteredValue;
-            else return this.value;
         }
+    },
+    created() {
+        this.displayedNodes = this.getValueToRender();
     },
     components: {
         TreeNode,

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -20,7 +20,7 @@
         <div :class="cx('wrapper')" :style="{ maxHeight: scrollHeight }" v-bind="ptm('wrapper')">
             <ul :class="cx('rootChildren')" role="tree" :aria-labelledby="ariaLabelledby" :aria-label="ariaLabel" v-bind="ptm('rootChildren')">
                 <TreeNode
-                    v-for="(node, index) of displayedNodes"
+                    v-for="(node, index) of valueToRender"
                     :key="node.key"
                     :node="node"
                     :templates="$slots"
@@ -68,7 +68,6 @@ export default {
         },
         filterValue(newValue, oldValue) {
             if (newValue !== oldValue) {
-                this.displayedNodes = this.getValueToRender();
                 if (this.autoExpandOnFilter) {
                     for (let node of this.displayedNodes) {
                         this.expandNode(node);
@@ -229,10 +228,6 @@ export default {
 
             return matched;
         },
-        getValueToRender() {
-            if (this.filterValue && this.filterValue.trim().length > 0) return this.filteredValue;
-            else return this.value;
-        },
         expandNode(node) {
             if (node.children && node.children.length) {
                 this.d_expandedKeys[node.key] = true;
@@ -263,10 +258,11 @@ export default {
             }
 
             return filteredNodes;
+        },
+        valueToRender() {
+            if (this.filterValue && this.filterValue.trim().length > 0) return this.filteredValue;
+            else return this.value;
         }
-    },
-    created() {
-        this.displayedNodes = this.getValueToRender();
     },
     components: {
         TreeNode,

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -70,9 +70,12 @@ export default {
             if (this.autoExpandOnFilter && newValue !== oldValue) {
                 if (newValue?.length > 3) {
                     for (let node of this.valueToRender) {
-                        this.expandNode(node);
+                        this.expandNode(node, false);
                     }
                     this.d_expandedKeys = { ...this.d_expandedKeys };
+                } else {
+                    this.d_expandedKeys = {}
+                    this.expandToSelections();
                 }
             }
         }
@@ -174,8 +177,11 @@ export default {
         isNodeSelected(node) {
             return this.selectionMode && this.selectionKeys ? this.selectionKeys[node.key] === true : false;
         },
+        isPartialChecked(node) {
+            return this.selectionKeys?.[node.key]?.partialChecked === true;
+        },
         isChecked(node) {
-            return this.selectionKeys ? this.selectionKeys[node.key] && this.selectionKeys[node.key].checked : false;
+            return this.selectionKeys?.[node.key]?.checked === true;
         },
         isNodeLeaf(node) {
             return node.leaf === false ? false : !(node.children && node.children.length);
@@ -228,13 +234,18 @@ export default {
 
             return matched;
         },
-        expandNode(node) {
-            if (node.children && node.children.length) {
+        expandNode(node, expandIfSelected) {
+            if (node.children && node.children.length && (expandIfSelected ? this.isChecked(node) || this.isPartialChecked(node) : true)) {
                 this.d_expandedKeys[node.key] = true;
 
                 for (let child of node.children) {
-                    this.expandNode(child);
+                    this.expandNode(child, expandIfSelected);
                 }
+            }
+        },
+        expandToSelections() {
+            for (let node of this.valueToRender) {
+                this.expandNode(node, true);
             }
         }
     },


### PR DESCRIPTION
Requested in #3996

Updates Tree component with watcher on `filterValue` that automatically sets expanded nodes based on filter value length. Minimum threshold of 3 characters used when expanding nodes due to poor performance in large trees, although this could alternatively use the number of filtered nodes instead of filter value length as a threshold value. Filter of length >= 3 characters expands tree to all filtered nodes; otherwise, expands to all selected nodes.