### PR TITLE
fix(Select): replace logical OR Operator to Nullish Coalescing Operator

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -46,7 +46,7 @@
             @keydown="onKeyDown"
             v-bind="ptm('label')"
         >
-            <slot name="value" :value="modelValue" :placeholder="placeholder">{{ label === 'p-emptylabel' ? '&nbsp;' : label || 'empty' }}</slot>
+            <slot name="value" :value="modelValue" :placeholder="placeholder">{{ label === 'p-emptylabel' ? '&nbsp;' : label ?? 'empty' }}</slot>
         </span>
         <slot v-if="isClearIconVisible" name="clearicon" :class="cx('clearIcon')" :clearCallback="onClearClick">
             <component :is="clearIcon ? 'i' : 'TimesIcon'" ref="clearIcon" :class="[cx('clearIcon'), clearIcon]" @click="onClearClick" v-bind="ptm('clearIcon')" data-pc-section="clearicon" />


### PR DESCRIPTION
###Defect Fixes
- Fix: #6437

## Summary
- It seems the original intent was to display "empty" when the label does not exist, but due to the behavior of the OR operator, the label is considered falsy when it is the number 0, causing "empty" to be displayed.
 
- Modify the code to use the Nullish Coalescing Operator instead, so that "empty" is only shown when the label is `undefined` or `null`.

## Test

- AS-IS
<img width="268" alt="image" src="https://github.com/user-attachments/assets/f206ed1c-9468-4fa4-9de7-d6ed9ccc1aee">


- TO-BE
<img width="276" alt="image" src="https://github.com/user-attachments/assets/09198eeb-2b7b-4306-9c7e-d6b4fd934fc6">
