### PR TITLE
Form: reset not working, changed value not update input

### DIFF
--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -76,7 +76,7 @@ export default {
         $formValue: {
             immediate: false,
             handler(newValue) {
-                if (this.$pcForm?.states?.[this.$formName] && newValue !== this.d_value) {
+                if (this.$formName !== undefined && this.$pcForm?.states?.[this.$formName] && newValue !== this.d_value) {
                     this.d_value = newValue;
                 }
             }
@@ -120,6 +120,9 @@ export default {
         // @deprecated use $filled instead
         filled() {
             return this.$filled;
+        },
+        formValue() {
+            return this.$pcForm?.states?.[this.$formName]?.value;
         }
     }
 };

--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -73,7 +73,7 @@ export default {
                 this.d_value !== newValue && (this.d_value = newValue);
             }
         },
-        formValue: {
+        $formValue: {
             immediate: false,
             handler(newValue) {
                 if (this.$pcForm?.states?.[this.$formName] && newValue !== this.d_value) {
@@ -111,15 +111,15 @@ export default {
         $formDefaultValue() {
             return this.d_value ?? this.$pcFormField?.initialValue ?? this.$pcForm?.initialValues?.[this.$formName];
         },
+        $formValue() {
+            return this.$pcForm?.states?.[this.$formName]?.value;
+        },
         controlled() {
             return this.$inProps.hasOwnProperty('modelValue') || (!this.$inProps.hasOwnProperty('modelValue') && !this.$inProps.hasOwnProperty('defaultValue'));
         },
         // @deprecated use $filled instead
         filled() {
             return this.$filled;
-        },
-        formValue() {
-            return this.$pcForm?.states?.[this.name]?.value;
         }
     }
 };

--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -72,6 +72,14 @@ export default {
             handler(newValue) {
                 this.d_value !== newValue && (this.d_value = newValue);
             }
+        },
+        formValue: {
+            immediate: false,
+            handler(newValue) {
+                if (this.$pcForm?.states?.[this.$formName] && newValue !== this.d_value) {
+                    this.d_value = newValue;
+                }
+            }
         }
     },
     formField: {},
@@ -109,6 +117,9 @@ export default {
         // @deprecated use $filled instead
         filled() {
             return this.$filled;
+        },
+        formValue() {
+            return this.$pcForm?.states?.[this.name]?.value;
         }
     }
 };

--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -120,9 +120,6 @@ export default {
         // @deprecated use $filled instead
         filled() {
             return this.$filled;
-        },
-        formValue() {
-            return this.$pcForm?.states?.[this.$formName]?.value;
         }
     }
 };


### PR DESCRIPTION
### Defect Fixes
fix #6755

### Solution
Added watcher in `BaseEditableHolder` component which listens for `$pcForm.state[inputName]` and changes `d_value` after reset action

### Other possible solution
I am not sure if it will be worth adding Event bus for this - discussion needed
Emit `reset` event from `Form` component and listen for that event in `BaseEditableHolder`.