### PR TITLE
feat/InputNumber: Accept Comma And NumpadDecimal as decimal "sign", o…

### DIFF
--- a/components/lib/inputnumber/InputNumber.vue
+++ b/components/lib/inputnumber/InputNumber.vue
@@ -540,6 +540,11 @@ export default {
             let isDecimalSign = this.isDecimalSign(char);
             const isMinusSign = this.isMinusSign(char);
 
+            if (this.locale === 'fr-FR' && (event.code === 'Comma' || event.code === 'NumpadDecimal') && !isDecimalSign) {
+                isDecimalSign = true
+                char = decimalSign
+            }
+
             if (event.code !== 'Enter') {
                 event.preventDefault();
             }


### PR DESCRIPTION
As anAZERTY (French) keyboard layout with french localization : having to use the comma is really counter intuitive. Here is a schema for better understanding.

![354626602-0ea25181-44d4-44a3-9040-05c44de22ce2](https://github.com/user-attachments/assets/a74bef40-a8af-4b5b-8f93-349e2237bd96)

To improve the user experience, it would be desirable to use a Comma (, or ,) to go to the decimal part.

###Defect Fixes
#3722 