### PR TITLE
Implements "pause on hover" Toast feature & exposes onMouseEnter and onMouseLeave callback props

### DIFF
--- a/packages/primevue/src/toast/BaseToast.vue
+++ b/packages/primevue/src/toast/BaseToast.vue
@@ -49,6 +49,14 @@ export default {
         closeButtonProps: {
             type: null,
             default: null
+        },
+        onMouseEnter: {
+            type: Function,
+            default: undefined
+        },
+        onMouseLeave: {
+            type: Function,
+            default: undefined
         }
     },
     style: ToastStyle,

--- a/packages/primevue/src/toast/Toast.d.ts
+++ b/packages/primevue/src/toast/Toast.d.ts
@@ -250,6 +250,14 @@ export interface ToastProps {
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * Used to specify a callback function to be run when the @mouseenter event is fired on the message component.
+     */
+    onMouseEnter?: Function | undefined;
+    /**
+     * Used to specify a callback function to be run when the @mouseleave event is fired on the message component.
+     */
+    onMouseLeave?: Function | undefined;
 }
 
 /**


### PR DESCRIPTION
I understand you don't want feature PRs, however I did this before reading that so please consider this code change. This is not backwards breaking in any way and is simply a port of a feature that was added to PrimeReact two years ago. I used the [commit from that project](https://github.com/primefaces/primereact/commit/fd07f37c9d2052cdd947e9ed3424805c1eac50a4) as a guide to make this change and took great care to ensure the change was clean, concise and matches the existing code style.

The issue that PR was accepted for was https://github.com/primefaces/primereact/issues/3272

That being said, I didn't see any information in the README.md nor did I see a CONTRIBUTING.md file so I was not clear on how to set this up so I could test my code so be aware these changes have not been tested! The code change is, however, very simple and I see no reason why it would not work as intended. Either way, please do test and confirm before merging.

### Description of changes:
- Added `onMouseEnter` and `onMouseLeave` props to `BaseToast`.
- Added definitions and doc comments for the new props to `ToastProps` interface in `Toast.d.ts`. As far as I can tell this should cause the API docs page to update to describe the new props (this was the only place in the codebase where text from other props' documentation page was present).
- Updated `ToastMessage.vue` so that when a toast with a `message.life` value set is created, the current timestamp is logged in the component. 
  - When the mouse enter/leave events are fired, the user defined callback (if set) is fired and our code is not run if the `defaultPrevented` property is set on the event object.
  - On mouse enter, the timer for the `life-end` callback is terminated and a new `life-end` time is calculated (and stored to the component) by subtracting the current timestamp from the previously sent `life-end` time.
  - On mouse leave, the code to start the `life-end` timer is ran again.
- The previous code that started the timer was moved from the `onMounted` lifecylce hook to a callable method to achieve this. The new method now uses the original life value at the start, but uses the calculated life time left each time it's started after being paused.

### Note:
 All new timer start/stop programming is contingent on `message.life` being set, to ensure this change will not affect the behavior of "sticky" messages. This should support starting and stopping the timer on repeated mouse hovers without issue.

### Result: 
If a message is created with a life of 10 seconds (for example) and the user moves the mouse over the message after 5 seconds the life-end timer is terminated. No matter how long the mouse stays over the component it will remain visible. Upon removing the mouse from the component the `life-end` timer will be restarted with the remaining 5 seconds.