### PR TITLE
fix(Password): add 'autofocus' property on Password component

### DIFF
--- a/packages/primevue/src/password/BasePassword.vue
+++ b/packages/primevue/src/password/BasePassword.vue
@@ -138,6 +138,10 @@ export default {
         ariaLabel: {
             type: String,
             default: null
+        },
+        autofocus: {
+            type: Boolean,
+            default: false
         }
     },
     style: PasswordStyle,

--- a/packages/primevue/src/password/Password.vue
+++ b/packages/primevue/src/password/Password.vue
@@ -18,6 +18,7 @@
             :disabled="disabled"
             :variant="variant"
             :invalid="invalid"
+            :autofocus="autofocus"
             @input="onInput"
             @focus="onFocus"
             @blur="onBlur"


### PR DESCRIPTION
## Defect Fixes
- Fix: #6413.

## Summary

- Modify `BasePassword.vue` to allow `<Password>` component can receive `autofocus` attribute.

## Test

```
<Password v-model="value" autofocus :feedback="false" />
```

- AS-IS

https://github.com/user-attachments/assets/3aa1d1d8-63dc-4424-a502-3b8b49024b32


- TO-BE


https://github.com/user-attachments/assets/dc12fe63-90cd-4e4e-9737-7810b505d19a