### PR TITLE
fix: #5878, #5261 : DataTable recursive loop

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -748,9 +748,7 @@ export default {
 
             filterEvent.filteredValue = filteredValue;
             this.$emit('filter', filterEvent);
-            this.$nextTick(() => {
-                this.$emit('value-change', this.processedData);
-            });
+            this.$emit('value-change', filteredValue);
 
             return filteredValue;
         },
@@ -2019,13 +2017,13 @@ export default {
 
             if (!this.lazy && !this.virtualScrollerOptions?.lazy) {
                 if (data && data.length) {
-                    if (this.hasFilters) {
-                        data = this.filter(data);
-                    }
-
                     if (this.sorted) {
                         if (this.sortMode === 'single') data = this.sortSingle(data);
                         else if (this.sortMode === 'multiple') data = this.sortMultiple(data);
+                    }
+
+                    if (this.hasFilters) {
+                        data = this.filter(data);
                     }
                 }
             }


### PR DESCRIPTION
The commit 01b38bf has introduced a recursive loop in the DataTable component trying to solve the #3818 issue.

Since the 3.45.0 version, we can't use rowGroupMode and v-model:filters together anymore (issues #5261, #5878). The browser tab freezes when we do it.

This PR fixes the following issues : #5261, #5878
