### PR TITLE
fix(DataTable/BodyCell): apply updated cell value after value sorting

### DIFF
--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -401,20 +401,22 @@ export default {
                 }
             }
         },
-        moveToPreviousCell(event) {
+        async moveToPreviousCell(event) {
             let currentCell = this.findCell(event.target);
             let targetCell = this.findPreviousEditableColumn(currentCell);
 
             if (targetCell) {
+                await this.$nextTick();
                 invokeElementMethod(targetCell, 'click');
                 event.preventDefault();
             }
         },
-        moveToNextCell(event) {
+        async moveToNextCell(event) {
             let currentCell = this.findCell(event.target);
             let targetCell = this.findNextEditableColumn(currentCell);
 
             if (targetCell) {
+                await this.$nextTick();
                 invokeElementMethod(targetCell, 'click');
                 event.preventDefault();
             }

--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -304,11 +304,11 @@ export default {
         bindDocumentEditListener() {
             if (!this.documentEditListener) {
                 this.documentEditListener = (event) => {
+                    this.selfClick = this.$el && this.$el.contains(event.target);
+
                     if (!this.selfClick) {
                         this.completeEdit(event, 'outside');
                     }
-
-                    this.selfClick = false;
                 };
 
                 document.addEventListener('mousedown', this.documentEditListener);
@@ -335,9 +335,7 @@ export default {
                     this.$emit('cell-edit-init', { originalEvent: event, data: this.rowData, field: this.field, index: this.rowIndex });
 
                     this.overlayEventListener = (e) => {
-                        if (this.$el && this.$el.contains(e.target)) {
-                            this.selfClick = true;
-                        }
+                        this.selfClick = this.$el && this.$el.contains(e.target);
                     };
 
                     OverlayEventBus.on('overlay-click', this.overlayEventListener);

--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -311,12 +311,12 @@ export default {
                     this.selfClick = false;
                 };
 
-                document.addEventListener('click', this.documentEditListener);
+                document.addEventListener('mousedown', this.documentEditListener);
             }
         },
         unbindDocumentEditListener() {
             if (this.documentEditListener) {
-                document.removeEventListener('click', this.documentEditListener);
+                document.removeEventListener('mousedown', this.documentEditListener);
                 this.documentEditListener = null;
                 this.selfClick = false;
             }
@@ -329,8 +329,6 @@ export default {
         },
         onClick(event) {
             if (this.editMode === 'cell' && this.isEditable()) {
-                this.selfClick = true;
-
                 if (!this.d_editing) {
                     this.d_editing = true;
                     this.bindDocumentEditListener();

--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -221,6 +221,7 @@ export default {
     documentEditListener: null,
     selfClick: false,
     overlayEventListener: null,
+    editCompleteTimeout: null,
     data() {
         return {
             d_editing: this.editing,
@@ -306,8 +307,14 @@ export default {
                 this.documentEditListener = (event) => {
                     this.selfClick = this.$el && this.$el.contains(event.target);
 
+                    if (this.editCompleteTimeout) {
+                        clearTimeout(this.editCompleteTimeout);
+                    }
+
                     if (!this.selfClick) {
-                        this.completeEdit(event, 'outside');
+                        this.editCompleteTimeout = setTimeout(() => {
+                            this.completeEdit(event, 'outside');
+                        }, 1);
                     }
                 };
 
@@ -319,6 +326,11 @@ export default {
                 document.removeEventListener('mousedown', this.documentEditListener);
                 this.documentEditListener = null;
                 this.selfClick = false;
+
+                if (this.editCompleteTimeout) {
+                    clearTimeout(this.editCompleteTimeout);
+                    this.editCompleteTimeout = null;
+                }
             }
         },
         switchCellToViewMode() {


### PR DESCRIPTION
## Defect Fixes
- fix: #6572

<br/>

## How To Resolve
### 1. Change Event Trigger Order
> Commits: [[3763298](https://github.com/primefaces/primevue/pull/6984/commits/37632982a94b3ecbd0a656059cc5f58dc043fbe2), [b5ca685](https://github.com/primefaces/primevue/pull/6984/commits/b5ca6858a99e650c0f23ebb725046897924bf500)]

#### Description:
- When changing and reflecting a cell's value, the primary events involved are `cell-edit-init` and `cell-edit-complete`.
- The `cell-edit-init` event initializes the cell's default values based on the current rowData.
- When the `cell-edit-complete` event is triggered, it updates the cell with the modified value.
- However, if the DataTable sorts the data when the `cell-edit-complete` event occurs, it results in the previous data remaining in the cell. 
- This happens because when navigating from Cell A to Cell B, the event sequence is:
```js
// Current event order

(A) `cell-edit-init` -> (B) `cell-edit-init` -> (A)`cell-edit-complete`
```

<br/>

- To function as intended, the event sequence should be:
```js
// Expected event order

(A) `cell-edit-init` -> (A)`cell-edit-complete` -> (B) `cell-edit-init`
```
<br/>

- To resolve this issue, the event trigger order needs to be changed:
- First, modify the `documentEditListener` to trigger the event on `mousedown` instead of `click` when another cell is clicked.
- Second, update the `documentEditListener` to determine `selfClick` and execute `completeEdit()` accordingly.

<br/>



### 2. Waiting 1ms to Ensure Focus
> Commit:  [[bd0a270](https://github.com/primefaces/primevue/pull/6984/commits/bd0a270b1c88dce69e7a72d5371aff6c956cf98c)]
#### Description:
- In the updated hook, the element is focused after a 1ms delay:

```js
updated() {
      ...
      if (this.d_editing && (this.editMode === 'cell' || (this.editMode === 'row' && this.columnProp('rowEditor')))) {
          setTimeout(() => {
              const focusableEl = getFirstFocusableElement(this.$el);

              focusableEl && focusableEl.focus(); 
          }, 1); /** here **/
      }
  },
```

<br/>

- This ensures that the logic triggered by clicking outside waits for the element to be focused by delaying the execution by 1ms:

```js
this.documentEditListener = (event) => {
    ...
    if (!this.selfClick) {
        this.editCompleteTimeout = setTimeout(() => {
            this.completeEdit(event, 'outside');
        }, 1); /** here **/
    }
};
	
```

<br/>

### 3. Await Reactive Changes to Access the Latest Cell Data
> Commit: [[3763298](https://github.com/primefaces/primevue/pull/6984/commits/37632982a94b3ecbd0a656059cc5f58dc043fbe2)]

#### Description:
- Currently, when performing `[Tab]` or `[Shift+Tab]` operations to navigate to the previous or next cell, the code directly accesses the DOM to find the cells. 
- However, this approach causes the updated data not to be reflected in the cells.
- To fix this, a `$nextTick` operation is added to wait for the reactive data changes before accessing the latest cell data:

```js
async moveToPreviousCell(event) {
      let currentCell = this.findCell(event.target);
      let targetCell = this.findPreviousEditableColumn(currentCell);
      if (targetCell) {
          await this.$nextTick();  /** here **/
          invokeElementMethod(targetCell, 'click');
          event.preventDefault();
      }
  },

```

<br/>

## Test


https://github.com/user-attachments/assets/ff15dae5-c210-4108-aba4-0b1b4264b3a2


