### PR TITLE
fix DataTable: Allow drop below bottom row

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -295,7 +295,6 @@ import {
     getOffset,
     getOuterHeight,
     getOuterWidth,
-    getWindowScrollTop,
     isClickable,
     removeClass,
     setAttribute
@@ -1532,7 +1531,7 @@ export default {
 
             if (this.rowDragging && this.draggedRowIndex !== index) {
                 let rowElement = event.currentTarget;
-                let rowY = getOffset(rowElement).top + getWindowScrollTop();
+                let rowY = getOffset(rowElement).top;
                 let pageY = event.pageY;
                 let rowMidY = rowY + getOuterHeight(rowElement) / 2;
                 let prevRowElement = rowElement.previousElementSibling;


### PR DESCRIPTION
Fixes #6014 by removing the double counting of the page scroll position.

The `getOffset()` utility function already includes the window's scroll position (see [here](https://github.com/primefaces/primeuix/blob/20388c576629d62cc9625ba87c1975aba78f85ef/packages/utils/src/dom/methods/getOffset.ts#L6-L7)). Double counting the scroll offset meant that the DataTable `onRowDragOver` event handler always thought we were on the top-half of the row, preventing the indicator from being shown at the bottom of the row.
