### PR TITLE
fix: #6015 IconField compatibility with InputNumber

### DIFF
--- a/public/themes/arya-blue/theme.css
+++ b/public/themes/arya-blue/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/arya-orange/theme.css
+++ b/public/themes/arya-orange/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/arya-purple/theme.css
+++ b/public/themes/arya-purple/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/aura-dark-amber/theme.css
+++ b/public/themes/aura-dark-amber/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-blue/theme.css
+++ b/public/themes/aura-dark-blue/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-cyan/theme.css
+++ b/public/themes/aura-dark-cyan/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-green/theme.css
+++ b/public/themes/aura-dark-green/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-indigo/theme.css
+++ b/public/themes/aura-dark-indigo/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-lime/theme.css
+++ b/public/themes/aura-dark-lime/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-noir/theme.css
+++ b/public/themes/aura-dark-noir/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-pink/theme.css
+++ b/public/themes/aura-dark-pink/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-purple/theme.css
+++ b/public/themes/aura-dark-purple/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-dark-teal/theme.css
+++ b/public/themes/aura-dark-teal/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #a1a1aa;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #a1a1aa;
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-amber/theme.css
+++ b/public/themes/aura-light-amber/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-blue/theme.css
+++ b/public/themes/aura-light-blue/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-cyan/theme.css
+++ b/public/themes/aura-light-cyan/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-green/theme.css
+++ b/public/themes/aura-light-green/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-indigo/theme.css
+++ b/public/themes/aura-light-indigo/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-lime/theme.css
+++ b/public/themes/aura-light-lime/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-noir/theme.css
+++ b/public/themes/aura-light-noir/theme.css
@@ -1850,12 +1850,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2110,7 +2110,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2118,7 +2118,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-pink/theme.css
+++ b/public/themes/aura-light-pink/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-purple/theme.css
+++ b/public/themes/aura-light-purple/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/aura-light-teal/theme.css
+++ b/public/themes/aura-light-teal/theme.css
@@ -1846,12 +1846,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #94a3b8;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #94a3b8;
   }
@@ -2106,7 +2106,7 @@
     color: #f87171;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2114,7 +2114,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/bootstrap4-dark-blue/theme.css
+++ b/public/themes/bootstrap4-dark-blue/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2089,7 +2089,7 @@
     color: #f19ea6;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/bootstrap4-dark-purple/theme.css
+++ b/public/themes/bootstrap4-dark-purple/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2089,7 +2089,7 @@
     color: #f19ea6;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/bootstrap4-light-blue/theme.css
+++ b/public/themes/bootstrap4-light-blue/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #495057;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #495057;
   }
@@ -2089,7 +2089,7 @@
     color: #dc3545;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/bootstrap4-light-purple/theme.css
+++ b/public/themes/bootstrap4-light-purple/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #495057;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #495057;
   }
@@ -2089,7 +2089,7 @@
     color: #dc3545;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/fluent-light/theme.css
+++ b/public/themes/fluent-light/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #605e5c;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #605e5c;
   }
@@ -2085,7 +2085,7 @@
     color: #a4252c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/lara-dark-amber/theme.css
+++ b/public/themes/lara-dark-amber/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-blue/theme.css
+++ b/public/themes/lara-dark-blue/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-green/theme.css
+++ b/public/themes/lara-dark-green/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-indigo/theme.css
+++ b/public/themes/lara-dark-indigo/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-pink/theme.css
+++ b/public/themes/lara-dark-pink/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-purple/theme.css
+++ b/public/themes/lara-dark-purple/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-dark-teal/theme.css
+++ b/public/themes/lara-dark-teal/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2104,7 +2104,7 @@
     color: #fca5a5;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-amber/theme.css
+++ b/public/themes/lara-light-amber/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-blue/theme.css
+++ b/public/themes/lara-light-blue/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-green/theme.css
+++ b/public/themes/lara-light-green/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-indigo/theme.css
+++ b/public/themes/lara-light-indigo/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-pink/theme.css
+++ b/public/themes/lara-light-pink/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-purple/theme.css
+++ b/public/themes/lara-light-purple/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/lara-light-teal/theme.css
+++ b/public/themes/lara-light-teal/theme.css
@@ -1844,12 +1844,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
   }
@@ -2104,7 +2104,7 @@
     color: #e24c4c;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2112,7 +2112,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
   }
@@ -2089,7 +2089,7 @@
     color: #e57373;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
   }
@@ -2089,7 +2089,7 @@
     color: #e57373;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
   }
@@ -2089,7 +2089,7 @@
     color: #e57373;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
   }
@@ -2089,7 +2089,7 @@
     color: #e57373;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/md-dark-deeppurple/theme.css
+++ b/public/themes/md-dark-deeppurple/theme.css
@@ -1850,12 +1850,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2110,7 +2110,7 @@
     color: #f44435;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 3rem;
   }
 
@@ -2118,7 +2118,7 @@
     left: 3rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 3rem;
   }
 

--- a/public/themes/md-dark-indigo/theme.css
+++ b/public/themes/md-dark-indigo/theme.css
@@ -1850,12 +1850,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2110,7 +2110,7 @@
     color: #f44435;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 3rem;
   }
 
@@ -2118,7 +2118,7 @@
     left: 3rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 3rem;
   }
 

--- a/public/themes/md-light-deeppurple/theme.css
+++ b/public/themes/md-light-deeppurple/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
@@ -2109,7 +2109,7 @@
     color: #B00020;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 3rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 3rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 3rem;
   }
 

