### PR TITLE
fix: Slider: "Unable to preventDefault inside passive event listener invocation" in primevue_slider.js (touchmove)

### DIFF
--- a/packages/primevue/src/slider/Slider.vue
+++ b/packages/primevue/src/slider/Slider.vue
@@ -155,12 +155,10 @@ export default {
             }
 
             event.currentTarget.focus();
-            event.preventDefault();
         },
         onDrag(event) {
             if (this.dragging) {
                 this.setValue(event);
-                event.preventDefault();
             }
         },
         onDragEnd(event) {


### PR DESCRIPTION
This PR fixes [#5745](https://github.com/primefaces/primevue/issues/5745).

The event.preventDefault() method has been removed.

The touch event uses the .passive modifier, and also uses the preventDefault method. On mobile devices, the browser will report an error.

The official documentation for Vue.js is as follows:

https://vuejs.org/guide/essentials/event-handling.html#event-modifiers

Do not use .passive and .prevent together, because .passive already indicates to the browser that you do not intend to prevent the event's default behavior, and you will likely see a warning from the browser if you do so.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.