### PR TITLE
feat(Select): avoid IME input issue when typing in filter

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -495,6 +495,12 @@ export default {
             !this.virtualScrollerDisabled && this.virtualScroller.scrollToIndex(0);
         },
         onFilterKeyDown(event) {
+            const isComposing = event.isComposing;
+
+            // Avoid IME input issue in Chinese, Japanese and Korean languages
+            // If they are still typing, do not trigger onFilterKeyDown
+            if (isComposing) return;
+
             switch (event.code) {
                 case 'ArrowDown':
                     this.onArrowDownKey(event);


### PR DESCRIPTION
###Defect Fixes
Fix #6279

Stop `onFilterKeyDown` when IME is still typing.