### PR TITLE
bump vue version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
         "@primeuix/utils": "^0.1.3"
     },
     "peerDependencies": {
-        "vue": "^3.0.0"
+        "vue": "^3.3.0"
     },
     "engines": {
         "node": ">=12.11.0"


### PR DESCRIPTION
closes #6492

the `slots` argument of _DefineComponent, which is used in [here](https://github.com/primefaces/primevue/blob/master/packages/core/src/index.d.ts#L17), is introduced in vue 3.3 (see https://github.com/vuejs/core/commit/5a2f5d59cffa36a99e6f2feab6b3ba7958b7362f and https://github.com/vuejs/core/commit/bdf557f6f233c039fff8007b1b16aec00c4e68aa).
Therefore, I think we should bump vue version of peerdependency.