### PR TITLE
#6443 fix: v-tooltip -> getTarget: Correctly fallback to el when find…

### DIFF
--- a/packages/primevue/src/tooltip/Tooltip.js
+++ b/packages/primevue/src/tooltip/Tooltip.js
@@ -449,7 +449,7 @@ const Tooltip = BaseTooltip.extend('tooltip', {
             return targetLeft + width > viewport.width || targetLeft < 0 || targetTop < 0 || targetTop + height > viewport.height;
         },
         getTarget(el) {
-            return hasClass(el, 'p-inputwrapper') ? findSingle(el, 'input') : el;
+            return hasClass(el, 'p-inputwrapper') ? findSingle(el, 'input') ?? el : el;
         },
         getModifiers(options) {
             // modifiers


### PR DESCRIPTION
…Single returns null

###Defect Fixes
closes #6443
