### PR TITLE
fix: hide clear icon when options array is empty

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -1137,7 +1137,7 @@ export default {
             return isEmpty(this.fluid) ? !!this.$pcFluid : this.fluid;
         },
         isClearIconVisible() {
-            return this.showClear && this.d_value != null && isNotEmpty(this.options);
+            return this.showClear && this.d_value && this.d_value.length && this.d_value != null && isNotEmpty(this.options);
         }
     },
     directives: {


### PR DESCRIPTION
Fixes #7265