### PR TITLE
correct field type for column body slot

### DIFF
--- a/packages/primevue/src/column/Column.d.ts
+++ b/packages/primevue/src/column/Column.d.ts
@@ -661,7 +661,7 @@ export interface ColumnSlots {
         /**
          * Column field.
          */
-        field: string;
+        field: string | ((item: any) => string) | undefined;
         /**
          * Row index.
          */


### PR DESCRIPTION
Set the type for the field `field` in the Column body slot to match the column field type