### PR TITLE
Fix #6317 InputOtp

### DIFF
--- a/packages/primevue/src/inputotp/InputOtp.vue
+++ b/packages/primevue/src/inputotp/InputOtp.vue
@@ -71,6 +71,10 @@ export default {
                 this.moveToPrev(event);
             } else if (event.inputType === 'insertText' || event.inputType === 'deleteContentForward') {
                 this.moveToNext(event);
+            } else if (event instanceof CustomEvent) {
+                // iOS/macOS one-time-code autocomplete uses CustomEvent vs. InputEvent for each character in the code
+                // If moveToNext is not called, it will continue to append the next value after the first character
+                this.moveToNext(event);
             }
         },
         updateModel(event) {


### PR DESCRIPTION
This resolves the jumbled input when using the autocomplete feature in iOS/macOS to fill a one-time-code field (#6317).

iOS/macOS sends a CustomEvent vs. an InputEvent, and thus has no `inputType`. However, it does still need to move to the next input field, otherwise the next character is just appended after the first, resulting in 123456 becoming 165432.

I have confirmed that the proof of concept handler used here works: https://stackblitz.com/edit/primevue-4-vite-issue-template-kmmtvs?file=src%2FApp.vue

However, I am unsure of whether there might be other CustomEvents that would fire that would not want to move to the next field. Unfortunately, there were no other identifying characteristics of the event that Apple sends that I could use in order to limit the impact of this change.