### PR TITLE
PrimeFlex to Tailwind CSS Docs Typo

### DIFF
--- a/apps/showcase/doc/guides/primeflex/MigrationDoc.vue
+++ b/apps/showcase/doc/guides/primeflex/MigrationDoc.vue
@@ -7,7 +7,7 @@
         </p>
         <p>Install PrimeCLT.</p>
         <DocSectionCode :code="code1" hideToggleCode importCode hideStackBlitz />
-        <p>Run the <i>pf2wt</i> in a directory that contains files to be migrated.</p>
+        <p>Run the <i>pf2tw</i> in a directory that contains files to be migrated.</p>
         <DocSectionCode :code="code2" hideToggleCode importCode hideStackBlitz />
         <p>There are a couple of utility classes that are not migrated as they have no counterparts, use flexbox utilities instead as replacements.</p>
         <ul class="leading-loose">


### PR DESCRIPTION
## About
Fixes a `pf2tw` command typo in the [PrimeFlex to Tailwind CSS Migration](https://primevue.org/guides/primeflex/#migration) Docs.

![image](https://github.com/user-attachments/assets/77f511aa-928a-43c4-9d11-45c36721e1ad)
