### PR TITLE
fix(autocomplete): avoid default event prevention on enter key press primefaces#6788

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -702,8 +702,6 @@ export default {
                     this.hide();
                 }
             }
-
-            event.preventDefault();
         },
         onEscapeKey(event) {
             this.overlayVisible && this.hide(true);


### PR DESCRIPTION
### Defect Fixes
Fixes https://github.com/primefaces/primevue/issues/6788

The default event prevention added with commit https://github.com/primefaces/primevue/commit/439ece1f2f2d991e3eb5e9aea9d4fd950da13fbc does not allow to submit a form using enter and numpad enter keys 