### PR TITLE
Update DrawerEmitsOptions

### DIFF
--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -263,6 +263,10 @@ export interface DrawerEmitsOptions {
      * Callback to invoke when drawer gets hidden.
      */
     hide(): void;
+    /**
+     * Callback to invoke after drawer is hidden.
+     */
+    'after-hide'(): void;
 }
 
 export declare type DrawerEmits = EmitFn<DrawerEmitsOptions>;


### PR DESCRIPTION
Adds 'after-hide' to DrawerEmitsOptions in Drawer.d.ts

Looks like 'after-hide' in DrawerEmitsOptions was somehow missing. In Drawer.vue emit 'after-hide' is define.

###Defect Fixes
[Issue](https://github.com/primefaces/primevue/issues/6621)
