### PR TITLE
fix: Adjust `p-inputnumber-button-group` `z-index` so it's not lower …

### DIFF
--- a/packages/primevue/src/inputnumber/style/InputNumberStyle.js
+++ b/packages/primevue/src/inputnumber/style/InputNumberStyle.js
@@ -40,6 +40,7 @@ const theme = ({ dt }) => `
     top: 1px;
     right: 1px;
     height: calc(100% - 2px);
+    z-index: 1;
 }
 
 .p-inputnumber-stacked .p-inputnumber-increment-button {


### PR DESCRIPTION
…when input text receives focus while in input group.

The issue was that input text was getting `z-index: 1` when in input group: https://github.com/primefaces/primevue/blob/master/packages/primevue/src/inputgroup/style/InputGroupStyle.js#L58

This PR adds `z-index: 1` for the stacked p-inputnumber-button-group

###Defect Fixes
Fixes #6212 
