### PR TITLE
#6737 fix: Binding "name" to InputText and Textarea fields

### DIFF
--- a/packages/primevue/src/inputtext/InputText.vue
+++ b/packages/primevue/src/inputtext/InputText.vue
@@ -1,5 +1,5 @@
 <template>
-    <input type="text" :class="cx('root')" :value="d_value" :disabled="disabled" :aria-invalid="$invalid || undefined" @input="onInput" v-bind="attrs" />
+    <input type="text" :name="name" :class="cx('root')" :value="d_value" :disabled="disabled" :aria-invalid="$invalid || undefined" @input="onInput" v-bind="attrs" />
 </template>
 
 <script>

--- a/packages/primevue/src/textarea/Textarea.vue
+++ b/packages/primevue/src/textarea/Textarea.vue
@@ -1,5 +1,5 @@
 <template>
-    <textarea :class="cx('root')" :value="d_value" :disabled="disabled" :aria-invalid="invalid || undefined" @input="onInput" v-bind="attrs"></textarea>
+    <textarea :class="cx('root')" :name="name" :value="d_value" :disabled="disabled" :aria-invalid="invalid || undefined" @input="onInput" v-bind="attrs"></textarea>
 </template>
 
 <script>


### PR DESCRIPTION
### What is wrong?

After taking a deeper look at the code related to the [issue](https://github.com/primefaces/primevue/issues/6737). Turns out that the problem is not related specifically to the `<InputText>` being inside HTML `<form>` element, but rather always occurs outside the `<Form>` component.

### Why is the behavior happening?

1. `<Form>` component is explicitly binding the `name` prop to its fields, see `packages/forms/src/useform/index.js:49`

2. `<InputText>` (and also `<TextArea>`) do not pass the `name` prop to their fields. `v-bind="attrs"` that is used does not include the `name` prop because `attrs` is merged from `$attrs` (through `$_attrsWithoutPT`, see `packages/core/src/basecomponent/BaseComponent.vue:374` ), as you might know `$attrs` includes attributes that are not explicitly declared as props. However in this case `name` prop is already declared on the parent component `<BaseEditableHolder>` props, thus it won't be available on `$attrs`variable, thus not in `$_attrsWithoutPT`, thus not in `attrs`.

The solution works now for both inside and outside `<Form>` with minimal changes. closes #6737 

I'm not sure if there is a better solution to this problem. Removing the `name` from  `<BaseEditableHolder>`  prop does not seem to be an option, due to its numerous usage across child components. If you have a better suggestion, feel free to share it with me.
