### PR TITLE
Proposal for #5463: Add a resetState method to splitter to manually reset state

### DIFF
--- a/packages/primevue/src/splitter/Splitter.d.ts
+++ b/packages/primevue/src/splitter/Splitter.d.ts
@@ -226,6 +226,13 @@ export interface SplitterEmitsOptions {
 
 export declare type SplitterEmits = EmitFn<SplitterEmitsOptions>;
 
+export interface SplitterMethods {
+    /**
+     * This method resizes all panels by either using the stored state in the case of a stateful Splitter, the size property of each SplitterPanel, or by resetting them to their default values.
+     */
+    resetState(): void;
+}
+
 /**
  * **PrimeVue - Splitter**
  *
@@ -238,7 +245,7 @@ export declare type SplitterEmits = EmitFn<SplitterEmitsOptions>;
  * @group Component
  *
  */
-declare const Splitter: DefineComponent<SplitterProps, SplitterSlots, SplitterEmits>;
+declare const Splitter: DefineComponent<SplitterProps, SplitterSlots, SplitterEmits, SplitterMethods>;
 
 declare module 'vue' {
     export interface GlobalComponents {

--- a/packages/primevue/src/splitter/Splitter.vue
+++ b/packages/primevue/src/splitter/Splitter.vue
@@ -22,9 +22,9 @@
 </template>
 
 <script>
-import { getVNodeProp } from '@primevue/core/utils';
-import { getWidth, getHeight, getOuterWidth, getOuterHeight } from '@primeuix/utils/dom';
+import { getHeight, getOuterHeight, getOuterWidth, getWidth } from '@primeuix/utils/dom';
 import { isArray } from '@primeuix/utils/object';
+import { getVNodeProp } from '@primevue/core/utils';
 import BaseSplitter from './BaseSplitter.vue';
 
 export default {
@@ -53,29 +53,7 @@ export default {
         };
     },
     mounted() {
-        if (this.panels && this.panels.length) {
-            let initialized = false;
-
-            if (this.isStateful()) {
-                initialized = this.restoreState();
-            }
-
-            if (!initialized) {
-                let children = [...this.$el.children].filter((child) => child.getAttribute('data-pc-name') === 'splitterpanel');
-                let _panelSizes = [];
-
-                this.panels.map((panel, i) => {
-                    let panelInitialSize = panel.props && panel.props.size ? panel.props.size : null;
-                    let panelSize = panelInitialSize || 100 / this.panels.length;
-
-                    _panelSizes[i] = panelSize;
-                    children[i].style.flexBasis = 'calc(' + panelSize + '% - ' + (this.panels.length - 1) * this.gutterSize + 'px)';
-                });
-
-                this.panelSizes = _panelSizes;
-                this.prevSize = parseFloat(_panelSizes[0]).toFixed(4);
-            }
-        }
+        this.initializePanels();
     },
     beforeUnmount() {
         this.clear();
@@ -84,6 +62,31 @@ export default {
     methods: {
         isSplitterPanel(child) {
             return child.type.name === 'SplitterPanel';
+        },
+        initializePanels() {
+            if (this.panels && this.panels.length) {
+                let initialized = false;
+
+                if (this.isStateful()) {
+                    initialized = this.restoreState();
+                }
+
+                if (!initialized) {
+                    let children = [...this.$el.children].filter((child) => child.getAttribute('data-pc-name') === 'splitterpanel');
+                    let _panelSizes = [];
+
+                    this.panels.map((panel, i) => {
+                        let panelInitialSize = panel.props && panel.props.size ? panel.props.size : null;
+                        let panelSize = panelInitialSize || 100 / this.panels.length;
+
+                        _panelSizes[i] = panelSize;
+                        children[i].style.flexBasis = 'calc(' + panelSize + '% - ' + (this.panels.length - 1) * this.gutterSize + 'px)';
+                    });
+
+                    this.panelSizes = _panelSizes;
+                    this.prevSize = parseFloat(_panelSizes[0]).toFixed(4);
+                }
+            }
         },
         onResizeStart(event, index, isKeyDown) {
             this.gutterElement = event.currentTarget || event.target.parentElement;
@@ -348,6 +351,9 @@ export default {
             }
 
             return false;
+        },
+        resetState() {
+            this.initializePanels();
         }
     },
     computed: {


### PR DESCRIPTION
Hello,

I'm encountering the issue #5463, and I don't think the approach proposed by matansha is ideal. Recalculating the "initial" state on every component update will reset user resize actions each time the component is updated, making it unusable.

One potential solution could be for the Splitter to observe changes on the size property of each SplitterPanel. However, this seems risky because these values might be updated simultaneously across all panels, leading to unintended frequent updates.

A more straightforward approach could be to introduce a reset function on the Splitter component, allowing users to manually re-run the initialization code (initializeState).

For those who want permanent synchronization, they could add a watcher on the size props to trigger a reset on each update.

resolves #5463   