### PR TITLE
Fix #6371: Add node and expanded data on nodetoggleicon.

### DIFF
--- a/packages/primevue/src/tree/TreeNode.vue
+++ b/packages/primevue/src/tree/TreeNode.vue
@@ -18,7 +18,7 @@
             <button v-ripple type="button" :class="cx('nodeToggleButton')" @click="toggle" tabindex="-1" v-bind="getPTOptions('nodeToggleButton')">
                 <template v-if="node.loading && loadingMode === 'icon'">
                     <!-- TODO: nodetogglericon deprecated since v4.0-->
-                    <component v-if="templates['nodetoggleicon'] || templates['nodetogglericon']" :is="templates['nodetoggleicon'] || templates['nodetogglericon']" :class="cx('nodeToggleIcon')" />
+                    <component v-if="templates['nodetoggleicon'] || templates['nodetogglericon']" :is="templates['nodetoggleicon'] || templates['nodetogglericon']" :node="node" :expanded="expanded" :class="cx('nodeToggleIcon')" />
                     <SpinnerIcon v-else spin :class="cx('nodetogglericon')" v-bind="ptm('nodeToggleIcon')" />
                 </template>
                 <template v-else>


### PR DESCRIPTION
Nodetoggleicon slot is used to customize expand / collapse and loading icon, but when loading mode is set to icon mode and a node is loading, TreeNode use nodetoggleicon without any props instead of binding node and expanded.
This commit bind node and expanded props to nodetoggleicon slot when loading mode is set to icon and node.loading is true.
