### PR TITLE
feat(Drawer): add `appendTo` option to support rendering DOM into current element

### DIFF
--- a/packages/primevue/src/drawer/BaseDrawer.vue
+++ b/packages/primevue/src/drawer/BaseDrawer.vue
@@ -51,6 +51,10 @@ export default {
         blockScroll: {
             type: Boolean,
             default: false
+        },
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
         }
     },
     style: DrawerStyle,

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -7,7 +7,7 @@
  * @module drawer
  *
  */
-import type { DefineComponent, DesignToken, EmitFn, GlobalComponentConstructor, PassThrough } from '@primevue/core';
+import type { DefineComponent, DesignToken, EmitFn, GlobalComponentConstructor, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ButtonPassThroughOptions } from 'primevue/button';
 import type { PassThroughOptions } from 'primevue/passthrough';
@@ -181,6 +181,11 @@ export interface DrawerProps {
      * @defaultValue false
      */
     blockScroll?: boolean | undefined;
+    /**
+     * A valid query selector or an HTMLElement to specify where the dialog gets attached. Special keywords are 'body' for document body and 'self' for the element itself.
+     * @defaultValue 'body'
+     */
+    appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
     /**
      * It generates scoped CSS variables using design tokens for the component.
      */

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -1,5 +1,5 @@
 <template>
-    <Portal>
+    <Portal :appendTo="appendTo">
         <div v-if="containerVisible" :ref="maskRef" @mousedown="onMaskClick" :class="cx('mask')" :style="sx('mask', true, { position })" v-bind="ptm('mask')">
             <transition name="p-drawer" @enter="onEnter" @after-enter="onAfterEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
                 <div v-if="visible" :ref="containerRef" v-focustrap :class="cx('root')" role="complementary" :aria-modal="modal" v-bind="ptmi('root')">


### PR DESCRIPTION
###Feature Requests
add `appendTo` option to support rendering DOM into current element, like `antd`
https://ant-design.antgroup.com/components/drawer-cn#drawer-demo-render-in-current