### PR TITLE
docs: improve opening sentence for `VirtualScroller`

### DIFF
--- a/apps/showcase/doc/virtualscroller/BasicDoc.vue
+++ b/apps/showcase/doc/virtualscroller/BasicDoc.vue
@@ -1,7 +1,7 @@
 <template>
     <DocSectionText v-bind="$attrs">
         <p>
-            VirtualScroller requires <i>items</i> as the data to display, <i>itemSize</i> for the dimensions of an item and <i>item</i> template are required on component. In addition, an initial array is required based on the total number of items
+            VirtualScroller requires <i>items</i> as the data to display, <i>itemSize</i> for the dimensions of an item, an <i>item</i> template, and an initial array is required based on the total number of items
             to display. Size of the viewport is configured using <i>scrollWidth</i>, <i>scrollHeight</i> properties directly or with CSS <i>width</i> and <i>height</i> styles.
         </p>
     </DocSectionText>

--- a/apps/showcase/doc/virtualscroller/BasicDoc.vue
+++ b/apps/showcase/doc/virtualscroller/BasicDoc.vue
@@ -1,7 +1,7 @@
 <template>
     <DocSectionText v-bind="$attrs">
         <p>
-            VirtualScroller requires <i>items</i> as the data to display, <i>itemSize</i> for the dimensions of an item, an <i>item</i> template, and an initial array is required based on the total number of items
+            VirtualScroller requires <i>items</i> as the data to display, <i>itemSize</i> for the dimensions of an item, an <i>item</i> template, and an initial array based on the total number of items
             to display. Size of the viewport is configured using <i>scrollWidth</i>, <i>scrollHeight</i> properties directly or with CSS <i>width</i> and <i>height</i> styles.
         </p>
     </DocSectionText>


### PR DESCRIPTION
While trying to figure out how to implement an async-lazy-but-not-virtual multiselect, I noticed that this opening sentence didn't make sense 🙂