### PR TITLE
Fix: prevent unwanted horizontal scroll with scrollIntoView

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -929,7 +929,7 @@ export default {
                 const element = findSingle(this.list, `li[id="${id}"]`);
 
                 if (element) {
-                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
                 } else if (!this.virtualScrollerDisabled) {
                     this.virtualScroller && this.virtualScroller.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex);
                 }

--- a/packages/primevue/src/cascadeselect/CascadeSelect.vue
+++ b/packages/primevue/src/cascadeselect/CascadeSelect.vue
@@ -757,7 +757,7 @@ export default {
                 const element = findSingle(this.list, `li[id="${id}"]`);
 
                 if (element) {
-                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
                 }
             });
         },

--- a/packages/primevue/src/contextmenu/ContextMenu.vue
+++ b/packages/primevue/src/contextmenu/ContextMenu.vue
@@ -577,7 +577,7 @@ export default {
             const element = findSingle(this.list, `li[id="${id}"]`);
 
             if (element) {
-                element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
             }
         },
         createProcessedItems(items, level = 0, parent = {}, parentKey = '') {

--- a/packages/primevue/src/menubar/Menubar.vue
+++ b/packages/primevue/src/menubar/Menubar.vue
@@ -588,7 +588,7 @@ export default {
             const element = findSingle(this.menubar, `li[id="${id}"]`);
 
             if (element) {
-                element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
             }
         },
         createProcessedItems(items, level = 0, parent = {}, parentKey = '') {

--- a/packages/primevue/src/panelmenu/PanelMenuList.vue
+++ b/packages/primevue/src/panelmenu/PanelMenuList.vue
@@ -320,7 +320,7 @@ export default {
             const element = findSingle(this.$el, `li[id="${`${this.focusedItemId}`}"]`);
 
             if (element) {
-                element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
             }
         },
         autoUpdateActiveItemPath(expandedKeys) {

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -918,7 +918,7 @@ export default {
                 const element = findSingle(this.list, `li[id="${id}"]`);
 
                 if (element) {
-                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                    element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
                 } else if (!this.virtualScrollerDisabled) {
                     this.virtualScroller && this.virtualScroller.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex);
                 }

--- a/packages/primevue/src/tieredmenu/TieredMenu.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenu.vue
@@ -611,7 +611,7 @@ export default {
             const element = findSingle(this.menubar, `li[id="${id}"]`);
 
             if (element) {
-                element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
+                element.scrollIntoView && element.scrollIntoView({ block: 'nearest' });
             }
         },
         createProcessedItems(items, level = 0, parent = {}, parentKey = '') {

--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -498,7 +498,7 @@ export default {
                 let selectedItem = findSingle(this.overlay, '[data-p-selected="true"]');
 
                 if (selectedItem) {
-                    selectedItem.scrollIntoView({ block: 'nearest', inline: 'start' });
+                    selectedItem.scrollIntoView({ block: 'nearest' });
                 }
             }
         }


### PR DESCRIPTION
Replaces `inline: 'start'` with the default behavior (`inline: 'nearest'`) in multiple overlay components to avoid unnecessary horizontal scrolling when a scrollbar is present.

Affected components:
- AutoComplete
- CascadeSelect
- ContextMenu
- Menubar
- PanelMenuList
- Select
- TieredMenu
- TreeSelect

fix #7243 
 