### PR TITLE
feat(menu): idea to introduce generics and better types for components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,5 +95,19 @@ module.exports = {
             { blankLine: 'always', prev: '*', next: 'block-like' },
             { blankLine: 'always', prev: ['import'], next: ['const', 'let', 'var'] }
         ]
-    }
+    },
+    overrides: [
+        {
+            files: ['*.typedef.vue'],
+            extends: ['plugin:vue/vue3-recommended', '@vue/eslint-config-typescript', 'plugin:@typescript-eslint/recommended-type-checked'],
+            parser: 'vue-eslint-parser',
+            parserOptions: {
+                ecmaVersion: 'latest',
+                sourceType: 'module',
+                parser: '@typescript-eslint/parser',
+                project: ['tsconfig.lint.json'],
+                extraFileExtensions: ['.vue']
+            }
+        }
+    ]
 };

--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -191,11 +191,11 @@ export interface MenuRouterBindProps {
 /**
  * Defines valid properties in Menu component.
  */
-export interface MenuProps {
+export interface MenuProps<Item extends MenuItem = MenuItem> {
     /**
      * An array of menuitems.
      */
-    model?: MenuItem[] | undefined;
+    model?: Item[] | undefined;
     /**
      * Defines if menu would displayed as a popup.
      * @defaultValue false
@@ -252,7 +252,7 @@ export interface MenuProps {
 /**
  * Defines valid slots in Menu component.
  */
-export interface MenuSlots {
+export interface MenuSlots<Item extends MenuItem = MenuItem> {
     /**
      * Custom start template.
      */
@@ -269,7 +269,7 @@ export interface MenuSlots {
         /**
          * Menuitem instance
          */
-        item: MenuItem;
+        item: Item;
         /**
          * Label property of the menuitem
          */
@@ -287,7 +287,7 @@ export interface MenuSlots {
         /**
          * Menuitem instance
          */
-        item: MenuItem;
+        item: Item;
         /**
          * Style class of the item icon element.
          */
@@ -302,7 +302,7 @@ export interface MenuSlots {
         /**
          * Menuitem instance
          */
-        item: MenuItem;
+        item: Item;
     }): VNode[];
     /**
      * Custom submenu item template.
@@ -312,7 +312,7 @@ export interface MenuSlots {
         /**
          * Menuitem instance
          */
-        item: MenuItem;
+        item: Item;
     }): VNode[];
 }
 

--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -7,7 +7,7 @@
  * @module menu
  *
  */
-import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
+import type { DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { MenuItem } from 'primevue/menuitem';
 import type { PassThroughOptions } from 'primevue/passthrough';
@@ -370,11 +370,11 @@ export interface MenuMethods {
  * @group Component
  *
  */
-declare const Menu: DefineComponent<MenuProps, MenuSlots, MenuEmits, MenuMethods>;
+declare const Menu: typeof import('./Menu.typedef.vue')['default'];
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Menu: DefineComponent<MenuProps, MenuSlots, MenuEmits, MenuMethods>;
+        Menu: typeof import('./Menu.typedef.vue')['default'];
     }
 }
 

--- a/packages/primevue/src/menu/Menu.ts-playground.typedef.vue
+++ b/packages/primevue/src/menu/Menu.ts-playground.typedef.vue
@@ -1,13 +1,16 @@
 <template>
-    <Menu :items="model">
-        <template #item="{ item }"> </template>
+    <Menu :model="model">
+        <!-- We can safely access additional keys on the object instead of it acting as any. -->
+        <template #item="{ item }">{{ item.additionalData }}</template>
     </Menu>
 </template>
 
 <script setup lang="ts">
-const model = [
+import { MenuItem } from 'primevue/menuitem/MenuItem';
+
+const model: (MenuItem & { additionalData: Record<string, number> })[] = [
     {
-        a: 1
+        additionalData: {}
     }
 ];
 </script>

--- a/packages/primevue/src/menu/Menu.ts-playground.typedef.vue
+++ b/packages/primevue/src/menu/Menu.ts-playground.typedef.vue
@@ -1,0 +1,13 @@
+<template>
+    <Menu :items="model">
+        <template #item="{ item }"> </template>
+    </Menu>
+</template>
+
+<script setup lang="ts">
+const model = [
+    {
+        a: 1
+    }
+];
+</script>

--- a/packages/primevue/src/menu/Menu.typedef.vue
+++ b/packages/primevue/src/menu/Menu.typedef.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts" generic="Item extends MenuItem">
 import type { MenuItem } from 'primevue/menuitem';
-import { MenuEmits, MenuProps, MenuSlots } from './Menu';
+import { MenuEmits, MenuMethods, MenuProps, MenuSlots } from './Menu';
 
 defineProps<MenuProps<Item>>();
 defineSlots<MenuSlots<Item>>();
 defineEmits<MenuEmits>();
+defineExpose<MenuMethods>();
 </script>

--- a/packages/primevue/src/menu/Menu.typedef.vue
+++ b/packages/primevue/src/menu/Menu.typedef.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts" generic="T extends MenuItem">
+import type { MenuItem } from 'primevue/menuitem';
+import { VNode } from 'vue';
+
+defineProps<{
+    items: T[];
+}>();
+defineSlots<{
+    item(scope: { item: T }): VNode[];
+}>();
+</script>

--- a/packages/primevue/src/menu/Menu.typedef.vue
+++ b/packages/primevue/src/menu/Menu.typedef.vue
@@ -1,11 +1,8 @@
-<script setup lang="ts" generic="T extends MenuItem">
+<script setup lang="ts" generic="Item extends MenuItem">
 import type { MenuItem } from 'primevue/menuitem';
-import { VNode } from 'vue';
+import { MenuEmits, MenuProps, MenuSlots } from './Menu';
 
-defineProps<{
-    items: T[];
-}>();
-defineSlots<{
-    item(scope: { item: T }): VNode[];
-}>();
+defineProps<MenuProps<Item>>();
+defineSlots<MenuSlots<Item>>();
+defineEmits<MenuEmits>();
 </script>

--- a/packages/primevue/tsconfig.json
+++ b/packages/primevue/tsconfig.json
@@ -21,6 +21,6 @@
             "@primevue/icons/*": ["../../packages/icons/src/*"]
         }
     },
-    "include": ["**/*.ts", "src/*"],
+    "include": ["**/*.ts", "src/*", "**/*.typedef.vue"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
### Motivation
Better TS support which provides real type safety instead of just acting as `any` - mostly for safe usage of slotProps and emits payloads.

### Explanation
In a codebase this large it is near impossible to convert everything into composition API with TS, but we can define "secondary" components that will handle the types in a way that Vue can understand perfectly including generic types.

In this PR I have prepared it for the `Menu` component which uses the MenuItem interface for the `model` prop.

This way of doing it should be a non-breaking change for all current usage as it would just infer the actual types of the items.

### Caveats
Some prop types are very complicated, mostly the ones that extend large interfaces such as `ButtonHTMLAttributes` which the Vue compiler cannot handle when used inside of the `defineProps` macro. We would have to find a reasonable way around this. I go more into detail in this discussion: https://github.com/orgs/primefaces/discussions/3392