### PR TITLE
Fixed #7335

### DIFF
--- a/packages/primevue/src/datatable/BodyRow.vue
+++ b/packages/primevue/src/datatable/BodyRow.vue
@@ -350,12 +350,21 @@ export default {
                 let nextRowFieldData = currentRowFieldData;
                 let groupRowSpan = 0;
 
+                if(this.d_rowExpanded){
+                    groupRowSpan++;
+                }
+
                 while (currentRowFieldData === nextRowFieldData) {
                     groupRowSpan++;
                     let nextRowData = this.value[++index];
 
                     if (nextRowData) {
                         nextRowFieldData = resolveFieldData(nextRowData, field);
+
+                        const nextRowKeyData = this.dataKey ? resolveFieldData(nextRowData, this.dataKey) : null;
+                        const isNextRowExpanded = (nextRowKeyData && this.expandedRows?.hasOwnProperty?.(nextRowKeyData)) || this.expandedRows?.some?.((d) => this.equals(nextRowData, d))
+            
+                        if(isNextRowExpanded) groupRowSpan++;
                     } else {
                         break;
                     }


### PR DESCRIPTION
Ensures that the last rows of a group do not shift left when expanding rows.   The issue was caused by the grouped column being hidden, affecting row alignment   based on the number of expanded rows.