### PR TITLE
fix: Performance issue for TreeSelect component

### DIFF
--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -452,22 +452,11 @@ export default {
         onOverlayKeydown(event) {
             if (event.code === 'Escape') this.hide();
         },
-        findSelectedNodes(node, keys, selectedNodes) {
-            if (node) {
-                if (this.isSelected(node, keys)) {
-                    selectedNodes.push(node);
-                    delete keys[node.key];
-                }
+        fillNodeMap(node, nodeMap) {
+            nodeMap[node.key] = node;
 
-                if (Object.keys(keys).length && node.children) {
-                    for (let childNode of node.children) {
-                        this.findSelectedNodes(childNode, keys, selectedNodes);
-                    }
-                }
-            } else {
-                for (let childNode of this.options) {
-                    this.findSelectedNodes(childNode, keys, selectedNodes);
-                }
+            if (node.children?.length) {
+                node.children.forEach(children => this.fillNodeMap(children, nodeMap))
             }
         },
         isSelected(node, keys) {
@@ -520,13 +509,24 @@ export default {
         }
     },
     computed: {
+        nodeMap() {
+            const nodeMap = {};
+
+            this.options?.forEach(node => this.fillNodeMap(node, nodeMap))
+
+            return nodeMap;
+        },
         selectedNodes() {
             let selectedNodes = [];
 
             if (this.d_value && this.options) {
-                let keys = { ...this.d_value };
+                Object.keys(this.d_value).forEach(key => {
+                    const node = this.nodeMap[key];
 
-                this.findSelectedNodes(null, keys, selectedNodes);
+                    if (this.isSelected(node, this.d_value)) {
+                        selectedNodes.push(node)
+                    }
+                })
             }
 
             return selectedNodes;


### PR DESCRIPTION
Fixes #6950
You can read a detailed explanation in the issue.

Here’s how I measured performance for the current version:

```
selectedNodes() {
  let selectedNodes = [];
  
  if (this.d_value && this.options) {
      let keys = { ...this.d_value };
      
      performance.mark('findSelectedNodesStart');
  
      this.findSelectedNodes(null, keys, selectedNodes);
  
      performance.mark('findSelectedNodesEnd');
  
      const perfResult = performance.measure('findSelectedNodesDuration', 'findSelectedNodesStart', 'findSelectedNodesEnd');
  
      console.log(`findSelectedNodes duration: ${perfResult.duration}`);
  }
  
  return selectedNodes;
        }
```

And here’s how I measure it for my solution:

```
nodeMap() {
    const nodeMap = {};

    performance.mark('nodeMapStart');

    this.options?.forEach(node => this.fillNodeMap(node, nodeMap))

    performance.mark('nodeMapEnd');

    const perfResult = performance.measure('nodeMapDuration', 'nodeMapStart', 'nodeMapEnd');

    console.log(`nodeMap duration: ${perfResult.duration}`);

    return nodeMap;
},
```

In both cases, execution time was captured exactly for the recursive function, so I consider it proof.