### PR TITLE
Fix #4214: Screenreader improve hidden accessible

### DIFF
--- a/packages/core/src/base/style/BaseStyle.js
+++ b/packages/core/src/base/style/BaseStyle.js
@@ -131,15 +131,13 @@ const css = ({ dt }) => `
     clip: rect(0 0 0 0);
     height: 1px;
     margin: -1px;
+    opacity: 0;
     overflow: hidden;
     padding: 0;
+    pointer-events: none;
     position: absolute;
+    white-space: nowrap;
     width: 1px;
-}
-
-.p-hidden-accessible input,
-.p-hidden-accessible select {
-    transform: scale(0);
 }
 
 .p-overflow-hidden {


### PR DESCRIPTION
Fix #4214: Screenreader improve hidden accessible

Based on this PF ticket: https://github.com/primefaces/primefaces/issues/12577

Based on NVDA: https://github.com/nvaccess/nvda/issues/16300

This is the modern way to hide things but still make them screenreader visible.  Tested with JAWS and NVDA


