### PR TITLE
fix #7294: AutoComplete - don't block default behaviour for Space key (writing a space) if no focused option 

### DIFF
--- a/apps/showcase/pages/uikit/index.vue
+++ b/apps/showcase/pages/uikit/index.vue
@@ -166,7 +166,7 @@
 
             <div class="flex flex-col md:flex-row gap-6 md:gap-6 mb-8">
                 <a
-                    href="https://www.figma.com/design/G855HjuSyK8viJr0a5ZjRG/Preview-%7C%C2%A0PrimeOne-%7C-3.0.1?node-id=830-41631&t=m1MbOTTqKsBSRBLS-1"
+                    href="https://www.figma.com/design/JRSFCni27PU4TrqOjoWeOA/Preview-%7C PrimeOne-|-3.1.0?node-id=806-36648&t=CpfshQ7laurr043o-1"
                     class="p-8 w-full md:w-6/12 bg-white flex flex-col items-center border-2 border-transparent hover:border-primary transition-colors duration-300"
                     target="_blank"
                     rel="noopener noreferrer"
@@ -176,7 +176,7 @@
                     <img alt="Figma Light" src="https://primefaces.org/cdn/primevue/images/uikit/logo-figma-light.svg" class="w-16" />
                 </a>
                 <a
-                    href="https://www.figma.com/design/XBQzDl4vDOO0pyxEGYcICt/Preview-%7C%C2%A0Dark-%7C-PrimeOne-%7C-3.0.1?node-id=806-36648&t=7AME0kw905t3PVVY-1"
+                    href="https://www.figma.com/design/ybRv6Rx2vGo9vQR0KRRt6G/Preview-%7C-Dark-%7C PrimeOne-|-3.1.0?node-id=6738-55117&t=XXwVln6ycpiKPlSS-1"
                     class="p-8 w-full md:w-6/12 bg-gray-900 flex flex-col items-center border-2 border-transparent hover:border-primary transition-colors duration-300"
                     target="_blank"
                     rel="noopener noreferrer"

--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -60,7 +60,19 @@
             >
                 <slot name="chip" :class="cx('pcChip')" :value="option" :index="i" :removeCallback="(event) => removeOption(event, i)" v-bind="ptm('pcChip')">
                     <!-- TODO: removetokenicon and removeTokenIcon  deprecated since v4.0. Use chipicon slot and chipIcon prop-->
-                    <Chip :class="cx('pcChip')" :label="getOptionLabel(option)" :removeIcon="chipIcon || removeTokenIcon" removable :unstyled="unstyled" @remove="removeOption($event, i)" :pt="ptm('pcChip')">
+                    <Chip
+                        :class="cx('pcChip')"
+                        :label="getOptionLabel(option)"
+                        :removeIcon="chipIcon || removeTokenIcon"
+                        removable
+                        :unstyled="unstyled"
+                        @remove="removeOption($event, i)"
+                        :pt="ptm('pcChip')"
+                        @keydown="(event) => onClearIconKeyDown(event, i)"
+                        v-bind="ptm('clearIcon')"
+                        data-pc-section="clearicon"
+                        :tabindex="!disabled ? 0 : -1"
+                    >
                         <template #removeicon>
                             <slot :name="$slots.chipicon ? 'chipicon' : 'removetokenicon'" :class="cx('chipIcon')" :index="i" :removeCallback="(event) => removeOption(event, i)" />
                         </template>
@@ -344,6 +356,18 @@ export default {
             this.focusedOptionIndex = -1;
             this.$emit('blur', event);
             this.formField.onBlur?.();
+        },
+        onClearIconKeyDown(event, index) {
+            if (this.disabled) {
+                event.preventDefault();
+                return;
+            }
+            switch (event.code) {
+                case 'Enter':
+                case 'NumpadEnter':
+                    this.removeOption(event, index);
+                    break;
+            }
         },
         onKeyDown(event) {
             if (this.disabled) {

--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -387,8 +387,11 @@ export default {
 
                 case 'Enter':
                 case 'NumpadEnter':
-                case 'Space':
                     this.onEnterKey(event);
+                    break;
+
+                case 'Space':
+                    this.onSpaceKey(event);
                     break;
 
                 case 'Escape':
@@ -704,6 +707,11 @@ export default {
             }
 
             event.preventDefault();
+        },
+        onSpaceKey(event) {
+            if (this.focusedOptionIndex !== -1) {
+                this.onEnterKey(event);
+            }
         },
         onEscapeKey(event) {
             this.overlayVisible && this.hide(true);

--- a/packages/primevue/src/inputnumber/BaseInputNumber.vue
+++ b/packages/primevue/src/inputnumber/BaseInputNumber.vue
@@ -136,6 +136,10 @@ export default {
         ariaLabel: {
             type: String,
             default: null
+        },
+        required: {
+            type: Boolean,
+            default: false
         }
     },
     style: InputNumberStyle,

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -17,6 +17,7 @@
             :placeholder="placeholder"
             :aria-labelledby="ariaLabelledby"
             :aria-label="ariaLabel"
+            :required="required"
             :size="size"
             :invalid="invalid"
             :variant="variant"

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -3,6 +3,7 @@
         <input
             v-if="editable"
             ref="focusInput"
+            :name="name"
             :id="labelId || inputId"
             type="text"
             :class="[cx('label'), inputClass, labelClass]"
@@ -29,6 +30,7 @@
         <span
             v-else
             ref="focusInput"
+            :name="name"
             :id="labelId || inputId"
             :class="[cx('label'), inputClass, labelClass]"
             :style="[inputStyle, labelStyle]"


### PR DESCRIPTION
- Add dedicated handler for Space key press in AutoComplete
- Trigger selection on Space key only when a focused option exists

Fixes #7294 