### PR TITLE
fix: #7333 Avoid rendering meaningless Datepicker Today button for timeOnly variant

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -506,6 +506,7 @@
                     </div>
                     <div v-if="showButtonBar" :class="cx('buttonbar')" v-bind="ptm('buttonbar')">
                         <Button
+                            v-if="!timeOnly"
                             :label="todayLabel"
                             @click="onTodayButtonClick($event)"
                             :class="cx('pcTodayButton')"


### PR DESCRIPTION
Fix for https://github.com/primefaces/primevue/issues/7333

When using DatePicker's timeOnly variant with showButtonBar enabled, both "Today" and "Clear" buttons are included, but "Today" has no meaning with only a time. Clicking it sets the time to 0:00.

"Clear" remains very useful. We would like to render the buttonBar for timeOnly Datepickers without the "Today" button by default to avoid needing passthrough to control its visibility.

Before:
<img width="307" alt="Screenshot 2025-02-26 at 14 08 40" src="https://github.com/user-attachments/assets/8ca68bc1-c8ec-4fbb-ba2f-c390c869461b" />

After:
<img width="278" alt="Screenshot 2025-02-26 at 14 08 09" src="https://github.com/user-attachments/assets/f75fcc59-252f-4896-a163-72ef5597e6af" />

If this fix is approved, it might be also be good to update theme styles to support making the left button of the buttonBar conditionally rendered without moving the right button in the layout.