### PR TITLE
feat(select): added autoOptionFocusAfterFilter

### DIFF
--- a/packages/primevue/src/select/BaseSelect.vue
+++ b/packages/primevue/src/select/BaseSelect.vue
@@ -117,6 +117,10 @@ export default {
             type: Boolean,
             default: false
         },
+        autoOptionFocusAfterFilter: {
+            type: Boolean,
+            default: false
+        },
         autoFilterFocus: {
             type: Boolean,
             default: false

--- a/packages/primevue/src/select/Select.d.ts
+++ b/packages/primevue/src/select/Select.d.ts
@@ -483,6 +483,11 @@ export interface SelectProps {
      */
     autoOptionFocus?: boolean | undefined;
     /**
+     * Whether to focus on the first visible or selected element when the user filters the options.
+     * @defaultValue false
+     */
+    autoOptionFocusAfterFilter?: boolean | undefined;
+    /**
      * Whether to focus on the filter element when the overlay panel is shown.
      * @defaultValue false
      */

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -488,7 +488,7 @@ export default {
             const value = event.target.value;
 
             this.filterValue = value;
-            this.focusedOptionIndex = -1;
+            this.focusedOptionIndex = this.autoOptionFocusAfterFilter ? this.findFirstFocusedOptionIndex() : -1;
             this.$emit('filter', { originalEvent: event, value });
 
             !this.virtualScrollerDisabled && this.virtualScroller.scrollToIndex(0);


### PR DESCRIPTION
Fix: https://github.com/primefaces/primevue/issues/7286

This seems like a good improvement for the user as it auto selects the best matching option after filtering possibly saving them some key presses since the option is already selected for them.

before: filter options -> press ArrowDown -> press Enter
now: filter options -> press Enter