### PR TITLE
fix(Dialog): fix some components ignoring :pt prop

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -18,8 +18,7 @@
                                     @click="maximize"
                                     :tabindex="maximizable ? '0' : '-1'"
                                     :unstyled="unstyled"
-                                    v-bind="maximizeButtonProps"
-                                    :pt="ptm('pcMaximizeButton')"
+                                    v-bind="{ ...maximizeButtonProps, ...ptm('pcMaximizeButton') }"
                                     data-pc-group-section="headericon"
                                 >
                                     <template #icon="slotProps">
@@ -36,8 +35,7 @@
                                     @click="close"
                                     :aria-label="closeAriaLabel"
                                     :unstyled="unstyled"
-                                    v-bind="closeButtonProps"
-                                    :pt="ptm('pcCloseButton')"
+                                    v-bind="{ ...closeButtonProps, ...ptm('pcCloseButton') }"
                                     data-pc-group-section="headericon"
                                 >
                                     <template #icon="slotProps">


### PR DESCRIPTION
### Defect Fixes

Fixes #6594.

I thought object returned by `ptm()` and `_getPTValue()` should be received using `v-bind` instead of the `:pt` prop.

## Reproduction

```js
 <Dialog
            v-model:visible="visible"
            modal
            :maximizable="true"
            :pt="{
                pcCloseButton: ({}) => ({
                    class: 'fix-#6594', // Test value
                }),
            }"
        >
```

## Screenshot

- **AS-IS**

<img width="522" alt="image" src="https://github.com/user-attachments/assets/bb3a1ded-5285-4690-bb63-dd5d2d7135c7"> 



- **TO-BE**

<img width="523" alt="image" src="https://github.com/user-attachments/assets/1815ed9c-2ce7-41fe-835a-5bb7468b05f3">