### PR TITLE
fixed typo in delay doc

### DIFF
--- a/apps/showcase/doc/tooltip/DelayDoc.vue
+++ b/apps/showcase/doc/tooltip/DelayDoc.vue
@@ -1,6 +1,6 @@
 <template>
     <DocSectionText v-bind="$attrs">
-        <p>Dlays to the enter and leave events are defined with <i>showDelay</i> and <i>hideDelay</i> options respectively.</p>
+        <p>Delays to the enter and leave events are defined with <i>showDelay</i> and <i>hideDelay</i> options respectively.</p>
     </DocSectionText>
     <div class="card flex flex-wrap justify-center">
         <Button v-tooltip="{ value: 'Confirm to proceed', showDelay: 1000, hideDelay: 300 }" label="Save" />


### PR DESCRIPTION
Fixes typo in popover docs page for "delay"

<img width="667" alt="image" src="https://github.com/user-attachments/assets/381b8787-b533-4472-b41e-9ed82eb55774">
