### PR TITLE
Fixes: #6614 (DocPTVIewer: hovering over section name doesn't show the section correctly)

### DIFF
--- a/apps/showcase/components/doc/DocPTViewer.vue
+++ b/apps/showcase/components/doc/DocPTViewer.vue
@@ -86,12 +86,12 @@ export default {
             if (this.hoveredElements.length === 0) this.hoveredElements = find(document.querySelector('body'), selector); //TODO:
 
             this.hoveredElements?.forEach((el) => {
-                addClass(el, '!ring !ring-blue-500 !z-10');
+                addClass(el, '![outline:2px_dashed_blue] ![outline-offset:-2px] !z-10');
             });
         },
         leaveSection() {
             this.hoveredElements.forEach((el) => {
-                removeClass(el, '!ring !ring-blue-500 !z-10');
+                removeClass(el, '![outline:2px_dashed_blue] ![outline-offset:-2px] !z-10');
             });
 
             this.hoveredElements = [];


### PR DESCRIPTION
This PR fixes #6614

The original approach uses tailwind's ring class to show a box around the target section however box shadow doesn't appear always. To fix this I used outline, since it always shows up.

This PR also uses tailwind arbitrary properties, in order not to conflict with any other already applied tailwind class.

see difference: (the right one is the result of this PR)
![image](https://github.com/user-attachments/assets/8cf007e2-fda6-430c-9ab4-839284c3478a)
