### PR TITLE
fix(Carousel): allow autoplay when value has valid count

### DIFF
--- a/packages/primevue/src/carousel/Carousel.vue
+++ b/packages/primevue/src/carousel/Carousel.vue
@@ -602,7 +602,7 @@ export default {
             return this.orientation === 'vertical';
         },
         hasValidItemCount() {
-            return this.value && this.value.length >= this.d_numVisible;
+            return this.value && this.value.length > this.d_numVisible;
         },
         isCircular() {
             return this.hasValidItemCount() && this.d_circular;

--- a/packages/primevue/src/carousel/Carousel.vue
+++ b/packages/primevue/src/carousel/Carousel.vue
@@ -601,11 +601,14 @@ export default {
         isVertical() {
             return this.orientation === 'vertical';
         },
+        hasValidItemCount() {
+            return this.value && this.value.length >= this.d_numVisible;
+        },
         isCircular() {
-            return this.value && this.d_circular && this.value.length >= this.d_numVisible;
+            return this.hasValidItemCount() && this.d_circular;
         },
         isAutoplay() {
-            return this.autoplayInterval && this.allowAutoplay;
+            return this.hasValidItemCount() && this.autoplayInterval && this.allowAutoplay;
         },
         firstIndex() {
             return this.isCircular() ? -1 * (this.totalShiftedItems + this.d_numVisible) : this.totalShiftedItems * -1;


### PR DESCRIPTION
## Defect Fixes
- fix: #6812

<br/>

## How To Resolve
### Solution
In autoplay mode, when the count of value is less than or equal to this.d_numVisible, a bug causing white space to appear occurs.
To resolve this, I validate that the count of value is sufficient.

```js
 hasValidItemCount() {
      return this.value && this.value.length > this.d_numVisible;
  },
```


### Test

> Before: White space appeared.


https://github.com/user-attachments/assets/27cffe2e-b873-415b-8ee0-a992c6de48f4



<br/>

> After: Autoplay is disabled, and the item is displayed correctly.


<img width="748" alt="스크린샷 2024-12-01 오후 1 52 44" src="https://github.com/user-attachments/assets/860afb90-c3a3-4c7e-8426-c1aecd81d960">




