### PR TITLE
fix(textarea): issues with ResizeObserver inside of Firefox

### DIFF
--- a/packages/primevue/src/textarea/Textarea.vue
+++ b/packages/primevue/src/textarea/Textarea.vue
@@ -14,7 +14,10 @@ export default {
     mounted() {
         if (this.autoResize) {
             this.observer = new ResizeObserver(() => {
-                this.resize();
+                // Firefox has issues without the requestAnimationFrame - ResizeObserver loop completed with undelivered notifications.
+                requestAnimationFrame(() => {
+                    this.resize();
+                });
             });
             this.observer.observe(this.$el);
         }


### PR DESCRIPTION
I have encountered this issue within Firefox when using `auto-resize = true` on the `Textarea` component. It would only appear sometimes when trying it out myself, but it would happen every time when used inside of a Cypress test.

This change resolves the issue and should do no harm to other browsers.