### PR TITLE
Fix fileLimit issues in FileUpload component

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -104,7 +104,6 @@ export default {
     duplicateIEEvent: false,
     data() {
         return {
-            uploadedFileCount: 0,
             files: [],
             messages: [],
             focused: false,
@@ -152,7 +151,7 @@ export default {
                 this.checkFileLimit();
             }
 
-            if (this.auto && this.hasFiles && !this.isFileLimitExceeded()) {
+            if (this.auto && this.hasFiles) {
                 this.uploader();
             }
 
@@ -166,11 +165,9 @@ export default {
             this.$refs.fileInput.click();
         },
         uploader() {
-            if (this.customUpload) {
-                if (this.fileLimit) {
-                    this.uploadedFileCount += this.files.length;
-                }
+            if (this.isFileLimitExceeded()) return;
 
+            if (this.customUpload) {
                 this.$emit('uploader', { files: this.files });
                 this.clear();
             } else {
@@ -202,10 +199,7 @@ export default {
                         this.progress = 0;
 
                         if (xhr.status >= 200 && xhr.status < 300) {
-                            if (this.fileLimit) {
-                                this.uploadedFileCount += this.files.length;
-                            }
-
+                            this.uploadedFiles.push(...this.files);
                             this.$emit('upload', {
                                 xhr: xhr,
                                 files: this.files
@@ -217,7 +211,6 @@ export default {
                             });
                         }
 
-                        this.uploadedFiles.push(...this.files);
                         this.clear();
                     }
                 };
@@ -379,11 +372,11 @@ export default {
             return `${formattedSize} ${sizes[i]}`;
         },
         isFileLimitExceeded() {
-            if (this.fileLimit && this.fileLimit <= this.files.length + this.uploadedFileCount && this.focused) {
+            if (this.fileLimit && this.fileLimit <= this.files.length + this.uploadedFiles.length && this.focused) {
                 this.focused = false;
             }
 
-            return this.fileLimit && this.fileLimit < this.files.length + this.uploadedFileCount;
+            return this.fileLimit && this.fileLimit < this.files.length + this.uploadedFiles.length;
         },
         checkFileLimit() {
             if (this.isFileLimitExceeded()) {
@@ -421,7 +414,7 @@ export default {
             return this.uploadedFiles && this.uploadedFiles.length > 0;
         },
         chooseDisabled() {
-            return this.disabled || (this.fileLimit && this.fileLimit <= this.files.length + this.uploadedFileCount);
+            return this.disabled || (this.fileLimit && this.fileLimit <= this.files.length + this.uploadedFiles.length);
         },
         uploadDisabled() {
             return this.disabled || !this.hasFiles || (this.fileLimit && this.fileLimit < this.files.length);


### PR DESCRIPTION
### Defect Fixes
This PR addresses multiple issues related to the `fileLimit` property in the [FileUpload](https://primevue.org/fileupload/) component, enhancing its reliability and user experience.

1. Utilize `uploadedFiles.length` Instead of `uploadedFileCount`.
The `uploadedFileCount` variable was not consistently updated, especially in scenarios like the `removeUploadedFile` method. This inconsistency led to problems where users couldn't re-upload files because the upload button remained disabled. By directly using `uploadedFiles.length`, we eliminate the need for an extra variable and ensure accurate tracking of uploaded files.

2. Move `this.uploadedFiles.push(...this.files)` inside success condition.
This `push` was executed regardless of the API response, causing files to appear as uploaded even if the upload failed. By relocating this line inside the successful response condition we ensure that files are only marked as uploaded when the server confirms a successful upload.:
```js
if (xhr.status >= 200 && xhr.status < 300) {
    this.uploadedFiles.push(...this.files);
    // ...
} ///...
```
3. Add file limit check in `uploader` function.
Introduced a guard clause at the beginning of the uploader function to prevent uploads when the file limit is exceeded:
```js
uploader() {
    if (this.isFileLimitExceeded()) return;
    // ...
}
```
This is crucial for scenarios where the `uploader` function is called externally. It enforces the file limit consistently, preventing any additional files from being uploaded beyond the specified limit.

#### Related issues
https://github.com/primefaces/primevue/issues/1723
https://github.com/orgs/primefaces/discussions/2071

Please let me know if there are any questions or if further adjustments are needed. Your feedback is appreciated!