### PR TITLE
fix: update InputMaskPassThroughOptions

### DIFF
--- a/packages/primevue/src/inputmask/InputMask.d.ts
+++ b/packages/primevue/src/inputmask/InputMask.d.ts
@@ -60,10 +60,9 @@ export interface InputMaskSharedPassThroughMethodOptions {
  */
 export interface InputMaskPassThroughOptions {
     /**
-     * Used to pass attributes to the InputText component.
-     * @see {@link InputTextPassThroughOptions}
+     * Used to pass attributes to the root's DOM element.
      */
-    root?: InputTextPassThroughOptions<InputMaskSharedPassThroughMethodOptions>;
+    root?: InputMaskPassThroughOptionType;
     /**
      * Used to pass attributes to the InputText component.
      * @see {@link InputTextPassThroughOptions}

--- a/packages/primevue/src/inputmask/InputMask.d.ts
+++ b/packages/primevue/src/inputmask/InputMask.d.ts
@@ -9,7 +9,6 @@
  */
 import type { DefineComponent, DesignToken, EmitFn, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
-import type { InputTextPassThroughOptions } from 'primevue/inputtext';
 import type { PassThroughOptions } from 'primevue/passthrough';
 
 export declare type InputMaskPassThroughOptionType = InputMaskPassThroughAttributes | ((options: InputMaskPassThroughMethodOptions) => InputMaskPassThroughAttributes | string) | string | null | undefined;
@@ -65,9 +64,8 @@ export interface InputMaskPassThroughOptions {
     root?: InputMaskPassThroughOptionType;
     /**
      * Used to pass attributes to the InputText component.
-     * @see {@link InputTextPassThroughOptions}
      */
-    pcInputText?: InputTextPassThroughOptions<InputMaskSharedPassThroughMethodOptions>;
+    pcInputText?: InputMaskPassThroughOptionType;
     /**
      * Used to manage all lifecycle hooks.
      * @see {@link BaseComponent.ComponentHooks}


### PR DESCRIPTION
###Defect Fixes
#6998 

updated types for pcInputText as well, because true, they are both the same, but both have incorrect types

replication

https://stackblitz.com/edit/primevue-create-vue-typescript-issue-template-w85qqeei?file=src%2FApp.vue,src%2Ftheme.ts