### PR TITLE
fix(Passthrough): Typo - Fix declearativeDoc example typo

### DIFF
--- a/apps/showcase/doc/passthrough/DeclarativeDoc.vue
+++ b/apps/showcase/doc/passthrough/DeclarativeDoc.vue
@@ -25,7 +25,7 @@ export default {
 <Panel
     :pt="{
         root: {
-            class='border-1 border-solid'
+            class: 'border-1 border-solid'
         },
         header: {
             'data-test-id': 'testid',

--- a/apps/showcase/doc/passthrough/DeclarativeDoc.vue
+++ b/apps/showcase/doc/passthrough/DeclarativeDoc.vue
@@ -25,7 +25,7 @@ export default {
 <Panel
     :pt="{
         root: {
-            class='"border-1 border-solid'
+            class='border-1 border-solid'
         },
         header: {
             'data-test-id': 'testid',


### PR DESCRIPTION
###Defect Fixes
remove extra double quotes and replace class= with class:

