### PR TITLE
fix: remove needless description of popover

### DIFF
--- a/packages/primevue/src/popover/Popover.d.ts
+++ b/packages/primevue/src/popover/Popover.d.ts
@@ -237,7 +237,7 @@ export interface PopoverMethods {
 /**
  * **PrimeVue - Popover**
  *
- * _Popover, also known as Popover, is a container component that can overlay other components on page._
+ * _Popover is a container component that can overlay other components on page._
  *
  * [Live Demo](https://www.primevue.org/popover/)
  * --- ---


### PR DESCRIPTION
closes #6448 

The reference to the popover alias is no longer necessary and should be removed.
