### PR TITLE
Exposing appendTo prop of portal through Drawer

### DIFF
--- a/packages/primevue/scripts/components/drawer.js
+++ b/packages/primevue/scripts/components/drawer.js
@@ -70,7 +70,13 @@ const DrawerProps = [
         type: 'boolean',
         default: 'false',
         description: 'When enabled, it removes component related styles in the core.'
-    }
+    },
+    {
+        name: 'appendTo',
+        type: 'string',
+        default: 'body',
+        description: 'A valid query selector or an HTMLElement to specify where the drawer gets attached. Special keywords are "body" for document body and "self" for the element itself.'
+    },
 ];
 
 const DrawerEvents = [

--- a/packages/primevue/scripts/components/portal.js
+++ b/packages/primevue/scripts/components/portal.js
@@ -3,7 +3,7 @@ const PortalProps = [
         name: 'appendTo',
         type: 'string',
         default: 'body',
-        description: 'A valid query selector or an HTMLElement to specify where the dialog gets attached. Special keywords are "body" for document body and "self" for the element itself.'
+        description: 'A valid query selector or an HTMLElement to specify where the child component gets attached. Special keywords are "body" for document body and "self" for the element itself.'
     },
     {
         name: 'disabled',

--- a/packages/primevue/src/drawer/BaseDrawer.vue
+++ b/packages/primevue/src/drawer/BaseDrawer.vue
@@ -51,7 +51,11 @@ export default {
         blockScroll: {
             type: Boolean,
             default: false
-        }
+        },
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
+        },
     },
     style: DrawerStyle,
     provide() {

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -7,7 +7,7 @@
  * @module drawer
  *
  */
-import type { DefineComponent, DesignToken, EmitFn, PassThrough } from '@primevue/core';
+import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ButtonPassThroughOptions } from 'primevue/button';
 import type { PassThroughOptions } from 'primevue/passthrough';
@@ -200,6 +200,11 @@ export interface DrawerProps {
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * A valid query selector or an HTMLElement to specify where the drawer gets attached.
+     * @defaultValue body
+     */
+    appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
 }
 
 /**

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -1,5 +1,5 @@
 <template>
-    <Portal>
+    <Portal :appendTo="appendTo">
         <div v-if="containerVisible" :ref="maskRef" @mousedown="onMaskClick" :class="cx('mask')" :style="sx('mask', true, { position, modal })" v-bind="ptm('mask')">
             <transition name="p-drawer" @enter="onEnter" @after-enter="onAfterEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
                 <div v-if="visible" :ref="containerRef" v-focustrap :class="cx('root')" :style="sx('root')" role="complementary" :aria-modal="modal" v-bind="ptmi('root')">


### PR DESCRIPTION
We use primevue within Shadow DOM. We have found a way around styles not being applied to the shadow DOM but components are difficult to handle without control of where they are attached to. Exposing appendTo through Drawer would allow us to fully utilize it in our system.