### PR TITLE
fix(TreeSelect): prevent event propagation when clicking overlay

### DIFF
--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -88,6 +88,7 @@
                             @node-collapse="$emit('node-collapse', $event)"
                             @node-select="onNodeSelect"
                             @node-unselect="onNodeUnselect"
+                            @click.stop
                             :level="0"
                             :unstyled="unstyled"
                             :pt="ptm('pcTree')"
@@ -133,13 +134,13 @@ import { isEmpty, isNotEmpty } from '@primeuix/utils/object';
 import { ZIndex } from '@primeuix/utils/zindex';
 import { ConnectedOverlayScrollHandler, UniqueComponentId } from '@primevue/core/utils';
 import ChevronDownIcon from '@primevue/icons/chevrondown';
+import TimesIcon from '@primevue/icons/times';
 import Chip from 'primevue/chip';
 import OverlayEventBus from 'primevue/overlayeventbus';
 import Portal from 'primevue/portal';
 import Ripple from 'primevue/ripple';
 import Tree from 'primevue/tree';
 import BaseTreeSelect from './BaseTreeSelect.vue';
-import TimesIcon from '@primevue/icons/times';
 
 export default {
     name: 'TreeSelect',
@@ -228,14 +229,14 @@ export default {
 
             if (event.target.tagName === 'INPUT' || event.target.getAttribute('data-pc-section') === 'clearicon' || event.target.closest('[data-pc-section="clearicon"]')) {
                 return;
-            } else if (!this.disabled && (!this.overlay || !this.overlay.contains(event.target))) {
+            } else if (!this.overlay || !this.overlay.contains(event.target)) {
                 if (this.overlayVisible) this.hide();
                 else this.show();
 
                 focus(this.$refs.focusInput);
             }
         },
-        onClearClick(event) {
+        onClearClick() {
             this.onSelectionChange(null);
         },
         onSelectionChange(keys) {


### PR DESCRIPTION
## Defect Fixes
- fix: #4927

<br/>

## How to resolve
### Cause
- In "appendTo: self" mode, clicking the overlay expand icon causes the overlay to close unexpectedly.
- This happens because clicking the expand icon triggers the onClick event of the container ref.


### Resolved
- I have prevented event propagation when clicking the overlay in "appendTo: self" mode.

```js
<TSTree
  @click.stop  // added
 ... 
/>

```


### Test
<details>
  <summary>sample code</summary>

  ```js
  <template>
    <div class="card flex justify-center">
        <TreeSelect v-model="selectedValue" :options="nodes" placeholder="Select Item" class="md:w-80 w-full" append-to="self" />
    </div>
</template>

<script>
import { NodeService } from '/service/NodeService';

export default {
    data() {
        return {
            nodes: null,
            selectedValue: null
        };
    },
    mounted() {
        NodeService.getTreeNodes().then((data) => (this.nodes = data));
    }
};
</script>

  ```
</details>


> Before: when clicking expand or collapse icon, the overlay is closed :(

https://github.com/user-attachments/assets/65c4b15a-175c-409c-abae-b1b1bea481f5


<br/>


> After: when clicking expand or collapse icon, the overlay is not closed :)

https://github.com/user-attachments/assets/0adf8edd-ef87-476a-8d0a-29880676afa6