### PR TITLE
fix: change controlled condition in BaseEditableHolder

### DIFF
--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -104,7 +104,7 @@ export default {
             return this.d_value ?? this.$pcFormField?.initialValue ?? this.$pcForm?.initialValues?.[this.$formName];
         },
         controlled() {
-            return this.$inProps.hasOwnProperty('modelValue') ?? (!this.$inProps.hasOwnProperty('modelValue') && !this.$inProps.hasOwnProperty('defaultValue'));
+            return this.$inProps.modelValue !== undefined;
         },
         // @deprecated use $filled instead
         filled() {

--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -104,7 +104,7 @@ export default {
             return this.d_value ?? this.$pcFormField?.initialValue ?? this.$pcForm?.initialValues?.[this.$formName];
         },
         controlled() {
-            return this.$inProps.hasOwnProperty('modelValue') || (!this.$inProps.hasOwnProperty('modelValue') && !this.$inProps.hasOwnProperty('defaultValue'));
+            return this.$inProps.hasOwnProperty('modelValue') ?? (!this.$inProps.hasOwnProperty('modelValue') && !this.$inProps.hasOwnProperty('defaultValue'));
         },
         // @deprecated use $filled instead
         filled() {


### PR DESCRIPTION
### Defect Fixes
- fix: #6739
- when manual input of datePicker is not working with the keyboard.

### How to Resolve...?
- If the `controlled` condition changed, the datePicker input can be controlled via the keyboard. 


https://github.com/user-attachments/assets/6b096dd2-b894-47c9-a7f1-f3eb7ba1219d


<br/>

- However, I don't think this is a perfect solution. Understanding the purpose of modifying controlled in [this PR](https://github.com/primefaces/primevue/commit/2fc29287ff664e4b7e4f04216616c64c5835e14f#diff-901fa98d9cab4fbab1a366cd97f1c1cdce6c78ec3e7836c5165d8cfd84f34aeeL101) might help in finding a smoother fix. @mertsincan 
- I would appreciate any comments regarding this matter! :) 

> Note: In datePicker, inProps does not include modelValue.



