### PR TITLE
[Doc] created new component DocSectionCardWithValue

### DIFF
--- a/apps/showcase/components/doc/DocSectionCardWithValue.vue
+++ b/apps/showcase/components/doc/DocSectionCardWithValue.vue
@@ -1,0 +1,42 @@
+<template>
+    <div class="card flex flex-col items-center relative">
+        <slot></slot>
+
+        <div v-if="showValue" class="mt-3" :class="valueClass">
+            <b>Value:</b> <span>{{ value }}</span>
+        </div>
+
+        <div class="absolute top-2 right-2 flex items-center gap-1 opacity-20 hover:opacity-100 transition-opacity duration-300">
+            <Button
+                v-tooltip.bottom="{ value: showValue ? 'Hide Value' : 'Show Value', class: 'doc-section-code-tooltip' }"
+                @click="showValue = !showValue"
+                class="size-8"
+                severity="secondary"
+            >
+                <i v-if="showValue" class="pi pi-eye-slash text-lg"></i>
+                <i v-else class="pi text-lg pi-eye"></i>
+            </Button>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    inheritAttrs: false,
+    props: {
+        value: {
+            type: null,
+            default: null
+        },
+        valueClass: {
+            type: String,
+            default: 'mt-3'
+        }
+    },
+    data() {
+        return {
+            showValue: false
+        };
+    }
+};
+</script>

--- a/apps/showcase/doc/inputotp/BasicDoc.vue
+++ b/apps/showcase/doc/inputotp/BasicDoc.vue
@@ -2,9 +2,9 @@
     <DocSectionText v-bind="$attrs">
         <p>Two-way value binding is defined using <i>v-model</i>. The number of characters is defined with the <i>length</i> property, which is set to 4 by default.</p>
     </DocSectionText>
-    <div class="card flex justify-center">
+    <DocSectionCardWithValue :value="value" value-class="w-28">
         <InputOtp v-model="value" />
-    </div>
+    </DocSectionCardWithValue>
     <DocSectionCode :code="code" />
 </template>
 

--- a/apps/showcase/doc/inputotp/IntegerOnlyDoc.vue
+++ b/apps/showcase/doc/inputotp/IntegerOnlyDoc.vue
@@ -2,9 +2,9 @@
     <DocSectionText v-bind="$attrs">
         <p>When <i>integerOnly</i> is present, only integers can be accepted as input.</p>
     </DocSectionText>
-    <div class="card flex justify-center">
+    <DocSectionCardWithValue :value="value" value-class="w-28">
         <InputOtp v-model="value" integerOnly />
-    </div>
+    </DocSectionCardWithValue>
     <DocSectionCode :code="code" />
 </template>
 

--- a/apps/showcase/doc/inputotp/MaskDoc.vue
+++ b/apps/showcase/doc/inputotp/MaskDoc.vue
@@ -2,9 +2,9 @@
     <DocSectionText v-bind="$attrs">
         <p>Enable the <i>mask</i> option to hide the values in the input fields.</p>
     </DocSectionText>
-    <div class="card flex justify-center">
+    <DocSectionCardWithValue :value="value" value-class="w-28">
         <InputOtp v-model="value" mask />
-    </div>
+    </DocSectionCardWithValue>
     <DocSectionCode :code="code" />
 </template>
 

--- a/apps/showcase/doc/inputotp/SampleDoc.vue
+++ b/apps/showcase/doc/inputotp/SampleDoc.vue
@@ -2,7 +2,7 @@
     <DocSectionText v-bind="$attrs">
         <p>A sample UI implementation with templating and additional elements.</p>
     </DocSectionText>
-    <div class="card flex justify-center">
+    <DocSectionCardWithValue :value="value" value-class="w-28 mt-5">
         <div class="flex flex-col items-center">
             <div class="font-bold text-xl mb-2">Authenticate Your Account</div>
             <p class="text-surface-500 dark:text-surface-400 block mb-8">Please enter the code sent to your phone.</p>
@@ -19,7 +19,7 @@
                 <Button label="Submit Code"></Button>
             </div>
         </div>
-    </div>
+    </DocSectionCardWithValue>
     <DocSectionCode :code="code" />
 </template>
 

--- a/apps/showcase/doc/inputotp/TemplateDoc.vue
+++ b/apps/showcase/doc/inputotp/TemplateDoc.vue
@@ -2,13 +2,13 @@
     <DocSectionText v-bind="$attrs">
         <p>Define a template with your own UI elements with bindings to the provided events and attributes to replace the default design.</p>
     </DocSectionText>
-    <div class="card flex justify-center">
+    <DocSectionCardWithValue :value="value" value-class="w-28 mt-5">
         <InputOtp v-model="value">
             <template #default="{ attrs, events }">
                 <input type="text" v-bind="attrs" v-on="events" class="custom-otp-input" />
             </template>
         </InputOtp>
-    </div>
+    </DocSectionCardWithValue>
     <DocSectionCode :code="code" />
 </template>
 


### PR DESCRIPTION
This component adds a button to the top-right of the card, which toggles the real-time value display. See the screenshot below:

Default (inactive):
![image](https://github.com/user-attachments/assets/54b23503-9bb7-4984-bac3-d0047b1aae0b)

On hover:
![image](https://github.com/user-attachments/assets/183458a1-7bf1-47da-b943-0f068f08ce55)

When active:
![image](https://github.com/user-attachments/assets/ccd341bc-9daa-4cc6-97e7-8eb17703941a)



Example usage:
```vue
...
<DocSectionCardWithValue :value="value" value-class="w-28">
    <InputOtp v-model="value" integerOnly />
</DocSectionCardWithValue>
...

```


before, this was like this:
```vue
...
<div class="card flex justify-center">
    <InputOtp v-model="value" integerOnly />
</div>
...
```



P.S. If you like this approach and decide to merge it, I'll update the documentation for the other components as well.