### PR TITLE
apps/showcase: Persist darkTheme setting in localStorage

### DIFF
--- a/apps/showcase/app.vue
+++ b/apps/showcase/app.vue
@@ -9,6 +9,13 @@ import EventBus from '@/app/AppEventBus';
 
 export default {
     mounted() {
+        const itemString = localStorage.getItem(this.$appState.storageKey);
+        const item = JSON.parse(itemString);
+
+        if (item && item.darkTheme) {
+            this.toggleDarkMode({ dark: true });
+        }
+
         EventBus.on('dark-mode-toggle', this.darkModeToggleListener);
     },
     beforeUnmount() {
@@ -30,8 +37,16 @@ export default {
             if (isDark) document.documentElement.classList.add('p-dark');
             else document.documentElement.classList.remove('p-dark');
 
-            this.$appState.darkTheme = isDark;
+            const itemString = localStorage.getItem(this.$appState.storageKey);
+            const existingItem = itemString ? JSON.parse(itemString) : {};
 
+            this.$appState.darkTheme = isDark;
+            const item = {
+                ...existingItem,
+                darkTheme: isDark
+            };
+
+            localStorage.setItem(this.$appState.storageKey, JSON.stringify(item));
             EventBus.emit('dark-mode-toggle-complete');
         }
     }

--- a/apps/showcase/components/layout/AppNews.vue
+++ b/apps/showcase/components/layout/AppNews.vue
@@ -36,8 +36,12 @@ export default {
     },
     methods: {
         onClose() {
+            const itemString = localStorage.getItem(this.$appState.storageKey);
+            const existingItem = itemString ? JSON.parse(itemString) : {};
+
             this.$appState.newsActive = false;
             const item = {
+                ...existingItem,
                 hiddenNews: this.$appState.announcement.id
             };
 


### PR DESCRIPTION
This PR is for improving the Primevue docs site.

It adds `$appState.darkTheme` to `localStorage` so it persists across page visits. It also updates the existing usage of `localStorage` (keeping track of hidden news banner) to make sure other keys in the `localStorage` JSON are preserved.