### PR TITLE
feat(paginator): add initialPage prop for page initialization

### DIFF
--- a/packages/primevue/src/paginator/BasePaginator.vue
+++ b/packages/primevue/src/paginator/BasePaginator.vue
@@ -37,6 +37,10 @@ export default {
         alwaysShow: {
             type: Boolean,
             default: true
+        },
+        initialPage: {
+            type: Number,
+            default: 0
         }
     },
     style: PaginatorStyle,

--- a/packages/primevue/src/paginator/Paginator.d.ts
+++ b/packages/primevue/src/paginator/Paginator.d.ts
@@ -272,7 +272,7 @@ export interface PaginatorProps {
     alwaysShow?: boolean | undefined;
     /**
      * Number of the initial page to display.
-     * @defaultValue 0
+     * @defaultValue 1
      */
     initialPage?: number | undefined;
     /**

--- a/packages/primevue/src/paginator/Paginator.d.ts
+++ b/packages/primevue/src/paginator/Paginator.d.ts
@@ -271,6 +271,11 @@ export interface PaginatorProps {
      */
     alwaysShow?: boolean | undefined;
     /**
+     * Number of the initial page to display.
+     * @defaultValue 0
+     */
+    initialPage?: number | undefined;
+    /**
      * It generates scoped CSS variables using design tokens for the component.
      */
     dt?: DesignToken<any>;

--- a/packages/primevue/src/paginator/Paginator.spec.js
+++ b/packages/primevue/src/paginator/Paginator.spec.js
@@ -52,12 +52,12 @@ describe('Paginator.vue', () => {
     it('should initialize on the correct page when initialPage is set to a value greater than 0', async () => {
         await wrapper.setProps({ initialPage: 2 });
 
-        expect(wrapper.vm.page).toBe(2);
-        expect(wrapper.findAll('.p-paginator-page')[2].classes()).toContain('p-paginator-page-selected');
+        expect(wrapper.vm.page).toBe(1);
+        expect(wrapper.findAll('.p-paginator-page')[1].classes()).toContain('p-paginator-page-selected');
     });
 
     it('should initialize on page 0 when initialPage is 0', async () => {
-        await wrapper.setProps({ initialPage: 0 });
+        await wrapper.setProps({ initialPage: 1 });
 
         expect(wrapper.vm.page).toBe(0);
         expect(wrapper.findAll('.p-paginator-page')[0].classes()).toContain('p-paginator-page-selected');

--- a/packages/primevue/src/paginator/Paginator.spec.js
+++ b/packages/primevue/src/paginator/Paginator.spec.js
@@ -48,4 +48,25 @@ describe('Paginator.vue', () => {
 
         expect(wrapper.find('.p-select-label').text()).toBe('20');
     });
+
+    it('should initialize on the correct page when initialPage is set to a value greater than 0', async () => {
+        await wrapper.setProps({ initialPage: 2 });
+
+        expect(wrapper.vm.page).toBe(2);
+        expect(wrapper.findAll('.p-paginator-page')[2].classes()).toContain('p-paginator-page-selected');
+    });
+
+    it('should initialize on page 0 when initialPage is 0', async () => {
+        await wrapper.setProps({ initialPage: 0 });
+
+        expect(wrapper.vm.page).toBe(0);
+        expect(wrapper.findAll('.p-paginator-page')[0].classes()).toContain('p-paginator-page-selected');
+    });
+
+    it('should not change page when initialPage is negative', async () => {
+        await wrapper.setProps({ initialPage: -1 });
+
+        expect(wrapper.vm.page).toBe(0);
+        expect(wrapper.findAll('.p-paginator-page')[0].classes()).toContain('p-paginator-page-selected');
+    });
 });

--- a/packages/primevue/src/paginator/Paginator.spec.js
+++ b/packages/primevue/src/paginator/Paginator.spec.js
@@ -49,7 +49,7 @@ describe('Paginator.vue', () => {
         expect(wrapper.find('.p-select-label').text()).toBe('20');
     });
 
-    it('should initialize on the correct page when initialPage is set to a value greater than 0', async () => {
+    it('should initialize on the correct page when initialPage is set to a value greater than 1', async () => {
         await wrapper.setProps({ initialPage: 2 });
 
         expect(wrapper.vm.page).toBe(1);
@@ -57,6 +57,13 @@ describe('Paginator.vue', () => {
     });
 
     it('should initialize on page 0 when initialPage is 0', async () => {
+        await wrapper.setProps({ initialPage: 0 });
+
+        expect(wrapper.vm.page).toBe(0);
+        expect(wrapper.findAll('.p-paginator-page')[0].classes()).toContain('p-paginator-page-selected');
+    });
+
+    it('should initialize on page 0 when initialPage is 1', async () => {
         await wrapper.setProps({ initialPage: 1 });
 
         expect(wrapper.vm.page).toBe(0);

--- a/packages/primevue/src/paginator/Paginator.vue
+++ b/packages/primevue/src/paginator/Paginator.vue
@@ -146,7 +146,6 @@ export default {
 
             if (pageIndex >= 0 && pageIndex < this.pageCount && pageIndex !== this.page) {
                 this.d_first = pageIndex * this.d_rows;
-                this.page = pageIndex;
                 this.changePage(pageIndex);
             }
         },

--- a/packages/primevue/src/paginator/Paginator.vue
+++ b/packages/primevue/src/paginator/Paginator.vue
@@ -140,7 +140,16 @@ export default {
             if (this.page > 0 && newValue && this.d_first >= newValue) {
                 this.changePage(this.pageCount - 1);
             }
-        }
+        },
+        initialPage(newPage) {
+            const pageIndex = newPage - 1;
+
+            if (pageIndex >= 0 && pageIndex < this.pageCount && pageIndex !== this.page) {
+                this.d_first = pageIndex * this.d_rows;
+                this.page = pageIndex;
+                this.changePage(pageIndex);
+            }
+        },
     },
     mounted() {
         this.createStyle();


### PR DESCRIPTION
### **Defect Fixes**
#7023

### **Resolution**

#### **Cause**
The Paginator component did not have a way to initialize on a specific page.

#### **Solution**
Added a new initialPage prop to allow users to specify the page to initialize the Paginator.

### **Additional Notes**
- Added tests to cover the new initialPage functionality.
