### PR TITLE
docs(menu): add show/hide events to types and docs

### DIFF
--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -331,13 +331,13 @@ export interface MenuEmitsOptions {
      */
     blur(event: Event): void;
     /**
-     * Callback to invoke when the overlay is shown.
-     * @remarks Emitted when {@link MenuProps.popup} is true
+     * Callback to invoke when the menu popup is shown.
+     * @remarks Emitted when {@link MenuProps.popup} is true.
      */
     show(): void;
     /**
-     * Callback to invoke when the overlay is hidden.
-     * @remarks Emitted when {@link MenuProps.popup} is true
+     * Callback to invoke when the menu popup is hidden.
+     * @remarks Emitted when {@link MenuProps.popup} is true.
      */
     hide(): void;
 }

--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -330,6 +330,16 @@ export interface MenuEmitsOptions {
      * @param {Event} event - Browser event.
      */
     blur(event: Event): void;
+    /**
+     * Callback to invoke when the overlay is shown.
+     * @remarks Emitted when {@link MenuProps.popup} is true
+     */
+    show(): void;
+    /**
+     * Callback to invoke when the overlay is hidden.
+     * @remarks Emitted when {@link MenuProps.popup} is true
+     */
+    hide(): void;
 }
 
 export declare type MenuEmits = EmitFn<MenuEmitsOptions>;


### PR DESCRIPTION
The component does emit the show/hide events when it is being used as a popup, but the events were not documented.