### PR TITLE
fix(multi-select): autoFilterFocus and autoOptionFocus working together

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -738,6 +738,7 @@ export default {
             this.scrollInView();
 
             this.autoFilterFocus && focus(this.$refs.filterInput.$el);
+            this.autoUpdateModel();
         },
         onOverlayAfterEnter() {
             this.bindOutsideClickListener();
@@ -995,8 +996,11 @@ export default {
             });
         },
         autoUpdateModel() {
-            if (this.selectOnFocus && this.autoOptionFocus && !this.$filled) {
+            if (this.autoOptionFocus) {
                 this.focusedOptionIndex = this.findFirstFocusedOptionIndex();
+            }
+
+            if (this.selectOnFocus && this.autoOptionFocus && !this.$filled) {
                 const value = this.getOptionValue(this.visibleOptions[this.focusedOptionIndex]);
 
                 this.updateModel(null, [value]);


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7300

When using both autoFilterFocus and autoOptionFocus the first option would get focus for a brief moment, but then it would get unselected once the filter input gets the focus.

This change makes both of these work as expected - the input get focus and the first option is preselected.

Same as https://github.com/primefaces/primevue/pull/7282