### PR TITLE
fix (SelectButton): allow-empty property didn't work

### DIFF
--- a/apps/showcase/doc/selectbutton/AllowEmptyDoc.vue
+++ b/apps/showcase/doc/selectbutton/AllowEmptyDoc.vue
@@ -1,0 +1,57 @@
+<template>
+    <DocSectionText v-bind="$attrs">
+        <p>By default, the SelectButton allows to deselect all items. To enforce at least one selected item, set the <i>allow-empty</i> option to <i>false</i>.</p>
+    </DocSectionText>
+    <div class="card flex justify-center">
+        <SelectButton v-model="value" :options="options" :allow-empty="false" aria-labelledby="allow-empty" />
+    </div>
+    <DocSectionCode :code="code" />
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            value: 'One-Way',
+            options: ['One-Way', 'Return'],
+            code: {
+                basic: `
+<SelectButton v-model="value" :options="options" optionLabel="name"  :allow-empty="false" aria-labelledby="allow-empty" />
+`,
+                options: `
+<template>
+    <div class="card flex justify-center">
+        <SelectButton v-model="value" :options="options" optionLabel="name" :allow-empty="false" aria-labelledby="allow-empty" />
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            value: 'One-Way',
+            options: ['One-Way', 'Return']
+        };
+    }
+};
+<\/script>
+`,
+                composition: `
+<template>
+    <div class="card flex justify-center">
+        <SelectButton v-model="value" :options="options" optionLabel="name" :allow-empty="false" aria-labelledby="allow-empty" />
+    </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const value = ref('One-Way');
+const options = ref(['One-Way', 'Return']);
+<\/script>
+`
+            }
+        };
+    }
+};
+</script>

--- a/apps/showcase/pages/selectbutton/index.vue
+++ b/apps/showcase/pages/selectbutton/index.vue
@@ -22,6 +22,7 @@ import MultipleDoc from '@/doc/selectbutton/MultipleDoc.vue';
 import TemplateDoc from '@/doc/selectbutton/TemplateDoc.vue';
 import PTComponent from '@/doc/selectbutton/pt/index.vue';
 import ThemingDoc from '@/doc/selectbutton/theming/index.vue';
+import AllowEmptyDoc from '../../doc/selectbutton/AllowEmptyDoc.vue';
 
 export default {
     data() {
@@ -41,6 +42,11 @@ export default {
                     id: 'forms',
                     label: 'Forms',
                     component: FormsDoc
+                },
+                {
+                    id: 'allow-empty',
+                    label: 'Allow empty',
+                    component: AllowEmptyDoc
                 },
                 {
                     id: 'multiple',

--- a/apps/showcase/pages/selectbutton/index.vue
+++ b/apps/showcase/pages/selectbutton/index.vue
@@ -12,6 +12,7 @@
 
 <script>
 import AccessibilityDoc from '@/doc/selectbutton/AccessibilityDoc.vue';
+import AllowEmptyDoc from '@/doc/selectbutton/AllowEmptyDoc.vue';
 import BasicDoc from '@/doc/selectbutton/BasicDoc.vue';
 import DisabledDoc from '@/doc/selectbutton/DisabledDoc.vue';
 import FormsDoc from '@/doc/selectbutton/FormsDoc.vue';
@@ -22,7 +23,6 @@ import MultipleDoc from '@/doc/selectbutton/MultipleDoc.vue';
 import TemplateDoc from '@/doc/selectbutton/TemplateDoc.vue';
 import PTComponent from '@/doc/selectbutton/pt/index.vue';
 import ThemingDoc from '@/doc/selectbutton/theming/index.vue';
-import AllowEmptyDoc from '../../doc/selectbutton/AllowEmptyDoc.vue';
 
 export default {
     data() {

--- a/packages/primevue/src/selectbutton/SelectButton.vue
+++ b/packages/primevue/src/selectbutton/SelectButton.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="cx('root')" role="group" :aria-labelledby="ariaLabelledby" v-bind="ptmi('root')">
         <template v-for="(option, index) of options" :key="getOptionRenderKey(option)">
-            <ToggleButton
+            <ToggleButtonForSelectButton
                 :modelValue="isSelected(option)"
                 :onLabel="getOptionLabel(option)"
                 :offLabel="getOptionLabel(option)"
@@ -16,7 +16,7 @@
                         <span v-bind="ptm('pcToggleButton')['label']">{{ getOptionLabel(option) }}</span>
                     </slot>
                 </template>
-            </ToggleButton>
+            </ToggleButtonForSelectButton>
         </template>
     </div>
 </template>
@@ -98,7 +98,18 @@ export default {
         ripple: Ripple
     },
     components: {
-        ToggleButton
+        ToggleButtonForSelectButton: defineComponent({
+            ...ToggleButton,
+            emits: ['change'],
+            methods: {
+                ...ToggleButton.methods,
+                onChange: function (event) {
+                    if (!this.disabled && !this.readonly) {
+                        this.$emit('change', event);
+                    }
+                }
+            }
+        })
     }
 };
 </script>


### PR DESCRIPTION
## Defect Fixes

This PR fixes #6718 

## Changes

This PR added documentation to the homepage to include `allow-empty` and restored the correct functionality which was probably destroyed in [this](https://github.com/primefaces/primevue/commit/044eacead1bb0f96ab124b8ab228e7ea4f83309a) commit.

**Documentation:**
![image](https://github.com/user-attachments/assets/e4a700f3-6d20-465c-b975-37ac13c657fb)

**Behavior before the fix:**

https://github.com/user-attachments/assets/b8e31628-7c8b-4e22-92a4-eeb946960c79

**Behavior after the fix:**

https://github.com/user-attachments/assets/6772f71c-9d62-4f8c-9839-a306e399af81

