### PR TITLE
feat(badge): custom severity classes

### DIFF
--- a/packages/primevue/src/badge/style/BadgeStyle.js
+++ b/packages/primevue/src/badge/style/BadgeStyle.js
@@ -16,7 +16,8 @@ const classes = {
             'p-badge-warn': props.severity === 'warn',
             'p-badge-danger': props.severity === 'danger',
             'p-badge-secondary': props.severity === 'secondary',
-            'p-badge-contrast': props.severity === 'contrast'
+            'p-badge-contrast': props.severity === 'contrast',
+            [`p-badge-${props.severity}`]: props.severity && !['info', 'success', 'warn', 'danger', 'secondary', 'contrast'].includes(props.severity)
         }
     ]
 };


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7167

The badge does not allow extension of `severity`. It would be great to have the option to customize this component.