### PR TITLE
fix(dialog): escape closing when not closable via button

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -141,6 +141,7 @@ export default {
     },
     methods: {
         close() {
+            console.log('close');
             this.$emit('update:visible', false);
         },
         onEnter() {
@@ -331,7 +332,7 @@ export default {
                 this.bindDocumentDragEndListener();
             }
 
-            if (this.closeOnEscape && this.closable) {
+            if (this.closeOnEscape) {
                 this.bindDocumentKeyDownListener();
             }
         },

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -141,7 +141,6 @@ export default {
     },
     methods: {
         close() {
-            console.log('close');
             this.$emit('update:visible', false);
         },
         onEnter() {


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/6922

The closable prop is a little confusing as it's main purpose seems to be hiding of the button, but to me it sounds like it should prevent all closing. Ideally we would rename the prop and perhaps introduce a new one with more specific name, but that would be a breaking change.

Nevertheless this simple change should be enough to resolve the issue.