### PR TITLE
Cache hue value locally on ColorPicker

### DIFF
--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -39,6 +39,7 @@ export default {
         };
     },
     hsbValue: null,
+    localHue: null,
     outsideClickListener: null,
     documentMouseMoveListener: null,
     documentMouseUpListener: null,
@@ -91,7 +92,7 @@ export default {
             let brightness = Math.floor((100 * (150 - Math.max(0, Math.min(150, (event.pageY || event.changedTouches[0].pageY) - top)))) / 150);
 
             this.hsbValue = this.validateHSB({
-                h: this.hsbValue.h,
+                h: this.localHue,
                 s: saturation,
                 b: brightness
             });
@@ -103,9 +104,10 @@ export default {
         },
         pickHue(event) {
             let top = this.hueView.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0);
+            this.localHue = Math.floor((360 * (150 - Math.max(0, Math.min(150, (event.pageY || event.changedTouches[0].pageY) - top)))) / 150);
 
             this.hsbValue = this.validateHSB({
-                h: Math.floor((360 * (150 - Math.max(0, Math.min(150, (event.pageY || event.changedTouches[0].pageY) - top)))) / 150),
+                h: this.localHue,
                 s: 100,
                 b: 100
             });
@@ -339,6 +341,12 @@ export default {
                 }
             } else {
                 hsb = this.HEXtoHSB(this.defaultColor);
+            }
+
+            if (this.localHue == null) {
+                this.localHue = hsb.h;
+            } else {
+                hsb.h = this.localHue;
             }
 
             return hsb;


### PR DESCRIPTION
Fixes #4720 

My team and I came across Issue #4720 recently. I'll add a few more observations to describe this bug:

- The problem occurs when you drag the handle to the black color, as described by @cyhnkckali on Issue, which corresponds to the bottom edge of the selector. The left edge also causes the same behavior and corresponds to the different shades of gray, up to white. 
- The problem occurs when using the prop `format="hex"` (default) and `format="rgb"`. The problem is *not* reproduced when using `format="hsl"`.

This last point helps us understand where the problem comes from. Colors from white to black, and all shades of gray in between, are *hue-insensitive*. The hue selector can be set to any position, the color will always be the same.

However, the use of the prop `format="hex"`/`format="rgb"` coupled with the circular nature of the `v-model` means that the value we emitted (`$emit()`) and the one re-injected through the `v-model` loses the information about hue. For example, for black :
- `hex` = `#00000`: no hue information
- `rgb` = `rgb(0, 0, 0)` : no hue information
- `hsl` = `hls(123°, 0%, 0%)`: hue information is present, although useless when describing black

My proposed solution simply caches the hue value inside component so that it will always be set locally even if the information gets lost once emitted.
