### PR TITLE
Fixed #7021 - Galleria: thumbnails don't work on mobile

### DIFF
--- a/packages/primevue/src/galleria/GalleriaThumbnails.vue
+++ b/packages/primevue/src/galleria/GalleriaThumbnails.vue
@@ -421,6 +421,12 @@ export default {
             }
         },
         changePageOnTouch(e, diff) {
+            const touchThreshold = 10
+
+            if(Math.abs(diff) < touchThreshold) {
+                // only a click/tap
+                return;
+            }
             if (diff < 0) {
                 // left
                 this.navForward(e);


### PR DESCRIPTION
Fixing #7021 by adding a threshold that needs to be reached before the motion triggers a swipe.

If the swipe is not triggered, then the normal click handler will correctly navigate to the next item.

Tested on Android