### PR TITLE
[InputOtp] select box content when clicking on a box

### DIFF
--- a/packages/primevue/src/inputotp/InputOtp.vue
+++ b/packages/primevue/src/inputotp/InputOtp.vue
@@ -18,6 +18,7 @@
                     @blur="onBlur($event)"
                     @paste="onPaste($event)"
                     @keydown="onKeyDown($event)"
+                    @click="onClick($event)"
                     :pt="ptm('pcInput')"
                 />
             </slot>
@@ -127,6 +128,9 @@ export default {
         },
         onBlur(event) {
             this.$emit('blur', event);
+        },
+        onClick(event) {
+            setTimeout(() => event.target.select(), 1);
         },
         onKeyDown(event) {
             if (event.ctrlKey || event.metaKey) {


### PR DESCRIPTION
This PR fixes following problem:

When an OTP box is already focused and you click on it, the box content is not selected anymore. If the caret is before the content you can't update the value. Like the case in the screenshot below:
![image](https://github.com/user-attachments/assets/30303aaa-c623-4f69-88d9-3ffbac17d07e)


With this PR the content is always selected.