### PR TITLE
fix(fileupload): fix the types of the `content` slot

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.d.ts
+++ b/packages/primevue/src/fileupload/FileUpload.d.ts
@@ -530,7 +530,7 @@ export interface FileUploadSlots {
         /**
          * Status messages about upload process.
          */
-        messages: string | undefined;
+        messages: string[] | null;
     }): VNode[];
     /**
      * Custom content when there is no selected file.


### PR DESCRIPTION
Fix the wrong types of the `content` slot in the `fileupload` component.

Fix https://github.com/primefaces/primevue/issues/7189