### PR TITLE
Update ImportPTDoc.vue

### DIFF
--- a/apps/showcase/doc/nuxt/configuration/ImportPTDoc.vue
+++ b/apps/showcase/doc/nuxt/configuration/ImportPTDoc.vue
@@ -14,7 +14,7 @@ export default {
             code1: {
                 basic: `
 primevue: {
-    importPT: { from: '@/passthrough/mycustompt.js')}
+    importPT: { from: '@/passthrough/mycustompt.js' }
 }
 `
             },


### PR DESCRIPTION
Removing extra character ")". This creates a error in the nuxt.config file.

###Defect Fixes
Copying this settings into a nuxt.config.ts file will thrown an error because this parenthesis character shouldn't be there...

###Feature Requests
This was just a "typo". Easy fix.