### PR TITLE
fix: add an extra condition for tryOnMounted method

### DIFF
--- a/packages/core/src/usestyle/UseStyle.js
+++ b/packages/core/src/usestyle/UseStyle.js
@@ -6,7 +6,7 @@ import { isClient, isExist, setAttribute, setAttributes } from '@primeuix/utils/
 import { getCurrentInstance, nextTick, onMounted, readonly, ref, watch } from 'vue';
 
 function tryOnMounted(fn, sync = true) {
-    if (getCurrentInstance()) onMounted(fn);
+    if (getCurrentInstance() && getCurrentInstance().components) onMounted(fn);
     else if (sync) fn();
     else nextTick(fn);
 }


### PR DESCRIPTION
For issue #6445

This pull request includes an extra condition for tryOnMounted. It was made because `getCurrentInstance` returns an object that could have a `isMounted: true` flag value, but the value of the Vue application context properties, for example, 'components', could have `null`. So this fix is useful for `module federation` and can fix css variables problems that I described in issue ahead.