### PR TITLE
fix(TreeTable): prevent selection when selectable is set to false (checkbox mode)

### DIFF
--- a/packages/primevue/src/treetable/BodyCell.vue
+++ b/packages/primevue/src/treetable/BodyCell.vue
@@ -21,7 +21,7 @@
                 :modelValue="checked"
                 :binary="true"
                 :class="cx('pcNodeCheckbox')"
-                :readonly="node.selectable === false"
+                :disabled="node.selectable === false"
                 @change="toggleCheckbox"
                 :tabindex="-1"
                 :indeterminate="partialChecked"


### PR DESCRIPTION
## Defect Fixes
- fix: #6849

## How To Resolve
### Description
- When `selectionMode` is set to "checkbox", 
- there is an issue where the checkbox gets selected, even if the `selectable` property is set to false.
```js
<TreeTable 
	v-model:selectionKeys="selectedKey" 
	:value="nodes" 
	selectionMode="checkbox" // selectionMode is checkbox
	>  
    <Column field="name" header="Name" expander style="width: 34%"></Column>
    <Column field="size" header="Size" style="width: 33%"></Column>
    <Column field="type" header="Type" style="width: 33%"></Column>
</TreeTable>
```

<br/>

- To resolve this issue, the checkbox is set to disabled when `node.selectable` is `false`.
```js
// BodyCell.vue

<Checkbox
      v-if="checkboxSelectionMode && columnProp('expander')"
      :modelValue="checked"
      :binary="true"
      :class="cx('pcNodeCheckbox')"
      :disabled="node.selectable === false" // added
      ...
  >
...
```

<br/>

### Test
_before: when node.selectable is false, but the checkbox is clickable_
```js
// data

[
  { key: '0', data: {…}, children: [{ key: '0-0', data, ...}, ... ], selectable: false }, 
  { key: '1', data: {…}, children: [ ... ], selectable: false }
]
````

https://github.com/user-attachments/assets/8c273c47-699e-41ca-be36-b2c3f969f2f1


<br/>


_after: when node.selectable is false, but the checkbox is unclickable_
```js
// data

[
  { key: '0', data: {…}, children: [{ key: '0-0', data, ...}, ... ], selectable: false }, 
  { key: '1', data: {…}, children: [ ... ], selectable: false }
]
````
https://github.com/user-attachments/assets/590b3898-920a-4e57-bb7a-18177b428b05

