### PR TITLE
#6404 fix: add messages to FileUpload templates

### DIFF
--- a/apps/showcase/doc/fileupload/TemplateDoc.vue
+++ b/apps/showcase/doc/fileupload/TemplateDoc.vue
@@ -18,7 +18,7 @@
             </template>
             <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
                 <div class="flex flex-col gap-8 pt-4">
-                    <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+                    <Message v-for="message of messages" :key="message" :class="{ 'mb-8': !files.length && !uploadedFiles.length }" severity="error">
                         {{ message }}
                     </Message>
 
@@ -88,7 +88,7 @@ export default {
     </template>
     <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
         <div class="flex flex-col gap-8 pt-4">
-            <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+            <Message v-for="message of messages" :key="message" :class="{ 'mb-8': !files.length && !uploadedFiles.length}" severity="error">
                 {{ message }}
             </Message>
 
@@ -150,7 +150,7 @@ export default {
             </template>
             <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
                 <div class="flex flex-col gap-8 pt-4">
-                    <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+                    <Message v-for="message of messages" :key="message" :class="{ 'mb-8': !files.length && !uploadedFiles.length}" severity="error">
                         {{ message }}
                     </Message>
 

--- a/apps/showcase/doc/fileupload/TemplateDoc.vue
+++ b/apps/showcase/doc/fileupload/TemplateDoc.vue
@@ -16,8 +16,12 @@
                     </ProgressBar>
                 </div>
             </template>
-            <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback }">
+            <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
                 <div class="flex flex-col gap-8 pt-4">
+                    <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+                        {{ message }}
+                    </Message>
+
                     <div v-if="files.length > 0">
                         <h5>Pending</h5>
                         <div class="flex flex-wrap gap-4">
@@ -82,8 +86,12 @@ export default {
             </ProgressBar>
         </div>
     </template>
-    <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback }">
+    <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
         <div class="flex flex-col gap-8 pt-4">
+            <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+                {{ message }}
+            </Message>
+
             <div v-if="files.length > 0">
                 <h5>Pending</h5>
                 <div class="flex flex-wrap gap-4">
@@ -140,8 +148,12 @@ export default {
                     </ProgressBar>
                 </div>
             </template>
-            <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback }">
+            <template #content="{ files, uploadedFiles, removeUploadedFileCallback, removeFileCallback, messages }">
                 <div class="flex flex-col gap-8 pt-4">
+                    <Message v-for="message of messages" :key="message" :class="{'mb-8': !files.length && !uploadedFiles.length}" severity="error">
+                        {{ message }}
+                    </Message>
+
                     <div v-if="files.length > 0">
                         <h5>Pending</h5>
                         <div class="flex flex-wrap gap-4">


### PR DESCRIPTION
Update regarding [#6404](https://github.com/primefaces/primevue/issues/6404) to add `messages` to `content` template of `FileUpload` example. 

If any one in the team thinks this extension makes sense, the StackBlitz live example would also require updating for full effect. 