### PR TITLE
feat(button): add to prop type

### DIFF
--- a/packages/primevue/src/button/Button.d.ts
+++ b/packages/primevue/src/button/Button.d.ts
@@ -207,6 +207,10 @@ export interface ButtonProps extends ButtonHTMLAttributes {
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * Route Location the router-link should navigate to when clicked on.
+     */
+    to?: string
 }
 
 /**


### PR DESCRIPTION
The docs do show that the "to" prop is usable on the button, but the types don't support it, making it hard to use in typed components.

Ideally it would support all of the options that Vue Router accepts, but we would need the types from the Vue Router package which would have to be present on this project - out of my comfort zone with this repo for now, maybe a generic object type would atleast make it possible to use.

https://primevue.org/button/#link