### PR TITLE
fix(toggleswitch): ensure visual switch with Material theme

### DIFF
--- a/packages/themes/src/presets/material/toggleswitch/index.js
+++ b/packages/themes/src/presets/material/toggleswitch/index.js
@@ -3,7 +3,7 @@ export default {
         width: '2.75rem',
         height: '1rem',
         borderRadius: '30px',
-        gap: '0',
+        gap: '0px',
         shadow: 'none',
         focusRing: {
             width: '0',


### PR DESCRIPTION
**Defect Fixes**
Fixes #6735 

### Resolution
**Cause**
The issue occurred because the design token `toggleswitch.gap` was set to 0 without a unit, which caused inconsistencies when used in a calc() function within the inset-inline-start property.

**Solution**
Updated `toggleswitch.gap` from 0 to 0px