### PR TITLE
Fixed #7224 - Wrong InkBar position when set default value in TabList

### DIFF
--- a/packages/primevue/src/tablist/TabList.vue
+++ b/packages/primevue/src/tablist/TabList.vue
@@ -66,9 +66,9 @@ export default {
         }
     },
     mounted() {
-        this.$nextTick(() => {
+        setTimeout(() => {
             this.updateInkBar();
-        });
+        }, 150);
 
         if (this.showNavigators) {
             this.updateButtonState();


### PR DESCRIPTION
This PR fixed #7224 about wrong `inkBar` (indicator) position when putting default `value` to a `TabList` in page or a Dialog. `InkBar` is used in Aura theme, while the other themes are not using the inkBar in tabs, so other themes are unaffected.

I previously tried to add `this.updateInkBar()` in `updated` method but the animation seems a bit off.

**Using `updated`**
https://github.com/user-attachments/assets/7a7e0a89-e08a-4ef0-b222-d9720c13ebc0

So, I tried to use timeout and it looks better.

**Using `setTimeout` (this PR)**
https://github.com/user-attachments/assets/aa0eea73-dd43-42da-8a63-458949da41b7



