### PR TITLE
Fixed issue in Select.vue

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -352,11 +352,13 @@ export default {
             this.$emit('focus', event);
         },
         onBlur(event) {
-            this.focused = false;
-            this.focusedOptionIndex = -1;
-            this.searchValue = '';
-            this.$emit('blur', event);
-            this.formField.onBlur?.(event);
+            setTimeout(() => {
+                this.focused = false;
+                this.focusedOptionIndex = -1;
+                this.searchValue = '';
+                this.$emit('blur', event);
+                this.formField.onBlur?.(event);
+            }, 100);
         },
         onKeyDown(event) {
             if (this.disabled || isAndroid()) {


### PR DESCRIPTION
Small delay on blur handler to give enough time for the model to update from onOptionSelect(). This prevents the validation flicker issue because now the update value of the model is available when the blur event happens, and the formField.onBlur handler is called.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
This related to this reported issue:
https://github.com/primefaces/primevue/issues/6906