### PR TITLE
fix(tree): checkbox partialChecked not correct when filtering

### DIFF
--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -24,6 +24,7 @@
                     v-for="(node, index) of valueToRender"
                     :key="node.key"
                     :node="node"
+                    :unfilteredNode="getUnfilteredNode(node)"
                     :templates="$slots"
                     :level="level + 1"
                     :index="index"
@@ -219,6 +220,9 @@ export default {
             }
 
             return matched;
+        },
+        getUnfilteredNode(node) {
+            return this.filter ? this.value.find((n) => n.key === node.key) : undefined;
         }
     },
     computed: {

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -222,7 +222,7 @@ export default {
             return matched;
         },
         getUnfilteredNode(node) {
-            return this.filter ? this.value.find((n) => n.key === node.key) : undefined;
+            return this.filter && this.selectionMode === 'checkbox' ? this.value.find((n) => n.key === node.key) : undefined;
         }
     },
     computed: {


### PR DESCRIPTION
Fixes https://github.com/primefaces/primevue/issues/6928

The issue states that the defect is present in version 3, but it also presents in version 4.

**Tree Node**
- Added a new prop. `unfilteredNode`: The original node data before any filtering.
- Added a new computed value. `currentNode`: Returns unfilteredNode if available; otherwise, returns node.
- Added a new method. `getUnfilteredNode(node)`: Retrieves the unfiltered version of a node. Only works when its filtered and selection mode is set checkbox.

**Tree**
- Added `getUnfilteredNode` method to retrieve nodes without filtering when in checkbox selection mode. Only works when its filtered and selection mode is set checkbox.