### PR TITLE
Fix incorrect statement in palette() docs

### DIFF
--- a/apps/showcase/doc/theming/styled/utils/PaletteDoc.vue
+++ b/apps/showcase/doc/theming/styled/utils/PaletteDoc.vue
@@ -1,6 +1,6 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>Returns shades and tints of a given color from 50 to 950 as an array.</p>
+        <p>Returns shades and tints of a given color from 50 to 950 as an object.</p>
     </DocSectionText>
     <DocSectionCode :code="code" hideToggleCode importCode hideStackBlitz />
 </template>


### PR DESCRIPTION
`palette()` returns key-value pairs, not an array.

Do one-word typo fixes like this need tickets?