### PR TITLE
fix: rename isBlocked to isExpanded in SplitButtonState interface

### DIFF
--- a/packages/primevue/src/splitbutton/SplitButton.d.ts
+++ b/packages/primevue/src/splitbutton/SplitButton.d.ts
@@ -104,10 +104,10 @@ export interface SplitButtonPassThroughAttributes {
  */
 export interface SplitButtonState {
     /**
-     * Current blocked state as a boolean.
+     * Current expanded state as a boolean.
      * @defaultValue false
      */
-    isBlocked: boolean;
+    isExpanded: boolean;
 }
 
 /**


### PR DESCRIPTION
###Defect Fixes
#6988 