### PR TITLE
fix(dialog): block scroll behavior

### DIFF
--- a/packages/primevue/src/dialog/BaseDialog.vue
+++ b/packages/primevue/src/dialog/BaseDialog.vue
@@ -56,7 +56,7 @@ export default {
         },
         blockScroll: {
             type: Boolean,
-            default: false
+            default: undefined
         },
         baseZIndex: {
             type: Number,

--- a/packages/primevue/src/dialog/Dialog.d.ts
+++ b/packages/primevue/src/dialog/Dialog.d.ts
@@ -212,7 +212,8 @@ export interface DialogProps {
     showHeader?: boolean | undefined;
     /**
      * Whether background scroll should be blocked when dialog is visible.
-     * @defaultValue false
+     * @defaultValue undefined
+     * @remarks If unset it will act as true when {@link DialogProps.modal} is true.
      */
     blockScroll?: boolean | undefined;
     /**

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -219,17 +219,19 @@ export default {
                 this.$emit('maximize', event);
             }
 
-            if (!this.modal) {
-                this.maximized ? blockBodyScroll() : unblockBodyScroll();
+            if (this.c_blockScroll) {
+                blockBodyScroll();
+            } else {
+                unblockBodyScroll();
             }
         },
         enableDocumentSettings() {
-            if (this.modal || (!this.modal && this.blockScroll) || (this.maximizable && this.maximized)) {
+            if (this.c_blockScroll) {
                 blockBodyScroll();
             }
         },
         unbindDocumentState() {
-            if (this.modal || (!this.modal && this.blockScroll) || (this.maximizable && this.maximized)) {
+            if (this.c_blockScroll) {
                 unblockBodyScroll();
             }
         },
@@ -404,6 +406,18 @@ export default {
         },
         closeAriaLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.close : undefined;
+        },
+        c_blockScroll() {
+            if (this.maximizable && this.maximized) {
+                return true;
+            }
+
+            // If the blockScroll prop is unset we use the modal prop to not introduce a breaking change.
+            if (this.blockScroll == null) {
+                return this.modal;
+            }
+
+            return this.blockScroll;
         }
     },
     directives: {


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/6848

By changing the default value of `blockScroll` to `undefined` we do not introduce a breaking change and at the same time it is now possible to disable scroll blocking inside of modal dialogs.