### PR TITLE
fix(Select): Set `aria-invalid` attribute in non-editable mode as well

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -40,6 +40,7 @@
             :aria-expanded="overlayVisible"
             :aria-controls="id + '_list'"
             :aria-activedescendant="focused ? focusedOptionId : undefined"
+            :aria-invalid="invalid || undefined"
             :aria-disabled="disabled"
             @focus="onFocus"
             @blur="onBlur"


### PR DESCRIPTION
###Defect Fixes
Fixes #6813 

###Feature Requests
Sets `aria-invalid` attribute on the `Select` label in non-editable mode as well