### PR TITLE
fix: emit unmask value to update:modelValue when unmask mode

### DIFF
--- a/packages/primevue/src/inputmask/InputMask.vue
+++ b/packages/primevue/src/inputmask/InputMask.vue
@@ -446,7 +446,7 @@ export default {
         },
 
         updateModelValue(value) {
-            let val = this.unmask ? this.getUnmaskedValue() : value;
+            const val = this.unmask ? this.getUnmaskedValue() : value;
 
             this.currentVal = value;
 

--- a/packages/primevue/src/inputmask/InputMask.vue
+++ b/packages/primevue/src/inputmask/InputMask.vue
@@ -1,7 +1,7 @@
 <template>
     <InputText
         :id="id"
-        :value="modelValue"
+        :value="currentVal"
         :class="inputClass"
         :readonly="readonly"
         :disabled="disabled"
@@ -37,6 +37,11 @@ export default {
     inject: {
         $pcFluid: { default: null }
     },
+    data() {
+        return {
+            currentVal: ''
+        };
+    },
     watch: {
         mask(newMask, oldMask) {
             if (oldMask !== newMask) {
@@ -60,7 +65,7 @@ export default {
                 if (this.androidChrome) this.handleAndroidInput(event);
                 else this.handleInputChange(event);
 
-                this.$emit('update:modelValue', event.target.value);
+                this.updateModelValue(event.target.value);
             }
         },
         onFocus(event) {
@@ -96,7 +101,7 @@ export default {
         onBlur(event) {
             this.focus = false;
             this.checkVal();
-            this.updateModel(event);
+            this.updateModelValue(event.target.value);
 
             if (this.$el.value !== this.focusText) {
                 let e = document.createEvent('HTMLEvents');
@@ -133,18 +138,18 @@ export default {
 
                 this.clearBuffer(begin, end);
                 this.shiftL(begin, end - 1);
-                this.updateModel(event);
+                this.updateModelValue(event.target.value);
 
                 event.preventDefault();
             } else if (k === 'Enter') {
                 // enter
                 this.$el.blur();
-                this.updateModel(event);
+                this.updateModelValue(event.target.value);
             } else if (k === 'Escape') {
                 // escape
                 this.$el.value = this.focusText;
                 this.caret(0, this.checkVal());
-                this.updateModel(event);
+                this.updateModelValue(event.target.value);
                 event.preventDefault();
             }
 
@@ -203,7 +208,7 @@ export default {
                 event.preventDefault();
             }
 
-            this.updateModel(event);
+            this.updateModelValue(event.target.value);
 
             if (completed) {
                 this.$emit('complete', event);
@@ -420,7 +425,7 @@ export default {
             var pos = this.checkVal(true);
 
             this.caret(pos);
-            this.updateModel(event);
+            this.updateModelValue(event.target.value);
 
             if (this.isCompleted()) {
                 this.$emit('complete', event);
@@ -439,8 +444,11 @@ export default {
 
             return unmaskedBuffer.join('');
         },
-        updateModel(e) {
-            let val = this.unmask ? this.getUnmaskedValue() : e.target.value;
+
+        updateModelValue(value) {
+            let val = this.unmask ? this.getUnmaskedValue() : value;
+
+            this.currentVal = value;
 
             this.$emit('update:modelValue', this.defaultBuffer !== val ? val : '');
         },
@@ -448,7 +456,7 @@ export default {
             if (this.$el) {
                 if (this.modelValue == null) {
                     this.$el.value = '';
-                    updateModel && this.$emit('update:modelValue', '');
+                    updateModel && this.updateModelValue('');
                 } else {
                     this.$el.value = this.modelValue;
                     this.checkVal();
@@ -458,11 +466,7 @@ export default {
                             this.writeBuffer();
                             this.checkVal();
 
-                            if (updateModel) {
-                                let val = this.unmask ? this.getUnmaskedValue() : this.$el.value;
-
-                                this.$emit('update:modelValue', this.defaultBuffer !== val ? val : '');
-                            }
+                            if (updateModel) this.updateModelValue(this.$el.value);
                         }
                     }, 10);
                 }


### PR DESCRIPTION
## Defect Fixes
- fix #6276

<br/>

## how to resolve
### Why the issue occured?
- In version 3 ([v3](https://github.com/primefaces/primevue/blob/v3/components/lib/inputmask/InputMask.vue#L2C5-L2C60)), there was no issue of value mixing when in unmask mode. 
- This is because v3 used native input rather than `inputText component` and did not pass the value dynamically.

<img width="1699" alt="스크린샷 2024-09-16 오후 6 17 56" src="https://github.com/user-attachments/assets/b4dd80ac-23e9-42f9-bf88-10d6bac7b39e">

- However, in version 4 (v4), `inputText component` is used, which dynamically receives the value. 
- This causes an issue where the unmasked value is sent with `update:model-value`, leading to value updates being corrupted.

<br/>

### solution
> based on the behavior of v3, the following modifications were made:
1. `currentVal` variable was declared to display the masked value in inputText, regardless of whether it is in unmask mode.
2. The unmasked value is sent with `update:model-value` when unmask mode.
3. inputText displays the masked value using `currentVal`.

_result video_


https://github.com/user-attachments/assets/817cd8ba-995c-4106-b69d-ee6f65841023

