### PR TITLE
Improve typing of FileUploadState.messages

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.d.ts
+++ b/packages/primevue/src/fileupload/FileUpload.d.ts
@@ -304,7 +304,7 @@ export interface FileUploadState {
     /**
      * Current messages.
      */
-    messages: any[];
+    messages: string[] | null;
     /**
      * Current progress state as a number.
      */


### PR DESCRIPTION
`FileUploadState.messages`:
- usually string[]
- can also be `null`:

https://github.com/primefaces/primevue/blob/dcd66c151528b43576229f3a710f2537a302ee26/packages/primevue/src/fileupload/FileUpload.vue#L239