### PR TITLE
Fix: focus on wrong element when adding "Select" component to footer slot of DatePicker

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2549,7 +2549,10 @@ export default {
                                 let spanIndex = null;
 
                                 for (let i = 0; i < focusableElements.length; i++) {
-                                    if (focusableElements[i].tagName === 'SPAN') spanIndex = i;
+                                    if (focusableElements[i].tagName === 'SPAN') {
+                                        spanIndex = i;
+                                        break;
+                                    }
                                 }
 
                                 focusableElements[spanIndex].focus();


### PR DESCRIPTION
###Defect Fixes
I’m working on a customized version of the PrimeVue DatePicker that lets users select hours and minutes using the 'Select' component. 
I'm facing an issue where pressing the ArrowDown key focuses on the 'Select' component instead of the calendar dates. 
The focus logic is looking for a focusable 'SPAN' element, but instead of stopping at the first one, it continues looping, causing the last element to receive focus.

![image](https://github.com/user-attachments/assets/9de991c4-d0bf-4930-b067-cab67db29844)
