### PR TITLE
feat: add icons to password template example

### DIFF
--- a/apps/showcase/doc/password/TemplateDoc.vue
+++ b/apps/showcase/doc/password/TemplateDoc.vue
@@ -82,11 +82,11 @@ export default {
             </template>
             <template #footer>
                 <Divider />
-                <ul class="pl-2 ml-2 my-0 leading-normal">
-                    <li>At least one lowercase</li>
-                    <li>At least one uppercase</li>
-                    <li>At least one numeric</li>
-                    <li>Minimum 8 characters</li>
+                <ul class="my-0 leading-normal">
+                    <li><i :class="lowercase"></i> At least one lowercase</li>
+                    <li><i :class="uppercase"></i> At least one uppercase</li>
+                    <li><i :class="number"></i> At least one numeric</li>
+                    <li><i :class="length"></i> Minimum 8 characters</li>
                 </ul>
             </template>
         </Password>
@@ -94,9 +94,26 @@ export default {
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 const value = ref(null);
+
+const pass = 'pi pi-check text-green-500';
+const fail = 'pi pi-times text-red-500';
+
+const lowercase = computed(() => {
+  return /[a-z]/.test(value.value) ? pass : fail;
+});
+const uppercase = computed(() => {
+  return /[A-Z]/.test(value.value) ? pass : fail;
+});
+const number = computed(() => {
+  return /\d/.test(value.value) ? pass : fail;
+});
+const length = computed(() => {
+  return value.value.length > 8 ? pass : fail;
+});
+
 <\/script>
 `
             }


### PR DESCRIPTION
pimp password template example add green check and red times icons

https://stackblitz.com/edit/ye7iquos?file=src%2FApp.vue

![grafik](https://github.com/user-attachments/assets/858f2a9e-9972-468f-8569-6b4371267af9)

I have only changed the composition example. When you accept the change i can try to change also options example