### PR TITLE
fix(slider): correct range operation bug

### DIFF
--- a/packages/primevue/src/slider/Slider.spec.js
+++ b/packages/primevue/src/slider/Slider.spec.js
@@ -46,4 +46,58 @@ describe('Slider.vue', () => {
 
         expect(wrapper.emitted()['update:modelValue'][0][0]).toBe(0);
     });
+
+    it('should handle values outside range by filling the slider', async () => {
+        await wrapper.setProps({ min: 0, max: 200, modelValue: [-50, 250], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(0);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(100);
+
+        await wrapper.setProps({ min: -200, max: 200, modelValue: [-250, 250], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(0);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(100);
+    });
+
+    it('should handle values within range', async () => {
+        await wrapper.setProps({ min: -100, max: 100, modelValue: [0, 50], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(50);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(75);
+    });
+
+    it('should handle exact min and max values', async () => {
+        await wrapper.setProps({ min: -100, max: 100, modelValue: [-100, 100], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(0);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(100);
+    });
+
+    it('should handle fully positive range', async () => {
+        await wrapper.setProps({ min: -100, max: 100, modelValue: [0, 100], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(50);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(100);
+    });
+
+    it('should handle fully negative range', async () => {
+        await wrapper.setProps({ min: -200, max: -100, modelValue: [-200, -150], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(0);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(50);
+    });
+
+    it('should treat 0 as a valid start value', async () => {
+        await wrapper.setProps({ min: -100, max: 100, modelValue: [0, 50], range: true });
+
+        expect(wrapper.vm.rangeStartPosition).toBe(50);
+
+        expect(wrapper.vm.rangeEndPosition).toBe(75);
+    });
 });

--- a/packages/primevue/src/slider/Slider.vue
+++ b/packages/primevue/src/slider/Slider.vue
@@ -377,11 +377,17 @@ export default {
             else return ((this.value - this.min) * 100) / (this.max - this.min);
         },
         rangeStartPosition() {
-            if (this.value && this.value[0]) return ((this.value[0] < this.min ? 0 : this.value[0] - this.min) * 100) / (this.max - this.min);
+            if (this.value && this.value[0] !== undefined) {
+                if (this.value[0] < this.min) return 0;
+                else return ((this.value[0] - this.min) * 100) / (this.max - this.min);
+            }
             else return 0;
         },
         rangeEndPosition() {
-            if (this.value && this.value.length === 2) return ((this.value[1] > this.max ? 100 : this.value[1] - this.min) * 100) / (this.max - this.min);
+            if (this.value && this.value.length === 2 && this.value[1] !== undefined) {
+                if (this.value[1] > this.max) return 100;
+                else return ((this.value[1] - this.min) * 100) / (this.max - this.min);
+            }
             else return 100;
         }
     }


### PR DESCRIPTION
**Defect Fixes**
Fixes #6649

### Resolution
**Cause**
The slider component didn't handle certain range values correctly when the min and max properties were set, particularly when the range included zero and the model value started at zero.

**Example:**
- Create a slider with min = -100 and max = 100.
- Set modelValue = [0, 50].

In this setup:
Values like [1, 50] and [-1, 50] render correctly within the range. However, when the range starts exactly at 0, the slider incorrectly renders to the left instead of between -1 and 1 as expected.
This issue occurred because the slider's position calculation didn't consider cases where the starting value of the range (0) was at the center of the [min, max] boundary.

**Solution**
I changed the rangeStartPosition and rangeEndPosition logic a little bit:
- rangeStartPosition now returns 0% when the starting value is below min, which ensures it doesn’t incorrectly render to the left, as mentioned before.
- rangeEndPosition returns 100% when the end value exceeds max, ensuring the slider fills fully when values are out of bounds.

**Extra**
I added a couple of unit tests to validate the behavior of the range property within the slider component.