### PR TITLE
Prevent the select from closing when releasing the mouse outside the component while trying to edit or delete the filter text

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -734,12 +734,12 @@ export default {
                     }
                 };
 
-                document.addEventListener('click', this.outsideClickListener);
+                document.addEventListener('mousedown', this.outsideClickListener);
             }
         },
         unbindOutsideClickListener() {
             if (this.outsideClickListener) {
-                document.removeEventListener('click', this.outsideClickListener);
+                document.removeEventListener('mousedown', this.outsideClickListener);
                 this.outsideClickListener = null;
             }
         },


### PR DESCRIPTION
###Defect Fixes
When the user selected text inside the select and then the mouse left the container, the select was closed, preventing editing or deleting the text.

###Feature Requests
To fix this, the click event was replaced with mousedown in bindOutsideClickListener and unbindOutsideClickListener. With this change, the user can now select, edit, or delete text without the select exiting unexpectedly.


![2025-02-05_13h06_25](https://github.com/user-attachments/assets/9db8625c-0757-4d6e-8f9f-d5f0222c1589)



