### PR TITLE
fix(select): autoFilterFocus and autoOptionFocus working together

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -686,6 +686,7 @@ export default {
 
             setTimeout(() => {
                 this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
+                this.focusedOptionIndex = this.focusedOptionIndex !== -1 ? this.focusedOptionIndex : this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : this.editable ? -1 : this.findSelectedOptionIndex();
             }, 1);
         },
         onOverlayAfterEnter() {

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -686,7 +686,7 @@ export default {
 
             setTimeout(() => {
                 this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
-                this.focusedOptionIndex = this.focusedOptionIndex !== -1 ? this.focusedOptionIndex : this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : this.editable ? -1 : this.findSelectedOptionIndex();
+                this.autoUpdateModel();
             }, 1);
         },
         onOverlayAfterEnter() {
@@ -900,8 +900,11 @@ export default {
             });
         },
         autoUpdateModel() {
-            if (this.selectOnFocus && this.autoOptionFocus && !this.$filled) {
+            if (this.autoOptionFocus) {
                 this.focusedOptionIndex = this.findFirstFocusedOptionIndex();
+            }
+
+            if (this.selectOnFocus && this.autoOptionFocus && !this.$filled) {
                 this.onOptionSelect(null, this.visibleOptions[this.focusedOptionIndex], false);
             }
         },


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7283

When using both `autoFilterFocus` and `autoOptionFocus` the first option would get focus for a brief moment, but then it would get unselected once the filter input gets the focus.

This change makes both of these work as expected - the input get focus and the first option is preselected.