### PR TITLE
fix: handle click event using event.currentTarget in DataTable

### DIFF
--- a/packages/primevue/src/datatable/DataTable.spec.js
+++ b/packages/primevue/src/datatable/DataTable.spec.js
@@ -458,7 +458,7 @@ describe('DataTable.vue', () => {
         await wrapper.setProps({ selection: null, selectionMode: 'single' });
 
         await wrapper.vm.onRowClick({
-            originalEvent: { target: wrapper.findAll('tr.p-datatable-selectable-row')[0].element },
+            originalEvent: { currentTarget: wrapper.findAll('tr.p-datatable-selectable-row')[0].element },
             data: smallData[0],
             index: 0
         });
@@ -492,13 +492,13 @@ describe('DataTable.vue', () => {
         await wrapper.setProps({ selection: null, selectionMode: 'multiple', metaKeySelection: false });
 
         await wrapper.vm.onRowClick({
-            originalEvent: { target: wrapper.findAll('.p-datatable-selectable-row')[0].element },
+            originalEvent: { currentTarget: wrapper.findAll('.p-datatable-selectable-row')[0].element },
             data: smallData[0],
             index: 0
         });
 
         await wrapper.vm.onRowClick({
-            originalEvent: { target: wrapper.findAll('tr.p-datatable-selectable-row')[1].element },
+            originalEvent: { currentTarget: wrapper.findAll('tr.p-datatable-selectable-row')[1].element },
             data: smallData[1],
             index: 1
         });

--- a/packages/primevue/src/datatable/DataTable.spec.js
+++ b/packages/primevue/src/datatable/DataTable.spec.js
@@ -472,13 +472,13 @@ describe('DataTable.vue', () => {
         await wrapper.setProps({ selection: null, selectionMode: 'multiple' });
 
         await wrapper.vm.onRowClick({
-            originalEvent: { shiftKey: true, target: wrapper.findAll('tr.p-datatable-selectable-row')[0].element },
+            originalEvent: { shiftKey: true, currentTarget: wrapper.findAll('tr.p-datatable-selectable-row')[0].element },
             data: smallData[0],
             index: 0
         });
 
         await wrapper.vm.onRowClick({
-            originalEvent: { shiftKey: true, target: wrapper.findAll('tr.p-datatable-selectable-row')[1].element },
+            originalEvent: { shiftKey: true, currentTarget: wrapper.findAll('tr.p-datatable-selectable-row')[1].element },
             data: smallData[1],
             index: 1
         });

--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -281,24 +281,24 @@
 
 <script>
 import {
-addClass,
-addStyle,
-clearSelection,
-exportCSV,
-find,
-findSingle,
-focus,
-getAttribute,
-getHiddenElementOuterHeight,
-getHiddenElementOuterWidth,
-getIndex,
-getOffset,
-getOuterHeight,
-getOuterWidth,
-getWindowScrollTop,
-isClickable,
-removeClass,
-setAttribute
+    addClass,
+    addStyle,
+    clearSelection,
+    exportCSV,
+    find,
+    findSingle,
+    focus,
+    getAttribute,
+    getHiddenElementOuterHeight,
+    getHiddenElementOuterWidth,
+    getIndex,
+    getOffset,
+    getOuterHeight,
+    getOuterWidth,
+    getWindowScrollTop,
+    isClickable,
+    removeClass,
+    setAttribute
 } from '@primeuix/utils/dom';
 import { equals, findIndexInList, isEmpty, isNotEmpty, localeComparator, reorderArray, resolveFieldData, sort } from '@primeuix/utils/object';
 import { FilterMatchMode, FilterOperator, FilterService } from '@primevue/core/api';

--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -280,29 +280,29 @@
 </template>
 
 <script>
+import {
+addClass,
+addStyle,
+clearSelection,
+exportCSV,
+find,
+findSingle,
+focus,
+getAttribute,
+getHiddenElementOuterHeight,
+getHiddenElementOuterWidth,
+getIndex,
+getOffset,
+getOuterHeight,
+getOuterWidth,
+getWindowScrollTop,
+isClickable,
+removeClass,
+setAttribute
+} from '@primeuix/utils/dom';
+import { equals, findIndexInList, isEmpty, isNotEmpty, localeComparator, reorderArray, resolveFieldData, sort } from '@primeuix/utils/object';
 import { FilterMatchMode, FilterOperator, FilterService } from '@primevue/core/api';
 import { HelperSet, UniqueComponentId, getVNodeProp } from '@primevue/core/utils';
-import {
-    getAttribute,
-    clearSelection,
-    findSingle,
-    isClickable,
-    find,
-    focus,
-    exportCSV,
-    getOffset,
-    addStyle,
-    getIndex,
-    getOuterWidth,
-    getHiddenElementOuterWidth,
-    getHiddenElementOuterHeight,
-    getWindowScrollTop,
-    getOuterHeight,
-    removeClass,
-    addClass,
-    setAttribute
-} from '@primeuix/utils/dom';
-import { resolveFieldData, localeComparator, sort, findIndexInList, equals, reorderArray, isNotEmpty, isEmpty } from '@primeuix/utils/object';
 import ArrowDownIcon from '@primevue/icons/arrowdown';
 import ArrowUpIcon from '@primevue/icons/arrowup';
 import SpinnerIcon from '@primevue/icons/spinner';
@@ -736,7 +736,7 @@ export default {
             const body = this.$refs.bodyRef && this.$refs.bodyRef.$el;
             const focusedItem = findSingle(body, 'tr[data-p-selectable-row="true"][tabindex="0"]');
 
-            if (isClickable(event.target)) {
+            if (isClickable(event.currentTarget)) {
                 return;
             }
 
@@ -813,9 +813,9 @@ export default {
             this.rowTouched = false;
 
             if (focusedItem) {
-                if (event.target?.getAttribute('data-pc-section') === 'rowtoggleicon' || event.target?.parentElement?.getAttribute('data-pc-section') === 'rowtoggleicon') return;
+                if (event.currentTarget?.getAttribute('data-pc-section') === 'rowtoggleicon') return;
 
-                const targetRow = event.target?.closest('tr[data-p-selectable-row="true"]');
+                const targetRow = event.currentTarget?.closest('tr[data-p-selectable-row="true"]');
 
                 focusedItem.tabIndex = '-1';
                 targetRow.tabIndex = '0';


### PR DESCRIPTION
## Defect Fixes
Fixes: #6323 
### How to reproduce Issue
- First, paste code to `<template>` of `CellEditDoc.vue`
- and you click cell, you can see the issue
```html
<div class="card">
    <DataTable
        :value="products"
        editMode="cell"
        selectionMode="single"
        @cell-edit-complete="onCellEditComplete"
        :pt="{
            table: { style: 'min-width: 50rem' },
            column: {
                bodycell: ({ state }) => ({
                    class: [{ 'pt-0 pb-0': state['d_editing'] }]
                })
            }
        }"
    >
        <Column v-for="col of columns" :key="col.field" :field="col.field" :header="col.header" style="width: 25%">
            <template #body="{ data, field }">
                <div>
                    {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
                </div>
            </template>
            <template #editor="{ data, field }">
                <div>{{ data[field] }} 1</div>
            </template>
        </Column>
    </DataTable>
</div>
```
<br/>

- If you look at the video at the bottom, you can see that focusElement is null when the slot element is clicked.
For normal behavior, focusElement should exist.

https://github.com/user-attachments/assets/f26da6ea-4c00-47d2-b659-732b62fac952



<br/>

### How To Resolve
> I change event handling target `event.target` to `event.currentTarget`

- `event.target` references the clicked slot's internal element, which prevents finding the parent `<tr>` element. 
- `event.currentTarget` accurately points to the parent element that has the event handler attached.

_issue resolved video_

https://github.com/user-attachments/assets/a285c42c-43df-4079-83b6-e7c71b8af191



