### PR TITLE
feat(button): custom size classes

### DIFF
--- a/packages/primevue/src/button/Button.d.ts
+++ b/packages/primevue/src/button/Button.d.ts
@@ -171,7 +171,7 @@ export interface ButtonProps extends ButtonHTMLAttributes {
     /**
      * Defines the size of the button.
      */
-    size?: 'small' | 'large' | undefined;
+    size?: HintedString<'small' | 'large'> | undefined;
     /**
      * Specifies the variant of the component.
      * @defaultValue undefined

--- a/packages/primevue/src/button/style/ButtonStyle.js
+++ b/packages/primevue/src/button/style/ButtonStyle.js
@@ -641,6 +641,7 @@ const classes = {
             'p-button-outlined': props.outlined || props.variant === 'outlined',
             'p-button-sm': props.size === 'small',
             'p-button-lg': props.size === 'large',
+            [`p-button-${props.size}`]: props.size && props.size !== 'small' && props.size !== 'large',
             'p-button-plain': props.plain,
             'p-button-fluid': instance.hasFluid
         }


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7165

The button allows to extend the severity option but not the size option. I would like to add custom size to the button.