### PR TITLE
feat(button): add a11yAttrs to slot types

### DIFF
--- a/packages/primevue/src/button/Button.d.ts
+++ b/packages/primevue/src/button/Button.d.ts
@@ -227,7 +227,13 @@ export interface ButtonSlots {
     /**
      * Custom content such as icons, images and text can be placed inside the button via the default slot. Note that when slot is used, label, icon and badge properties are not included.
      */
-    default(): VNode[];
+    default(scope: {
+        /**
+        * Object containing the accessibility attributes.
+        * @remarks Only available when {@link ButtonProps.asChild} is set to true.
+        */
+        a11yAttrs?: Record<string, unknown>
+    }): VNode[];
     /**
      * Custom icon template.
      * @param {Object} scope - icon slot's params.


### PR DESCRIPTION
Ideally the types would only suggest it when the asChild option is set to true, but I suspect that we cannot do that without composition API and the generic types - even then it could be very messy.