### PR TITLE
Fix: Add removeCallback and index in Autocomplete chip slot definition

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.d.ts
+++ b/packages/primevue/src/autocomplete/AutoComplete.d.ts
@@ -582,6 +582,15 @@ export interface AutoCompleteSlots {
          * A value in the selection
          */
         value: any;
+        /**
+         * Index of the token.
+         */
+        index: number;
+        /**
+         * Remove token icon function.
+         * @param {Event} event - Browser event
+         */
+        removeCallback: (event: Event) => void;
     }): VNode[];
     /**
      * Custom header template of panel.


### PR DESCRIPTION
Add missing properties removeCallback and index off chip scopedslot in Autocomplete.d.ts.


Fix #7235