### PR TITLE
feat(toast) Added appendTo Prop to Toast Component

### DIFF
--- a/packages/primevue/scripts/components/toast.js
+++ b/packages/primevue/scripts/components/toast.js
@@ -24,6 +24,12 @@ const ToastProps = [
         description: 'Base zIndex value to use in layering.'
     },
     {
+        name: 'appendTo',
+        type: 'string',
+        default: 'body',
+        description: 'A valid query selector or an HTMLElement to specify where the overlay gets attached.'
+    },
+    {
         name: 'breakpoints',
         type: 'object',
         default: 'null',

--- a/packages/primevue/src/toast/BaseToast.vue
+++ b/packages/primevue/src/toast/BaseToast.vue
@@ -18,6 +18,10 @@ export default {
             type: Boolean,
             default: true
         },
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
+        },
         baseZIndex: {
             type: Number,
             default: 0

--- a/packages/primevue/src/toast/Toast.d.ts
+++ b/packages/primevue/src/toast/Toast.d.ts
@@ -11,6 +11,7 @@ import type { DefineComponent, DesignToken, EmitFn, PassThrough } from '@primevu
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
 import { ButtonHTMLAttributes, TransitionProps, VNode } from 'vue';
+import { HintedString } from "@primevue/core/index";
 
 export declare type ToastPassThroughOptionType = ToastPassThroughAttributes | ((options: ToastPassThroughMethodOptions) => ToastPassThroughAttributes | string) | string | null | undefined;
 
@@ -192,6 +193,11 @@ export interface ToastProps {
      * @defaultValue true
      */
     autoZIndex?: boolean | undefined;
+    /**
+     * A valid query selector or an HTMLElement to specify where the dialog gets attached.
+     * @defaultValue body
+     */
+    appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
     /**
      * Base zIndex value to use in layering.
      * @defaultValue 0

--- a/packages/primevue/src/toast/Toast.vue
+++ b/packages/primevue/src/toast/Toast.vue
@@ -1,5 +1,5 @@
 <template>
-    <Portal>
+    <Portal :appendTo="appendTo">
         <div ref="container" :class="cx('root')" :style="sx('root', true, { position })" v-bind="ptmi('root')">
             <transition-group name="p-toast-message" tag="div" @enter="onEnter" @leave="onLeave" v-bind="{ ...ptm('transition') }">
                 <ToastMessage


### PR DESCRIPTION
This PR introduces the appendTo prop to the Toast component, allowing toast messages to be appended to a specified element, including the root HTML element.

###Defect Fixes
fixes: #7218



