### PR TITLE
fix(Menubar): resolve passthrough props not passed to child components

### DIFF
--- a/packages/primevue/src/menubar/Menubar.vue
+++ b/packages/primevue/src/menubar/Menubar.vue
@@ -42,6 +42,7 @@
             :aria-labelledby="ariaLabelledby"
             :aria-label="ariaLabel"
             :pt="pt"
+            :get-parent-ptm="getParentPtm"
             :unstyled="unstyled"
             @focus="onFocus"
             @blur="onBlur"
@@ -57,10 +58,10 @@
 </template>
 
 <script>
-import { UniqueComponentId } from '@primevue/core/utils';
-import { focus, isTouchDevice, findSingle } from '@primeuix/utils/dom';
-import { isNotEmpty, resolve, isPrintableCharacter, isEmpty, findLastIndex } from '@primeuix/utils/object';
+import { findSingle, focus, isTouchDevice } from '@primeuix/utils/dom';
+import { findLastIndex, isEmpty, isNotEmpty, isPrintableCharacter, resolve } from '@primeuix/utils/object';
 import { ZIndex } from '@primeuix/utils/zindex';
+import { UniqueComponentId } from '@primevue/core/utils';
 import BarsIcon from '@primevue/icons/bars';
 import BaseMenubar from './BaseMenubar.vue';
 import MenubarSub from './MenubarSub.vue';
@@ -122,6 +123,9 @@ export default {
         },
         getItemLabel(item) {
             return this.getItemProp(item, 'label');
+        },
+        getParentPtm(name, params) {
+            return this.ptm(name, params);
         },
         isItemDisabled(item) {
             return this.getItemProp(item, 'disabled');

--- a/packages/primevue/src/menubar/MenubarSub.vue
+++ b/packages/primevue/src/menubar/MenubarSub.vue
@@ -1,5 +1,5 @@
 <template>
-    <ul :class="level === 0 ? cx('rootList') : cx('submenu')" v-bind="level === 0 ? ptm('rootList') : ptm('submenu')">
+    <ul :class="level === 0 ? cx('rootList') : cx('submenu')" v-bind="level === 0 ? getParentPtm('rootList') : getParentPtm('submenu')">
         <template v-for="(processedItem, index) of items" :key="getItemKey(processedItem)">
             <li
                 v-if="isItemVisible(processedItem) && !getItemProp(processedItem, 'separator')"
@@ -53,6 +53,7 @@
                     :level="level + 1"
                     :aria-labelledby="getItemLabelId(processedItem)"
                     :pt="pt"
+                    :get-parent-ptm="getParentPtm"
                     :unstyled="unstyled"
                     @item-click="$emit('item-click', $event)"
                     @item-mouseenter="$emit('item-mouseenter', $event)"
@@ -120,6 +121,10 @@ export default {
         activeItemPath: {
             type: Object,
             default: null
+        },
+        getParentPtm: {
+            type: Function,
+            default: null
         }
     },
     list: null,
@@ -141,7 +146,7 @@ export default {
             return `${this.menuId}_${processedItem.key}_label`;
         },
         getPTOptions(processedItem, index, key) {
-            return this.ptm(key, {
+            return this.getParentPtm(key, {
                 context: {
                     item: processedItem.item,
                     index,


### PR DESCRIPTION
## Defect Fixes
- fix: #6295 


<br/>

## How To Resolve
### Cause
**Issue with Passthrough in Menubar:**
- When using Passthrough (pt) in the Menubar component, 
- the passthrough properties are not applied correctly. Here's an example of the problematic code:
```js
<Menubar 
    :pt:rootList:style="'background-color: red'"
    :pt:itemLabel:style="'color: blue'"
    :pt:item:style="'background-color: yellow'"
    :pt:itemContent:style="'background-color: pink'"
    :pt:submenu:style="'background-color: orange'"
    :pt:separator:style="'border-block-start: 3px solid black'"
/>
```

<br/>

**Underlying Problem:**
- When invoking this.ptm, the ptm function internally calls the _getPTSelf function.
- The _getPTSelf function relies on the this.$_attrsPT variable to retrieve the passthrough attributes (e.g., pt:name attributes).

https://github.com/primefaces/primevue/blob/537772da644b32213eb3bf4bde860a2cc36141a7/packages/core/src/basecomponent/BaseComponent.vue#L223-L227

<br/>

- The child component (MenubarSub.vue) does not receive the parent’s passthrough attributes (e.g., pt:name attributes).
- As a result, the child component has an empty attribute object.

<img width="1324" alt="스크린샷 2025-01-25 오후 11 17 26" src="https://github.com/user-attachments/assets/f7ae4b72-9429-47de-a9c9-e867073c2ba0" />


<br/><br/>

### Solution

**Passing Parent ptm Function to Child Component:**

- To resolve the issue, pass the parent’s ptm function (getParentPtm) to the child component (MenubarSub.vue):
```js
getParentPtm(name, params) {
    return this.ptm(name, params);
},
```

<br/>

- Result: The child component now correctly receives the pt:name attributes.

<img width="1322" alt="스크린샷 2025-01-25 오후 11 16 53" src="https://github.com/user-attachments/assets/dd90863a-572f-4a67-8b28-e807ecc80709" />


<br/><br/>

### Test

<details>
  <summary>sample code</summary>
  
  ```js
<template>
    <Menubar
        :model="[
            {
                label: 'Home',
                icon: 'pi pi-home'
            },
            {
                label: 'Something',
                icon: 'pi pi-cart-arrow-down',
                items: [
                    {
                        label: 'Active',
                        icon: 'pi pi-bolt'
                    },
                    {
                        separator: true
                    },
                    {
                        label: 'Create New',
                        icon: 'pi pi-pencil'
                    }
                ]
            }
        ]"
        :pt:root:style="'background-color: aquamarine'"
        :pt:rootList:style="'background-color: red'"
        :pt:itemLabel:style="'color: blue'"
        :pt:item:style="'background-color: yellow'"
        :pt:itemContent:style="'background-color: pink'"
        :pt:submenu:style="'background-color: orange'"
        :pt:separator:style="'border-block-start: 3px solid black'"
        breakpoint="1px"
    />
</template>

<script></script>

```
</details>



|before|after|
|---|---|
|<img width="862" alt="스크린샷 2025-01-25 오후 11 27 49" src="https://github.com/user-attachments/assets/9b6bfcb0-1b96-4ddb-9a99-7cc14c7c21d6" />|<img width="848" alt="스크린샷 2025-01-25 오후 11 28 13" src="https://github.com/user-attachments/assets/67a95c44-bdd8-4138-aef4-9a67e8c9676d" />|

