### PR TITLE
Dialog: fix #6356 and implement #6357

### DIFF
--- a/packages/primevue/scripts/components/dialog.js
+++ b/packages/primevue/scripts/components/dialog.js
@@ -181,6 +181,17 @@ const DialogEvents = [
         ]
     },
     {
+        name: 'dragstart',
+        description: 'Fired when a dialog drag begins.',
+        arguments: [
+            {
+                name: 'event',
+                type: 'object',
+                description: 'Event Object'
+            }
+        ]
+    },
+    {
         name: 'dragend',
         description: 'Fired when a dialog drag completes.',
         arguments: [

--- a/packages/primevue/src/dialog/Dialog.d.ts
+++ b/packages/primevue/src/dialog/Dialog.d.ts
@@ -402,6 +402,11 @@ export interface DialogEmitsOptions {
      */
     unmaximize(event: Event): void;
     /**
+     * Fired when a dialog drag begins.
+     * @param {event} event - Browser event.
+     */
+    dragstart(event: Event): void;
+    /**
      * Fired when a dialog drag completes.
      * @param {event} event - Browser event.
      */

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -163,6 +163,10 @@ export default {
             if (this.modal) {
                 !this.isUnstyled && addClass(this.mask, 'p-overlay-mask-leave');
             }
+
+            if (this.dragging && this.documentDragEndListener) {
+                this.documentDragEndListener();
+            }
         },
         onLeave() {
             this.$emit('hide');

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -79,7 +79,7 @@ export default {
     name: 'Dialog',
     extends: BaseDialog,
     inheritAttrs: false,
-    emits: ['update:visible', 'show', 'hide', 'after-hide', 'maximize', 'unmaximize', 'dragend'],
+    emits: ['update:visible', 'show', 'hide', 'after-hide', 'maximize', 'unmaximize', 'dragstart', 'dragend'],
     provide() {
         return {
             dialogRef: computed(() => this._instance)
@@ -324,6 +324,8 @@ export default {
                 this.container.style.margin = '0';
                 document.body.setAttribute('data-p-unselectable-text', 'true');
                 !this.isUnstyled && addStyle(document.body, { 'user-select': 'none' });
+
+                this.$emit('dragstart', event);
             }
         },
         bindGlobalListeners() {


### PR DESCRIPTION
This PR fixes #6356 - Dialog dragging state not reset when a dialog is closed while being dragged. \
It additionally resolves #6357 by adding a `dragstart` event to accompany the `dragend` event.