### PR TITLE
fix(DataTable): update tabIndex when targetRow exists

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -849,7 +849,7 @@ export default {
                 const targetRow = event.currentTarget?.closest('tr[data-p-selectable-row="true"]');
 
                 focusedItem.tabIndex = '-1';
-                targetRow.tabIndex = '0';
+                if (targetRow) targetRow.tabIndex = '0';
             }
         },
         onRowDblClick(e) {


### PR DESCRIPTION
### Defect Fixes
- fix: #6904

### Test
> Before: When clicking on the empty space of the outer DataTable, the error occurred.

https://github.com/user-attachments/assets/913ff06b-00eb-4c8b-962e-b4bb94ccd381



> After: When clicking on the empty space of the outer DataTable, the error no longer occurs.


https://github.com/user-attachments/assets/320a6355-e394-4084-b598-98ae427ef16c



