### PR TITLE
fix(docs): makes the entire GuideDoc card clickable

### DIFF
--- a/apps/showcase/doc/setup/GuidesDoc.vue
+++ b/apps/showcase/doc/setup/GuidesDoc.vue
@@ -140,9 +140,8 @@
 .card {
     padding: 0;
     min-height: 15rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
 }
 
 .card a {


### PR DESCRIPTION
###Defect Fixes
Guide page cards are not fully clickable

###Feature Requests
Make the entire card clickable
