### PR TITLE
Initialized expandedRows as Array in Docs

### DIFF
--- a/apps/showcase/doc/datatable/RowExpansionDoc.vue
+++ b/apps/showcase/doc/datatable/RowExpansionDoc.vue
@@ -340,7 +340,7 @@ import { useToast } from 'primevue/usetoast';
 import { ProductService } from '@/service/ProductService';
 
 const products = ref();
-const expandedRows = ref({});
+const expandedRows = ref([]);
 const toast = useToast();
 
 onMounted(() => {


### PR DESCRIPTION
Initializing expandedRows as an Object ({}) will result in an error in Vue 3.5. expandedRows has to be initialized as either an empty Array or as a plain, empty ref()

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.