### PR TITLE
Theme designer content create fix

### DIFF
--- a/apps/showcase/components/layout/AppDesigner.vue
+++ b/apps/showcase/components/layout/AppDesigner.vue
@@ -226,7 +226,7 @@ export default {
             const theme = JSON.stringify(this.$appState.designer.preset, null, 4).replace(/"([^"]+)":/g, '$1:');
             const textContent = `import { createApp } from "vue";
 import PrimeVue from "primevue/config";
-import {${basePreset}} from "@primevue/themes/${basePreset.toLowerCase()}";
+import ${basePreset} from "@primevue/themes/${basePreset.toLowerCase()}";
 import { definePreset } from "@primevue/themes";
 
 const app = createApp(App);


### PR DESCRIPTION
When creating a theme from the theme designer the produced document has extra `{` `}` at the theme import