--- a/public/themes/md-light-indigo/theme.css
+++ b/public/themes/md-light-indigo/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
@@ -2109,7 +2109,7 @@
     color: #B00020;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 3rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 3rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 3rem;
   }
 

--- a/public/themes/mdc-dark-deeppurple/theme.css
+++ b/public/themes/mdc-dark-deeppurple/theme.css
@@ -1850,12 +1850,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2110,7 +2110,7 @@
     color: #f44435;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2118,7 +2118,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/mdc-dark-indigo/theme.css
+++ b/public/themes/mdc-dark-indigo/theme.css
@@ -1850,12 +1850,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2110,7 +2110,7 @@
     color: #f44435;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2118,7 +2118,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/mdc-light-deeppurple/theme.css
+++ b/public/themes/mdc-light-deeppurple/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
@@ -2109,7 +2109,7 @@
     color: #B00020;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/mdc-light-indigo/theme.css
+++ b/public/themes/mdc-light-indigo/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
@@ -2109,7 +2109,7 @@
     color: #B00020;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/mira/theme.css
+++ b/public/themes/mira/theme.css
@@ -1853,12 +1853,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #81A1C1;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #81A1C1;
   }
@@ -2113,7 +2113,7 @@
     color: #BF616A;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2121,7 +2121,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/nano/theme.css
+++ b/public/themes/nano/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.25rem;
     color: #697077;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.25rem;
     color: #697077;
   }
@@ -2085,7 +2085,7 @@
     color: #d8222f;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.5rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 1.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.5rem;
   }
 

--- a/public/themes/nova-accent/theme.css
+++ b/public/themes/nova-accent/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
   }
@@ -2085,7 +2085,7 @@
     color: #a80000;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/nova-alt/theme.css
+++ b/public/themes/nova-alt/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
   }
@@ -2089,7 +2089,7 @@
     color: #a80000;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/nova-vue/theme.css
+++ b/public/themes/nova-vue/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
   }
@@ -2089,7 +2089,7 @@
     color: #a80000;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/nova/theme.css
+++ b/public/themes/nova/theme.css
@@ -1829,12 +1829,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
   }
@@ -2089,7 +2089,7 @@
     color: #a80000;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2097,7 +2097,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #a6a6a6;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #a6a6a6;
   }
@@ -2085,7 +2085,7 @@
     color: #e7a3a3;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 1.858rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 1.858rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 1.858rem;
   }
 

--- a/public/themes/saga-blue/theme.css
+++ b/public/themes/saga-blue/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
   }
@@ -2085,7 +2085,7 @@
     color: #f44336;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/saga-green/theme.css
+++ b/public/themes/saga-green/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
   }
@@ -2085,7 +2085,7 @@
     color: #f44336;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/saga-orange/theme.css
+++ b/public/themes/saga-orange/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
   }
@@ -2085,7 +2085,7 @@
     color: #f44336;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/saga-purple/theme.css
+++ b/public/themes/saga-purple/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
   }
@@ -2085,7 +2085,7 @@
     color: #f44336;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/soho-dark/theme.css
+++ b/public/themes/soho-dark/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2109,7 +2109,7 @@
     color: #ff9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/soho-light/theme.css
+++ b/public/themes/soho-light/theme.css
@@ -1849,12 +1849,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #708da9;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #708da9;
   }
@@ -2109,7 +2109,7 @@
     color: #ff6767;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2117,7 +2117,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/tailwind-light/theme.css
+++ b/public/themes/tailwind-light/theme.css
@@ -1860,12 +1860,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #71717A;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #71717A;
   }
@@ -2120,7 +2120,7 @@
     color: #f0a9a7;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2128,7 +2128,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/vela-blue/theme.css
+++ b/public/themes/vela-blue/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/vela-green/theme.css
+++ b/public/themes/vela-green/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/vela-orange/theme.css
+++ b/public/themes/vela-orange/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/vela-purple/theme.css
+++ b/public/themes/vela-purple/theme.css
@@ -1825,12 +1825,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2085,7 +2085,7 @@
     color: #ef9a9a;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2rem;
   }
 
@@ -2093,7 +2093,7 @@
     left: 2rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2rem;
   }
 

--- a/public/themes/viva-dark/theme.css
+++ b/public/themes/viva-dark/theme.css
@@ -1857,12 +1857,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
@@ -2117,7 +2117,7 @@
     color: #f78c79;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2125,7 +2125,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 

--- a/public/themes/viva-light/theme.css
+++ b/public/themes/viva-light/theme.css
@@ -1857,12 +1857,12 @@
     width: 100%;
   }
 
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #898989;
   }
 
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #898989;
   }
@@ -2117,7 +2117,7 @@
     color: #f88c79;
   }
 
-  .p-icon-field-left > .p-inputtext {
+  .p-icon-field-left .p-inputtext {
     padding-left: 2.5rem;
   }
 
@@ -2125,7 +2125,7 @@
     left: 2.5rem;
   }
 
-  .p-icon-field-right > .p-inputtext {
+  .p-icon-field-right .p-inputtext {
     padding-right: 2.5rem;
   }
 


### PR DESCRIPTION
Given the CSS direct sibling selector, the appropriate padding for the input field could not be applied when InputNumber is used given it's nesting inside a `span` element. 

Removing the direct sibling selector and styling more akin to V4 allows the nested input to be detected, however I can gladly update to extend and specifically target the input of the nested number input if preferred. 

The `:last-of-type` selector on the `p-input-icon` element also fail in this regard due to the nesting, unless the markup is specifically set to have the `InputIcon` appear after the `InputText`. 

###Defect Fixes
[#6015](https://github.com/primefaces/primevue/issues/6015)