### PR TITLE
Knob (Typescript): Fix valueTemplate prop type definition

### DIFF
--- a/packages/primevue/src/knob/Knob.d.ts
+++ b/packages/primevue/src/knob/Knob.d.ts
@@ -191,7 +191,7 @@ export interface KnobProps {
      * Template string of the value.
      * @defaultValue '{value}'
      */
-    valueTemplate?: (val: number) => string | string | undefined;
+    valueTemplate?: ((val: number) => string) | string | undefined;
     /**
      * Index of the element in tabbing order.
      * @defaultValue 0


### PR DESCRIPTION
###Defect Fixes
[Issue #6843](https://github.com/primefaces/primevue/issues/6843)
This pull request fixes the TypeScript definition for the `valueTemplate` prop in the `Knob` component. The previous type declaration:

```typescript
valueTemplate?: (val: number) => string | string | undefined;
```

was incorrect and caused the prop to only accept functions, as `string | undefined` was interpreted as the return type of the function. This made it impossible to directly assign a `string` value to the `valueTemplate` prop.

The updated type:

```typescript
valueTemplate?: ((val: number) => string | undefined) | string;
```

correctly allows the prop to accept either:
- A function that returns `string | undefined`.
- A plain `string` value.
- Or remain undefined.

This change ensures the `valueTemplate` prop works as intended with both functions and strings.

(and yes, English is not my primary language, so I used ChatGPT to generate this summary)