### PR TITLE
#6420 fix: Select: autoFilterFocus stuck when switching between Selects

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -689,7 +689,9 @@ export default {
             this.alignOverlay();
             this.scrollInView();
 
-            this.autoFilterFocus && focus(this.$refs.filterInput.$el);
+            setTimeout(() => {
+                this.autoFilterFocus && focus(this.$refs.filterInput.$el);
+            }, 1);
         },
         onOverlayAfterEnter() {
             this.bindOutsideClickListener();
@@ -705,6 +707,7 @@ export default {
 
             this.autoFilterFocus && focus(this.$refs.focusInput);
             this.$emit('hide');
+
             this.overlay = null;
         },
         onOverlayAfterLeave(el) {


### PR DESCRIPTION
closes #6420

###Defect Fixes
closes #6420

Due to the setTimeout used in `hide` method, we need to execute focus 1ms after.