### PR TITLE
fix(autocomplete): ensure dt is correctly applied to InputText

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -31,6 +31,7 @@
             @input="onInput"
             @change="onChange"
             :unstyled="unstyled"
+            :dt="dt?.inputtext"
             :pt="ptm('pcInputText')"
         />
         <ul

--- a/packages/themes/types/autocomplete/index.d.ts
+++ b/packages/themes/types/autocomplete/index.d.ts
@@ -9,6 +9,7 @@
  */
 
 import { ColorSchemeDesignToken } from '..';
+import { InputTextDesignTokens } from '../inputtext';
 
 export interface AutoCompleteDesignTokens extends ColorSchemeDesignToken<AutoCompleteDesignTokens> {
     /**
@@ -427,6 +428,10 @@ export interface AutoCompleteDesignTokens extends ColorSchemeDesignToken<AutoCom
          */
         activeColor?: string;
     };
+    /**
+     * Used to pass tokens of the inputtext section
+     */
+    inputtext?: InputTextDesignTokens;
     /**
      * Used to pass tokens of the chip section
      */


### PR DESCRIPTION
**Defect Fixes**
#6828 

## Resolution
### Cause
The issue occurred because a specific design token for the InputText component used in the AutoComplete component was not declared. As a result, the InputText component was using its default styles.

### Solution
- Updated the AutoComplete component to explicitly pass the dt.inputtext design token to the InputText component.
- Updated the documentation to show the new dt.inputtext token for better clarity and usability.

## Extra
This might be the first time a design token is explicitly passed from a parent to a child component. If you have any thoughts, suggestions, or improvements regarding this approach, it'd be greatly appreciated!