### PR TITLE
fix(editor): broken color buttons after modelValue update

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -141,7 +141,6 @@ export default {
     },
     methods: {
         close() {
-            console.log('close');
             this.$emit('update:visible', false);
         },
         onEnter() {
@@ -332,7 +331,7 @@ export default {
                 this.bindDocumentDragEndListener();
             }
 
-            if (this.closeOnEscape) {
+            if (this.closeOnEscape && this.closable) {
                 this.bindDocumentKeyDownListener();
             }
         },

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -141,6 +141,7 @@ export default {
     },
     methods: {
         close() {
+            console.log('close');
             this.$emit('update:visible', false);
         },
         onEnter() {
@@ -331,7 +332,7 @@ export default {
                 this.bindDocumentDragEndListener();
             }
 
-            if (this.closeOnEscape && this.closable) {
+            if (this.closeOnEscape) {
                 this.bindDocumentKeyDownListener();
             }
         },

--- a/packages/primevue/src/editor/Editor.vue
+++ b/packages/primevue/src/editor/Editor.vue
@@ -19,7 +19,7 @@
                     <button class="ql-italic" type="button" v-bind="ptm('italic')"></button>
                     <button class="ql-underline" type="button" v-bind="ptm('underline')"></button>
                 </span>
-                <span :key="reRenderColorKey" class="ql-formats" v-bind="ptm('formats')">
+                <span class="ql-formats" v-bind="ptm('formats')">
                     <select class="ql-color" v-bind="ptm('color')"></select>
                     <select class="ql-background" v-bind="ptm('background')"></select>
                 </span>
@@ -64,16 +64,10 @@ export default {
     extends: BaseEditor,
     inheritAttrs: false,
     emits: ['text-change', 'selection-change', 'load'],
-    data() {
-        return {
-            reRenderColorKey: 0
-        };
-    },
     quill: null,
     watch: {
         modelValue(newValue, oldValue) {
             if (newValue !== oldValue && this.quill && !this.quill.hasFocus()) {
-                this.reRenderColorKey++;
                 this.renderValue(newValue);
             }
         },


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/6954

I could not find a reason why the color buttons needed to be rerendered. Perhaps an issue that was present in older versions of the editor? I checked the [original commit ](https://github.com/primefaces/primevue/commit/af50c82bb625c63227a72af5588bf9b8fb618e4d#diff-e626bf17f0814c503f89a012b676ff7f5c221683f8e49f51d8e4474e040a00ebR22)that introduced the `reRenderColorKey` property but there is no description about what it solves, maybe someone will take a look at this and know what's up. 