### PR TITLE
fix(floatlabel): correct font.weight style key weight for active label

### DIFF
--- a/packages/primevue/src/floatlabel/style/FloatLabelStyle.js
+++ b/packages/primevue/src/floatlabel/style/FloatLabelStyle.js
@@ -43,7 +43,7 @@ const theme = ({ dt }) => `
     top: ${dt('floatlabel.over.active.top')};
     transform: translateY(0);
     font-size: ${dt('floatlabel.active.font.size')};
-    font-weight: ${dt('floatlabel.label.active.font.weight')};
+    font-weight: ${dt('floatlabel.active.font.weight')};
 }
 
 .p-floatlabel:has(input.p-filled) label,


### PR DESCRIPTION
Problem
When we modify the design token floatlabel.active.font.weight for [FloatLabel Theming](https://primevue.org/floatlabel/#theming.tokens), it is not applied correctly because the code uses the incorrect key floatlabel.label.active.font.weight.

Solution
Change the key used in the code to the correct floatlabel.active.font.weight