### PR TITLE
fix: add an extra condition for tryOnMounted method

### DIFF
--- a/packages/core/src/usestyle/UseStyle.js
+++ b/packages/core/src/usestyle/UseStyle.js
@@ -6,7 +6,7 @@ import { isClient, isExist, setAttribute, setAttributes } from '@primeuix/utils/
 import { getCurrentInstance, nextTick, onMounted, readonly, ref, watch } from 'vue';
 
 function tryOnMounted(fn, sync = true) {
-    if (getCurrentInstance()) onMounted(fn);
+    if (getCurrentInstance() && getCurrentInstance().components) onMounted(fn);
     else if (sync) fn();
     else nextTick(fn);
 }


### PR DESCRIPTION
For issue #6453 
This pull request includes an extra condition for tryOnMounted. It was made because getCurrentInstance returns an object that could have a isMounted: true flag value, but the value of the Vue application context properties, for example, 'components', could have null. So this fix is useful for module federation and can fix CSS variables problems that I described in the issue ahead.
This change improves the problem with CSS rules applying. There are some pictures before and after changes. It's from my MF Primevue example https://github.com/andrew-cmdltt/primevue-4-vite-issue-template-mf.
Before:
![image](https://github.com/user-attachments/assets/d012c20b-ecea-46fe-900e-f42e9f299858)
After:
![image](https://github.com/user-attachments/assets/411baad0-c80f-48af-97bf-ddc95efdfe0a)
So now these CSS rules are not undefined and attached to the head:
![image](https://github.com/user-attachments/assets/a5adcf66-547b-43b3-9ba8-db831708452b)