### PR TITLE
Drawer: Add before-hide event to Drawer component

### DIFF
--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -262,6 +262,10 @@ export interface DrawerEmitsOptions {
     /**
      * Callback to invoke when drawer gets hidden.
      */
+    'before-hide'(): void;
+    /**
+     * Callback to invoke when drawer gets hidden.
+     */
     hide(): void;
     /**
      * Callback to invoke after drawer is hidden.

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -260,7 +260,7 @@ export interface DrawerEmitsOptions {
      */
     show(): void;
     /**
-     * Callback to invoke when drawer gets hidden.
+     * Callback to invoke before drawer gets hidden.
      */
     'before-hide'(): void;
     /**

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -114,8 +114,6 @@ export default {
                 !this.isUnstyled && addClass(this.mask, 'p-overlay-mask-leave');
             }
 
-            console.log('check');
-
             this.$emit('before-hide');
         },
         onLeave() {

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -54,7 +54,7 @@ export default {
     name: 'Drawer',
     extends: BaseDrawer,
     inheritAttrs: false,
-    emits: ['update:visible', 'show', 'after-show', 'hide', 'after-hide'],
+    emits: ['update:visible', 'show', 'after-show', 'hide', 'after-hide', 'before-hide'],
     data() {
         return {
             containerVisible: this.visible
@@ -113,6 +113,10 @@ export default {
             if (this.modal) {
                 !this.isUnstyled && addClass(this.mask, 'p-overlay-mask-leave');
             }
+
+            console.log('check');
+
+            this.$emit('before-hide');
         },
         onLeave() {
             this.$emit('hide');

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -688,7 +688,7 @@ export default {
             this.scrollInView();
 
             setTimeout(() => {
-                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
+                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput?.$el);
             }, 1);
         },
         onOverlayAfterEnter() {
@@ -705,7 +705,7 @@ export default {
 
             if (this.autoFilterFocus && this.filter) {
                 this.$nextTick(() => {
-                    focus(this.$refs.filterInput.$el);
+                    focus(this.$refs.filterInput?.$el);
                 });
             }
 


### PR DESCRIPTION
1. **Enhancement:** Add` before-hide` event to Drawer component.

    Issue referance (https://github.com/primefaces/primevue/issues/6770)

2. Bug: Select: Cannot read properties of null (reading '$el') - filter and auto-filter-focus error

    Issue referance (https://github.com/primefaces/primevue/issues/6793)
    Issue Referance (https://github.com/primefaces/primevue/issues/6804)



