### PR TITLE
fix(v4): add appendTo to drawer

### DIFF
--- a/packages/primevue/src/drawer/BaseDrawer.vue
+++ b/packages/primevue/src/drawer/BaseDrawer.vue
@@ -6,6 +6,10 @@ export default {
     name: 'BaseDrawer',
     extends: BaseComponent,
     props: {
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
+        },
         visible: {
             type: Boolean,
             default: false

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -125,6 +125,11 @@ export interface DrawerState {
  */
 export interface DrawerProps {
     /**
+     * A valid query selector or an HTMLElement to specify where the dialog gets attached.
+     * @defaultValue body
+     */
+    appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
+    /**
      * Specifies the visibility of the dialog.
      * @defaultValue false
      */

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -1,5 +1,5 @@
 <template>
-    <Portal>
+    <Portal :appendTo="appendTo">
         <div v-if="containerVisible" :ref="maskRef" @mousedown="onMaskClick" :class="cx('mask')" :style="sx('mask', true, { position })" v-bind="ptm('mask')">
             <transition name="p-drawer" @enter="onEnter" @after-enter="onAfterEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
                 <div v-if="visible" :ref="containerRef" v-focustrap :class="cx('root')" role="complementary" :aria-modal="modal" v-bind="ptmi('root')">


### PR DESCRIPTION
This fix adds appendTo functionality similar to other primevue components

Yesterday I encountered a problem in the drawer component, I needed the component to be created outside the body. Since I am currently developing a full-screen mode for my application and I need the drawer component to be a child component so that it can be displayed on top of the table opened in full-screen mode