### PR TITLE
fix: do not bubble up click event when calling choose file handler

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="isAdvanced" :class="cx('root')" v-bind="ptmi('root')">
-        <input ref="fileInput" type="file" @change="onFileSelect" :multiple="multiple" :accept="accept" :disabled="chooseDisabled" v-bind="ptm('input')" />
+        <input ref="fileInput" type="file" @change="onFileSelect" :multiple="multiple" :accept="accept" :disabled="chooseDisabled" v-bind="ptm('input')" @click.stop />
         <div :class="cx('header')" v-bind="ptm('header')">
             <slot name="header" :files="files" :uploadedFiles="uploadedFiles" :chooseCallback="choose" :uploadCallback="uploader" :clearCallback="clear">
                 <Button


### PR DESCRIPTION
###Defect Fixes
Do not bubble up click event when executing the choose-file handler. This gives unexpected results. 

