### PR TITLE
Update BreakingDoc.vue

### DIFF
--- a/apps/showcase/doc/guides/migration/v4/changes/BreakingDoc.vue
+++ b/apps/showcase/doc/guides/migration/v4/changes/BreakingDoc.vue
@@ -19,7 +19,7 @@
 
         <h4>Relocated APIs</h4>
         <ul class="flex flex-col gap-2 leading-normal">
-            <li>Imports from <i class="mark">primevue/api</i> have been relocated to <i class="mark">@primevue/core/api</i>.</li>
+            <li>Imports from <i class="mark">primevue/api</i> have been relocated to <i class="mark">@primevue/core/api</i>. If <i class="mark">@primevue/core</i> error during build, add <i class="mark">@primevue/core</i> to list of dependencies</li>
         </ul>
 
         <h4>Removed Files</h4>


### PR DESCRIPTION
In docs Relocated APIs
Imports from primevue/api have been relocated to @primevue/core/api.

This has missing information, if @primevue/core not yet added to dependencies it will error during Vite build. This PR propose to give more information.

###Defect Fixes
#6327 

Will also close #6327 