### PR TITLE
fix(inputotp): complete value on form submittion

### DIFF
--- a/packages/primevue/src/inputotp/InputOtp.vue
+++ b/packages/primevue/src/inputotp/InputOtp.vue
@@ -1,12 +1,12 @@
 <template>
     <div :class="cx('root')" v-bind="ptmi('root')">
+        <input type="hidden" :name="$formName" :value="modelValue" />
         <template v-for="i in length" :key="i">
             <slot :events="getTemplateEvents(i - 1)" :attrs="getTemplateAttrs(i - 1)" :index="i">
                 <OtpInputText
                     :value="tokens[i - 1]"
                     :type="inputType"
                     :class="cx('pcInputText')"
-                    :name="$formName"
                     :inputmode="inputMode"
                     :variant="variant"
                     :readonly="readonly"


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7025

The component would create a named input for each of the characters but that does not work with the form submit event because it will only collect the last input of the duplicately named inputs.