### PR TITLE
Select: filter and auto-filter-focus error fix

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -688,7 +688,7 @@ export default {
             this.scrollInView();
 
             setTimeout(() => {
-                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
+                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput?.$el);
             }, 1);
         },
         onOverlayAfterEnter() {
@@ -705,7 +705,7 @@ export default {
 
             if (this.autoFilterFocus && this.filter && !this.editable) {
                 this.$nextTick(() => {
-                    focus(this.$refs.filterInput.$el);
+                    focus(this.$refs.filterInput?.$el);
                 });
             }
 


### PR DESCRIPTION
Bug: Select: Cannot read properties of null (reading '$el') - filter and auto-filter-focus error

Same Fix for Both Below Bugs:
--------------------------------
Issue referance (https://github.com/primefaces/primevue/issues/6793)
Issue Referance (https://github.com/primefaces/primevue/issues/6804)