### PR TITLE
Use Tailwind's 'lg' 1024px width for components breakpoint prop default value

### DIFF
--- a/packages/primevue/scripts/components/datatable.js
+++ b/packages/primevue/scripts/components/datatable.js
@@ -345,7 +345,7 @@ const DataTableProps = [
     {
         name: 'breakpoint',
         type: 'string',
-        default: '960px',
+        default: '1024px',
         description: 'The breakpoint to define the maximum width boundary when using stack responsive layout.'
     },
     {

--- a/packages/primevue/scripts/components/orderlist.js
+++ b/packages/primevue/scripts/components/orderlist.js
@@ -45,7 +45,7 @@ const OrderListProps = [
     {
         name: 'breakpoint',
         type: 'string',
-        default: '960px',
+        default: '1024px',
         description: 'The breakpoint to define the maximum width boundary when responsiveness is enabled.'
     },
     {

--- a/packages/primevue/scripts/components/picklist.js
+++ b/packages/primevue/scripts/components/picklist.js
@@ -45,7 +45,7 @@ const PickListProps = [
     {
         name: 'breakpoint',
         type: 'string',
-        default: '960px',
+        default: '1024px',
         description: 'The breakpoint to define the maximum width boundary when responsiveness is enabled.'
     },
     {

--- a/packages/primevue/src/cascadeselect/BaseCascadeSelect.vue
+++ b/packages/primevue/src/cascadeselect/BaseCascadeSelect.vue
@@ -15,7 +15,7 @@ export default {
         placeholder: String,
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         dataKey: null,
         showClear: {

--- a/packages/primevue/src/cascadeselect/CascadeSelect.d.ts
+++ b/packages/primevue/src/cascadeselect/CascadeSelect.d.ts
@@ -305,7 +305,7 @@ export interface CascadeSelectProps {
     placeholder?: string | undefined;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/confirmdialog/ConfirmDialog.d.ts
+++ b/packages/primevue/src/confirmdialog/ConfirmDialog.d.ts
@@ -149,7 +149,7 @@ export interface ConfirmDialogBreakpoints {
      *
      * Example:
      *
-     * <ConfirmDialog :breakpoints="{'960px': '75vw', '640px': '100vw'}" ... />
+     * <ConfirmDialog :breakpoints="{'1024px': '75vw', '640px': '100vw'}" ... />
      *
      * Result:
      *

--- a/packages/primevue/src/contextmenu/BaseContextMenu.vue
+++ b/packages/primevue/src/contextmenu/BaseContextMenu.vue
@@ -28,7 +28,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         tabindex: {
             type: Number,

--- a/packages/primevue/src/contextmenu/ContextMenu.d.ts
+++ b/packages/primevue/src/contextmenu/ContextMenu.d.ts
@@ -229,7 +229,7 @@ export interface ContextMenuProps {
     model?: MenuItem[] | undefined;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/datatable/BaseDataTable.vue
+++ b/packages/primevue/src/datatable/BaseDataTable.vue
@@ -236,7 +236,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         showHeaders: {
             type: Boolean,

--- a/packages/primevue/src/datatable/DataTable.d.ts
+++ b/packages/primevue/src/datatable/DataTable.d.ts
@@ -1161,7 +1161,7 @@ export interface DataTableProps {
     frozenValue?: any[] | undefined | null;
     /**
      * The breakpoint to define the maximum width boundary when using stack responsive layout.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/dialog/Dialog.d.ts
+++ b/packages/primevue/src/dialog/Dialog.d.ts
@@ -143,7 +143,7 @@ export interface DialogBreakpoints {
      *
      * Example:
      *
-     * <Dialog :breakpoints="{'960px': '75vw', '640px': '100vw'}" ... />
+     * <Dialog :breakpoints="{'1024px': '75vw', '640px': '100vw'}" ... />
      *
      * Result:
      *

--- a/packages/primevue/src/dock/BaseDock.vue
+++ b/packages/primevue/src/dock/BaseDock.vue
@@ -24,7 +24,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         ariaLabel: {
             type: String,

--- a/packages/primevue/src/dock/Dock.d.ts
+++ b/packages/primevue/src/dock/Dock.d.ts
@@ -196,7 +196,7 @@ export interface DockProps {
     style?: any;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/megamenu/BaseMegaMenu.vue
+++ b/packages/primevue/src/megamenu/BaseMegaMenu.vue
@@ -16,7 +16,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         disabled: {
             type: Boolean,

--- a/packages/primevue/src/megamenu/MegaMenu.d.ts
+++ b/packages/primevue/src/megamenu/MegaMenu.d.ts
@@ -249,7 +249,7 @@ export interface MegaMenuProps {
     orientation?: 'horizontal' | 'vertical' | undefined;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/menubar/BaseMenubar.vue
+++ b/packages/primevue/src/menubar/BaseMenubar.vue
@@ -16,7 +16,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         ariaLabelledby: {
             type: String,

--- a/packages/primevue/src/menubar/Menubar.d.ts
+++ b/packages/primevue/src/menubar/Menubar.d.ts
@@ -237,7 +237,7 @@ export interface MenubarProps {
     model?: MenuItem[] | undefined;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/orderlist/BaseOrderList.vue
+++ b/packages/primevue/src/orderlist/BaseOrderList.vue
@@ -40,7 +40,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         striped: {
             type: Boolean,

--- a/packages/primevue/src/orderlist/OrderList.d.ts
+++ b/packages/primevue/src/orderlist/OrderList.d.ts
@@ -210,7 +210,7 @@ export interface OrderListProps {
     responsive?: boolean | undefined;
     /**
      * The breakpoint to define the maximum width boundary when responsiveness is enabled.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/picklist/BasePickList.vue
+++ b/packages/primevue/src/picklist/BasePickList.vue
@@ -40,7 +40,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         striped: {
             type: Boolean,

--- a/packages/primevue/src/picklist/PickList.d.ts
+++ b/packages/primevue/src/picklist/PickList.d.ts
@@ -331,7 +331,7 @@ export interface PickListProps {
     responsive?: boolean | undefined;
     /**
      * The breakpoint to define the maximum width boundary when responsiveness is enabled.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/popover/Popover.d.ts
+++ b/packages/primevue/src/popover/Popover.d.ts
@@ -97,7 +97,7 @@ export interface PopoverBreakpoints {
      *
      * Example:
      *
-     * <Popover :breakpoints="{'960px': '75vw', '640px': '100vw'}" ... />
+     * <Popover :breakpoints="{'1024px': '75vw', '640px': '100vw'}" ... />
      *
      * Result:
      *

--- a/packages/primevue/src/tieredmenu/BaseTieredMenu.vue
+++ b/packages/primevue/src/tieredmenu/BaseTieredMenu.vue
@@ -20,7 +20,7 @@ export default {
         },
         breakpoint: {
             type: String,
-            default: '960px'
+            default: '1024px'
         },
         autoZIndex: {
             type: Boolean,

--- a/packages/primevue/src/tieredmenu/TieredMenu.d.ts
+++ b/packages/primevue/src/tieredmenu/TieredMenu.d.ts
@@ -228,7 +228,7 @@ export interface TieredMenuProps {
     popup?: boolean | undefined;
     /**
      * The breakpoint to define the maximum width boundary.
-     * @defaultValue 960px
+     * @defaultValue 1024px
      */
     breakpoint?: string | undefined;
     /**

--- a/packages/primevue/src/toast/Toast.d.ts
+++ b/packages/primevue/src/toast/Toast.d.ts
@@ -158,7 +158,7 @@ export interface ToastBreakpointsType {
      *
      * Example:
      *
-     * <Toast :breakpoints="{'960px': { width: '75vw', ... }" ... />
+     * <Toast :breakpoints="{'1024px': { width: '75vw', ... }" ... />
      *
      */
     [key: string]: any;


### PR DESCRIPTION
## Feature Request
Suggesting to use Tailwind's 'lg' `1024px` breakpoint width instead of `960px` for components `breakpoint` prop default value.

Often times elements on a page will be styled to be hidden below Tailwind's 'lg' breakpoint, the minor difference in the 960-1024px range can cause confusion when certain elements get hidden, but certain components don't follow suite.

Most notably affected component is the [Menubar](https://primevue.org/menubar/) when I have mobile styles applied using the `lg:` [breakpoint prefix](https://tailwindcss.com/docs/responsive-design), but the Menubar component doesn't collapse into it's mobile state within the same width.

I have to remind myself to always set this prop value so I get consistent mobile styling behavior. Considering the library [officially suggests to use Tailwind](https://primevue.org/guides/primeflex/#tailwindcss) as the accompanying utility styling framework, this seems like an appropriate request.

## Scope
This will only update the component default values within `/packages/primevue`, if the idea is generally accepted I would be happy to update the values within `/apps/showcase/doc` as well.