### PR TITLE
fix(ConfirmPopup): set this.target to document.activeElement when this.target is empty

### DIFF
--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -176,7 +176,7 @@ export default {
             this.autoFocusAccept = this.confirmation.defaultFocus === undefined || this.confirmation.defaultFocus === 'accept' ? true : false;
             this.autoFocusReject = this.confirmation.defaultFocus === 'reject' ? true : false;
 
-            this.target = document.activeElement;
+            this.target = this.target || document.activeElement;
 
             this.bindOutsideClickListener();
             this.bindScrollListener();


### PR DESCRIPTION
## Defect Fixes
- fix #6525



<br/>

## How To Resolve

### Cause
- When the transition enter event occurs, `this.target` is updated to `document.activeElement`.
- This logic is necessary when the target option is empty.

```js
onEnter(el) {
    ...
    this.target = document.activeElement; // this is where it happens

    this.bindOutsideClickListener();
    this.bindScrollListener();
    this.bindResizeListener();

    ZIndex.set('overlay', el, this.$primevue.config.zIndex.overlay);
}
```

<br/>

- However, even when the target option exists, `this.target` is still updated to `document.activeElement`.
- If the triggered element is not an active element (e.g., a `<p>` or `<i>` tag), the popup position will be incorrect when it first opens.
- For example, if the triggered element is an `<i>` (_trash icon_)tag, the popup’s `this.target` will be set to `<body>` on the first open, causing the position to be incorrect.(_See the video example of the issue here_)

https://github.com/user-attachments/assets/9d880d57-832e-451e-8a94-5f211aea4fe5

<br/>

### Solution
- To resolve this, I updated the logic to set `this.target` to `document.activeElement` only when `this.target` is empty.
```js
// Before
this.target = document.activeElement;
```
```js
this.target = this.target || document.activeElement; 
```

<br/>

### Test
- When the `<i>` tag is clicked, the popup position is now correct the first time it opens.

https://github.com/user-attachments/assets/3c588580-84a2-45b7-bade-c84326553e69

<details>
  <summary>sample code</summary>

  ```js
<template>
    <ConfirmPopup></ConfirmPopup>
    <div class="card flex flex-wrap gap-6 justify-center items-center">
        <i @click="confirm1($event)" class="pi pi-trash"></i>
        <Button @click="confirm2($event)" label="Delete" severity="danger" outlined></Button>
    </div>
</template>

<script>
export default {
    methods: {
        confirm1(event) {
            this.$confirm.require({
                target: event.currentTarget,
                message: 'Are you sure you want to proceed?',
                icon: 'pi pi-exclamation-triangle',
                rejectProps: {
                    label: 'Cancel',
                    severity: 'secondary',
                    outlined: true
                },
                acceptProps: {
                    label: 'Save'
                },
                accept: () => {
                    this.$toast.add({ severity: 'info', summary: 'Confirmed', detail: 'You have accepted', life: 3000 });
                },
                reject: () => {
                    this.$toast.add({ severity: 'error', summary: 'Rejected', detail: 'You have rejected', life: 3000 });
                }
            });
        },
        confirm2(event) {
            this.$confirm.require({
                target: event.currentTarget,
                message: 'Do you want to delete this record?',
                icon: 'pi pi-info-circle',
                rejectProps: {
                    label: 'Cancel',
                    severity: 'secondary',
                    outlined: true
                },
                acceptProps: {
                    label: 'Delete',
                    severity: 'danger'
                },
                accept: () => {
                    this.$toast.add({ severity: 'info', summary: 'Confirmed', detail: 'Record deleted', life: 3000 });
                },
                reject: () => {
                    this.$toast.add({ severity: 'error', summary: 'Rejected', detail: 'You have rejected', life: 3000 });
                }
            });
        }
    }
};
</script>

  ```

</details>



