### PR TITLE
Fix InputNumber clearTimer: clearInterval -> clearTimeout

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -966,7 +966,7 @@ export default {
         },
         clearTimer() {
             if (this.timer) {
-                clearInterval(this.timer);
+                clearTimeout(this.timer);
             }
         },
         maxBoundry() {


### PR DESCRIPTION
In some cases it may cause an infinite loop.
Caught this bug in my project. Unfortunately, I couldn't reproduce it on stackblitz, and couldn't identify specific reasons for this behavior.

**Original code:**
Timeout created:
https://github.com/primefaces/primevue/blob/439bcd169e0e1cf8e422dd0a1bb60fa0a7293923/packages/primevue/src/inputnumber/InputNumber.vue#L294-L296

but interval cleared:
https://github.com/primefaces/primevue/blob/439bcd169e0e1cf8e422dd0a1bb60fa0a7293923/packages/primevue/src/inputnumber/InputNumber.vue#L967-L971