### PR TITLE
fix(TextArea): autoResize issue with v-show by implementing ResizeObserver

### DIFF
--- a/packages/primevue/src/textarea/Textarea.vue
+++ b/packages/primevue/src/textarea/Textarea.vue
@@ -15,17 +15,27 @@ export default {
         $pcFluid: { default: null }
     },
     mounted() {
-        if (this.$el.offsetParent && this.autoResize) {
-            this.resize();
+        if (this.autoResize) {
+            this.observer = new ResizeObserver(() => {
+                this.resize();
+            });
+            this.observer.observe(this.$el);
         }
     },
     updated() {
-        if (this.$el.offsetParent && this.autoResize) {
+        if (this.autoResize) {
             this.resize();
+        }
+    },
+    onBeforeUnmount() {
+        if (this.observer) {
+            this.observer.disconnect();
         }
     },
     methods: {
         resize() {
+            if (!this.$el.offsetParent) return;
+
             this.$el.style.height = 'auto';
             this.$el.style.height = this.$el.scrollHeight + 'px';
 

--- a/packages/primevue/src/textarea/Textarea.vue
+++ b/packages/primevue/src/textarea/Textarea.vue
@@ -27,7 +27,7 @@ export default {
             this.resize();
         }
     },
-    onBeforeUnmount() {
+    beforeUnmount() {
         if (this.observer) {
             this.observer.disconnect();
         }


### PR DESCRIPTION
## Defect Fixes
- fix #4510

<br/>

## Resolution
### Cause
- When `v-show` is applied to a parent element, the height of the TextArea is not automatically adjusted.
- This happens because the TextArea component does not detect visibility changes.
- The `updated` hook in the TextArea is only triggered by changes in its reactive data or props, and it doesn't respond to the parent’s v-show changes.

### Solution
- To address this, I implemented ResizeObserver.
- ResizeObserver detects size changes in elements and can also respond to visibility changes caused by the parent’s v-show.
- This ensures that the TextArea automatically adjusts its height when the parent’s visibility changes.


### Test



<details>
<summary>test sample code</summary>

```js
<template>
    <span v-show="value.display === true">
        <div>
            <Textarea id="xxx" v-model="value.text" autoResize rows="1" cols="30" />
        </div>
    </span>
</template>

<script setup>
import { ref } from 'vue';

const value = ref({ text: '', display: false });

setTimeout(() => {
    value.value.text = 'fsdfsdfsd dsfsdgsdd gsdfsdg  sdgsdgsdgsd  sgdsdfgsdg sdgsdgsd sdgsdfgs gsdgsdg sdgsdgsdgsd gsdsdgsdg';
}, 50);

setTimeout(() => {
    value.value.display = true;
    console.log('display');
}, 1000);
</script>

```
</details>

<br />

_before: AutoResize is not working when v-show is set to true_


https://github.com/user-attachments/assets/4958500c-c0e8-476e-a4f4-ee29e3889a26

<br />

_after: AutoResize is working when v-show is set to true__


https://github.com/user-attachments/assets/a2191e31-bac9-4d51-b7f6-02f66bf61a5c

