### PR TITLE
fix: wrong key name "aria.prevPageLabel" (#7200)

### DIFF
--- a/apps/showcase/doc/carousel/AccessibilityDoc.vue
+++ b/apps/showcase/doc/carousel/AccessibilityDoc.vue
@@ -12,7 +12,7 @@
         </p>
 
         <p>
-            Next and Previous navigators are button elements with <i>aria-label</i> attributes referring to the <i>aria.prevPageLabel</i> and <i>aria.nextPageLabel</i> properties of the <NuxtLink to="/configuration/#locale">locale</NuxtLink> API by
+            Next and Previous navigators are button elements with <i>aria-label</i> attributes referring to the <i>aria.previousPageLabel</i> and <i>aria.nextPageLabel</i> properties of the <NuxtLink to="/configuration/#locale">locale</NuxtLink> API by
             default respectively, you may still use your own aria roles and attributes as any valid attribute is passed to the button elements implicitly by using <i>nextButtonProps</i> and <i>prevButtonProps</i>.
         </p>
 

--- a/apps/showcase/doc/configuration/locale/LocaleApiDoc.vue
+++ b/apps/showcase/doc/configuration/locale/LocaleApiDoc.vue
@@ -377,7 +377,7 @@
                         <td>Next Page</td>
                     </tr>
                     <tr>
-                        <td>aria.prevPageLabel</td>
+                        <td>aria.previousPageLabel</td>
                         <td>Previous Page</td>
                     </tr>
                     <tr>

--- a/apps/showcase/doc/galleria/AccessibilityDoc.vue
+++ b/apps/showcase/doc/galleria/AccessibilityDoc.vue
@@ -12,7 +12,7 @@
         </p>
 
         <p>
-            Next and Previous navigators are button elements with <i>aria-label</i> attributes referring to the <i>aria.prevPageLabel</i> and <i>aria.nextPageLabel</i> properties of the <NuxtLink to="/configuration/#locale">locale</NuxtLink> API by
+            Next and Previous navigators are button elements with <i>aria-label</i> attributes referring to the <i>aria.previousPageLabel</i> and <i>aria.nextPageLabel</i> properties of the <NuxtLink to="/configuration/#locale">locale</NuxtLink> API by
             default respectively, you may still use your own aria roles and attributes as any valid attribute is passed to the button elements implicitly by using <i>nextButtonProps</i> and <i>prevButtonProps</i>.
         </p>
 

--- a/apps/showcase/doc/paginator/AccessibilityDoc.vue
+++ b/apps/showcase/doc/paginator/AccessibilityDoc.vue
@@ -4,7 +4,7 @@
         <p>Paginator is placed inside a <i>nav</i> element to indicate a navigation section. All of the paginator elements can be customized using templating however the default behavious is listed below.</p>
 
         <p>
-            First, previous, next and last page navigators elements with <i>aria-label</i> attributes referring to the <i>aria.firstPageLabel</i>, <i>aria.prevPageLabel</i>, <i>aria.nextPageLabel</i> and <i>aria.lastPageLabel</i> properties of the
+            First, previous, next and last page navigators elements with <i>aria-label</i> attributes referring to the <i>aria.firstPageLabel</i>, <i>aria.previousPageLabel</i>, <i>aria.nextPageLabel</i> and <i>aria.lastPageLabel</i> properties of the
             <NuxtLink to="/configuration/#locale">locale</NuxtLink> API respectively.
         </p>
 

--- a/packages/core/src/config/PrimeVue.d.ts
+++ b/packages/core/src/config/PrimeVue.d.ts
@@ -55,7 +55,7 @@ export interface PrimeVueLocaleAriaOptions {
     firstPageLabel?: string;
     lastPageLabel?: string;
     nextPageLabel?: string;
-    prevPageLabel?: string;
+    previousPageLabel?: string;
     rowsPerPageLabel?: string;
     jumpToPageDropdownLabel?: string;
     jumpToPageInputLabel?: string;

--- a/packages/core/src/config/PrimeVue.js
+++ b/packages/core/src/config/PrimeVue.js
@@ -103,7 +103,7 @@ export const defaultOptions = {
             firstPageLabel: 'First Page',
             lastPageLabel: 'Last Page',
             nextPageLabel: 'Next Page',
-            prevPageLabel: 'Previous Page',
+            previousPageLabel: 'Previous Page',
             rowsPerPageLabel: 'Rows per page',
             jumpToPageDropdownLabel: 'Jump to Page Dropdown',
             jumpToPageInputLabel: 'Jump to Page Input',

--- a/packages/primevue/src/carousel/Carousel.vue
+++ b/packages/primevue/src/carousel/Carousel.vue
@@ -637,7 +637,7 @@ export default {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.slide : undefined;
         },
         ariaPrevButtonLabel() {
-            return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.prevPageLabel : undefined;
+            return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.previousPageLabel : undefined;
         },
         ariaNextButtonLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.nextPageLabel : undefined;

--- a/packages/primevue/src/galleria/GalleriaThumbnails.vue
+++ b/packages/primevue/src/galleria/GalleriaThumbnails.vue
@@ -523,7 +523,7 @@ export default {
     },
     computed: {
         ariaPrevButtonLabel() {
-            return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.prevPageLabel : undefined;
+            return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.previousPageLabel : undefined;
         },
         ariaNextButtonLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.nextPageLabel : undefined;

--- a/packages/primevue/src/paginator/Paginator.vue
+++ b/packages/primevue/src/paginator/Paginator.vue
@@ -33,7 +33,7 @@
                         />
                         <PrevPageLink
                             v-else-if="item === 'PrevPageLink'"
-                            :aria-label="getAriaLabel('prevPageLabel')"
+                            :aria-label="getAriaLabel('previousPageLabel')"
                             :template="$slots.previcon || $slots.prevpagelinkicon"
                             @click="changePageToPrev($event)"
                             :disabled="isFirstPage || empty"


### PR DESCRIPTION
Should use `aria.previousPageLabel` instead of `aria.prevPageLabel`.

Issue link
#7200 