### PR TITLE
fix(InputNumber): added "required" prop which is present in wrapped component (InputText) already

### DIFF
--- a/packages/primevue/src/inputnumber/BaseInputNumber.vue
+++ b/packages/primevue/src/inputnumber/BaseInputNumber.vue
@@ -136,6 +136,10 @@ export default {
         ariaLabel: {
             type: String,
             default: null
+        },
+        required: {
+            type: Boolean,
+            default: false
         }
     },
     style: InputNumberStyle,

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -17,6 +17,7 @@
             :placeholder="placeholder"
             :aria-labelledby="ariaLabelledby"
             :aria-label="ariaLabel"
+            :required="required"
             :size="size"
             :invalid="invalid"
             :variant="variant"


### PR DESCRIPTION
### Problem
When used in a standard HTML `<form>`  element, a `required` tag is only recognized by the `InputText` component and not by the `InputNumber` component.

### Solution
Since the `InputNumber` component is simply a wrapper around the `InputText` component, which itself supports the `required` prop, this is a very straightforward fix of simply accepting and passing the props on to the wrapped components.

### Existing Functionality
The `allow-empty` prop tackles this from a different direction, however it resets the input field to 0 if emptied, which is a separate behaviour.  The `required` tag is recognized and validated natively by browsers, so it should be a part of all input fields, which is why this functionality is essential. 