### PR TITLE
 fix(Splitter): #6570 (Typo in splitter.js (autocomplete err))

### DIFF
--- a/packages/primevue/scripts/components/splitter.js
+++ b/packages/primevue/scripts/components/splitter.js
@@ -45,7 +45,7 @@ const SplitterProps = [
 
 const SplitterEvents = [
     {
-        name: 'resizened',
+        name: 'resizeend',
         description: 'Callback to invoke when resize ends.',
         arguments: [
             {


### PR DESCRIPTION
###Defect Fixes
fixes https://github.com/primefaces/primevue/issues/6570