### PR TITLE
Button with icon onyl - Rollback change from #7123

### DIFF
--- a/packages/primevue/src/button/Button.vue
+++ b/packages/primevue/src/button/Button.vue
@@ -8,7 +8,7 @@
             <slot v-else name="icon" :class="[cx('icon')]" v-bind="ptm('icon')">
                 <span v-if="icon" :class="[cx('icon'), icon, iconClass]" v-bind="ptm('icon')"></span>
             </slot>
-            <span v-if="!hasIcon || !!label" :class="cx('label')" v-bind="ptm('label')">{{ label || '&nbsp;' }}</span>
+            <span :class="cx('label')" v-bind="ptm('label')">{{ label || '&nbsp;' }}</span>
             <Badge v-if="badge" :value="badge" :class="badgeClass" :severity="badgeSeverity" :unstyled="unstyled" :pt="ptm('pcBadge')"></Badge>
         </slot>
     </component>


### PR DESCRIPTION
###Defect Fixes
#7325 

I'm not sure to understand what went wrong in #7123 as there is this css rule that hides the label if it's empty:

```
.p-button-icon-only .p-button-label {
  visibility: hidden;
  width: 0;
}
```

Putting back the span with an empty label would fix the buttons with only an icon.