### PR TITLE
fix: restore filter icon override functionality

### DIFF
--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -17,7 +17,7 @@
             v-bind="{ ...getColumnPT('pcColumnFilterButton', ptmFilterMenuParams), ...filterButtonProps.filter }"
         >
             <template #icon="slotProps">
-                <component :is="filterIconTemplate || hasFilter() ? 'FilterFillIcon' : 'FilterIcon'" :class="slotProps.class" v-bind="getColumnPT('filterMenuIcon')" />
+                <component :is="filterIconTemplate || (hasFilter() ? 'FilterFillIcon' : 'FilterIcon')" :class="slotProps.class" v-bind="getColumnPT('filterMenuIcon')" />
             </template>
         </Button>
         <Button


### PR DESCRIPTION
_Note: It's not yet released, so I didn't create an issue._

In the current released version, the logic is just `filterIconTemplate || 'FilterIcon'`.

This was changed to `filterIconTemplate || hasFilter() ? 'FilterFillIcon' : 'FilterIcon'` in 6c0e96fdcc7c410bd5e3203932f61e298e71ff5b and 2bfc867ec0d1e7a62bee6725aea10219421b39c3.

Since the ternary operator has a higher precedence than the logical OR (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table), this logic now means "use `FilterFillIcon` if `filterIconTemplate` is truthy", which is wrong. This PR adds parentheses to fix this bug.