### PR TITLE
fix: Destroy dialog instance on close to release unused memory

### DIFF
--- a/packages/primevue/src/dynamicdialog/DynamicDialog.vue
+++ b/packages/primevue/src/dynamicdialog/DynamicDialog.vue
@@ -61,6 +61,7 @@ export default {
     methods: {
         onDialogHide(instance) {
             !this.currentInstance && instance.options.onClose && instance.options.onClose({ type: 'dialog-close' });
+            delete this.instanceMap[instance.key];
         },
         onDialogAfterHide() {
             this.currentInstance && delete this.currentInstance;


### PR DESCRIPTION
### Defect Fixes
Fix [Issue #6535](https://github.com/primefaces/primevue/issues/6535)

#### Explanation
The dialog data was not being destroyed upon closing, leading to unnecessary memory consumption as the object was no longer used. The dialog component wasn't being destroyed even when it was no longer needed.

#### Solution
Destroy the instance data from the map when it is closed, ensuring that unused memory is released.
