### PR TITLE
Customize the injection document

### DIFF
--- a/packages/core/src/basecomponent/BaseComponent.vue
+++ b/packages/core/src/basecomponent/BaseComponent.vue
@@ -323,7 +323,7 @@ export default {
             return { classes: undefined, inlineStyles: undefined, load: () => {}, loadCSS: () => {}, loadTheme: () => {}, ...(this._getHostInstance(this) || {}).$style, ...this.$options.style };
         },
         $styleOptions() {
-            return { nonce: this.$primevueConfig?.csp?.nonce };
+            return { nonce: this.$primevueConfig?.csp?.nonce, document: this.$primevueConfig?.document };
         },
         $primevueConfig() {
             return this.$primevue?.config;

--- a/packages/core/src/basedirective/BaseDirective.js
+++ b/packages/core/src/basedirective/BaseDirective.js
@@ -70,7 +70,7 @@ const BaseDirective = {
     },
     _loadStyles: (el, binding, vnode) => {
         const config = BaseDirective._getConfig(binding, vnode);
-        const useStyleOptions = { nonce: config?.csp?.nonce };
+        const useStyleOptions = { nonce: config?.csp?.nonce, document: config?.document };
 
         BaseDirective._loadCoreStyles(el.$instance, useStyleOptions);
         BaseDirective._loadThemeStyles(el.$instance, useStyleOptions);

--- a/packages/core/src/config/PrimeVue.d.ts
+++ b/packages/core/src/config/PrimeVue.d.ts
@@ -15,6 +15,7 @@ export interface PrimeVueConfiguration {
     pt?: any;
     ptOptions?: any;
     csp?: PrimeVueCSPOptions;
+    document?: Document
 }
 
 export declare const defaultOptions: PrimeVueConfiguration;

--- a/packages/core/src/config/PrimeVue.js
+++ b/packages/core/src/config/PrimeVue.js
@@ -196,7 +196,7 @@ export function setupConfig(app, PrimeVue) {
         // common
         if (!Theme.isStyleNameLoaded('common')) {
             const { primitive, semantic } = BaseStyle.getCommonTheme?.() || {};
-            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce };
+            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce, document: PrimeVue.config?.document };
 
             BaseStyle.load(primitive?.css, { name: 'primitive-variables', ...styleOptions });
             BaseStyle.load(semantic?.css, { name: 'semantic-variables', ...styleOptions });


### PR DESCRIPTION
Currently all styles are injected into the top level document, I'm working on an application using ShadowDOM, and since the styles are currently injected into the outer document, which doesn't work properly in ShadowDOM, I'd like to specify where the styles are injected, based on a config item.
