### PR TITLE
fix(date-picker): inline used together with range and time options

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2756,7 +2756,7 @@ export default {
 
             if (propValue && Array.isArray(propValue)) {
                 if (this.isRangeSelection()) {
-                    propValue = this.inline ? propValue[0] : propValue[1] || propValue[0];
+                    propValue = propValue[1] || propValue[0];
                 } else if (this.isMultipleSelection()) {
                     propValue = propValue[propValue.length - 1];
                 }


### PR DESCRIPTION
When using selectionMode = range, showTime and inline options together the component would not allow the time of the second date to be edited.

This seems like a bug to me rather than a intended behavior of the component.

If it is for some reason intended, it should be documented that this won't indeed work.