### PR TITLE
Add disableThumbnailIndicatorsOnAllVisible to Galleria

### DIFF
--- a/packages/primevue/src/galleria/BaseGalleria.vue
+++ b/packages/primevue/src/galleria/BaseGalleria.vue
@@ -114,6 +114,10 @@ export default {
             type: null,
             default: null
         },
+        disableThumbnailIndicatorsOnAllVisible: {
+            type: Boolean,
+            default: true
+        },
         ariaLabel: {
             type: String,
             default: null

--- a/packages/primevue/src/galleria/Galleria.d.ts
+++ b/packages/primevue/src/galleria/Galleria.d.ts
@@ -399,6 +399,11 @@ export interface GalleriaProps {
      */
     nextButtonProps?: ButtonHTMLAttributes | undefined;
     /**
+     * When enabled and all thumbnails are visible the thumbnail navigators are disabled.
+     * @defaultValue true
+     */
+    disableThumbnailIndicatorsOnAllVisible?: boolean | undefined,
+    /**
      * Defines a string value that labels an interactive element.
      */
     ariaLabel?: string | undefined;

--- a/packages/primevue/src/galleria/GalleriaContent.vue
+++ b/packages/primevue/src/galleria/GalleriaContent.vue
@@ -48,6 +48,7 @@
                 :showThumbnailNavigators="$attrs.showThumbnailNavigators"
                 :prevButtonProps="$attrs.prevButtonProps"
                 :nextButtonProps="$attrs.nextButtonProps"
+                :disable-thumbnail-indicators-on-all-visible="$attrs.disableThumbnailIndicatorsOnAllVisible"
                 @stop-slideshow="stopSlideShow"
                 :pt="pt"
                 :unstyled="unstyled"

--- a/packages/primevue/src/galleria/GalleriaThumbnails.vue
+++ b/packages/primevue/src/galleria/GalleriaThumbnails.vue
@@ -137,7 +137,11 @@ export default {
         nextButtonProps: {
             type: null,
             default: null
-        }
+        },
+        disableThumbnailIndicatorsOnAllVisible: {
+            type: Boolean,
+            default: true
+        },
     },
     startPos: null,
     thumbnailsStyle: null,
@@ -508,10 +512,13 @@ export default {
             }
         },
         isNavBackwardDisabled() {
-            return (!this.circular && this.d_activeIndex === 0) || this.value.length <= this.d_numVisible;
+            return (!this.circular && this.d_activeIndex === 0) || this.allItemsVisibleAndShouldDisable();
         },
         isNavForwardDisabled() {
-            return (!this.circular && this.d_activeIndex === this.value.length - 1) || this.value.length <= this.d_numVisible;
+            return (!this.circular && this.d_activeIndex === this.value.length - 1) || this.allItemsVisibleAndShouldDisable();
+        },
+        allItemsVisibleAndShouldDisable() {
+            return this.value.length <= this.d_numVisible && this.disableThumbnailIndicatorsOnAllVisible;
         },
         firstItemAciveIndex() {
             return this.totalShiftedItems * -1;

--- a/packages/primevue/src/galleria/GalleriaThumbnails.vue
+++ b/packages/primevue/src/galleria/GalleriaThumbnails.vue
@@ -178,7 +178,7 @@ export default {
         let totalShiftedItems = this.totalShiftedItems;
 
         if (this.d_oldNumVisible !== this.d_numVisible || this.d_oldActiveItemIndex !== this.d_activeIndex) {
-            if (this.d_activeIndex <= this.getMedianItemIndex()) {
+            if (this.d_activeIndex <= this.getMedianItemIndex() || this.value.length <= this.d_numVisible) {
                 totalShiftedItems = 0;
             } else if (this.value.length - this.d_numVisible + this.getMedianItemIndex() < this.d_activeIndex) {
                 totalShiftedItems = this.d_numVisible - this.value.length;


### PR DESCRIPTION
###Feature Requests
This PR updates the Galleria Component to give the user a way to not disable the thumbnail navigators if all items are shown.

This improves the usability of the component, because the user should still be able to navigate using those indicators.

<img width="300" src="https://github.com/user-attachments/assets/28d6a8b5-b6a6-498f-96bb-56ab0c6f84c1">

With disableThumbnailIndicatorsOnAllVisible=false

<img width="300" src="https://github.com/user-attachments/assets/87f2ad45-6635-41f4-a886-fbf000b2c41d">
