### PR TITLE
DataTable : Allow ctrl-c during selection mode (port from Vue 3 PR)

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -919,7 +919,8 @@ export default {
                             this.$emit('update:selection', data);
                         }
 
-                        event.preventDefault();
+                        const isCopyShortcut = event.code === 'KeyC' && metaKey;
+                        if (!isCopyShortcut) event.preventDefault();
 
                         break;
                 }


### PR DESCRIPTION
When selection mode is enabled, you cannot ctrl-c data in the table which is highly annoying, This was already fixed in Vue 3 using the following PR: https://github.com/primefaces/primevue/pull/5759

It's a very small patch that makes a huge difference.

###Defect Fixes
https://github.com/primefaces/primevue/issues/6740


###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.