### PR TITLE
feat: initial support for custom elements

### DIFF
--- a/apps/showcase/components/layout/AppTopBar.vue
+++ b/apps/showcase/components/layout/AppTopBar.vue
@@ -223,7 +223,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.isOutsideTopbarMenuClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.isOutsideTopbarMenuClicked(target)) {
                         this.unbindOutsideClickListener();
                     }
                 };
@@ -237,8 +238,8 @@ export default {
                 this.outsideClickListener = null;
             }
         },
-        isOutsideTopbarMenuClicked(event) {
-            return !(this.$refs.topbarMenu.isSameNode(event.target) || this.$refs.topbarMenu.contains(event.target));
+        isOutsideTopbarMenuClicked(target) {
+            return !(this.$refs.topbarMenu.isSameNode(target) || this.$refs.topbarMenu.contains(target));
         },
         containerRef(el) {
             this.container = el;

--- a/packages/core/src/base/Base.js
+++ b/packages/core/src/base/Base.js
@@ -1,4 +1,4 @@
-export default {
+export const getBaseInstance = () => ({
     _loadedStyleNames: new Set(),
     getLoadedStyleNames() {
         return this._loadedStyleNames;
@@ -15,4 +15,6 @@ export default {
     clearLoadedStyleNames() {
         this._loadedStyleNames.clear();
     }
-};
+});
+
+export default getBaseInstance();

--- a/packages/core/src/base/style/BaseStyle.d.ts
+++ b/packages/core/src/base/style/BaseStyle.d.ts
@@ -6,6 +6,7 @@
  *
  */
 import type { Style, StyleOptions } from '@primevue/core/usestyle';
+import type { Theme as ThemeSingleton, dt as dtSingleton, css as cssSingleton } from '@primeuix/styled';
 
 export enum BaseClasses {}
 
@@ -15,5 +16,7 @@ export declare interface BaseStyle {
     classes?: object | undefined;
     inlineStyles?: object | undefined;
     load?: ((style: string | ((params?: any) => string | undefined), options?: StyleOptions) => Style | object | undefined) | undefined;
-    getStyleSheet?: ((extendedCSS?: string, props?: any) => string | undefined) | undefined;
+    getStyleSheet?: ((extendedCSS?: string, params?: any, props?: any) => string | undefined) | undefined;
 }
+
+export declare const getBaseStyleInstance: (Theme: typeof ThemeSingleton, dt: typeof dtSingleton, Css: typeof cssSingleton) => BaseStyle;

--- a/packages/core/src/basecomponent/BaseComponent.vue
+++ b/packages/core/src/basecomponent/BaseComponent.vue
@@ -1,9 +1,6 @@
 <script>
-import { Theme, ThemeService } from '@primeuix/styled';
 import { findSingle, isElement } from '@primeuix/utils/dom';
 import { getKeyValue, isArray, isFunction, isNotEmpty, isString, resolve, toFlatCase } from '@primeuix/utils/object';
-import Base from '@primevue/core/base';
-import BaseStyle from '@primevue/core/base/style';
 import { useAttrSelector } from '@primevue/core/useattrselector';
 import { mergeProps } from 'vue';
 import BaseComponentStyle from './style/BaseComponentStyle';
@@ -37,7 +34,7 @@ export default {
         isUnstyled: {
             immediate: true,
             handler(newValue) {
-                ThemeService.off('theme:change', this._loadCoreStyles);
+                this.$primevueStyled.ThemeService.off('theme:change', this._loadCoreStyles);
 
                 if (!newValue) {
                     this._loadCoreStyles();
@@ -48,7 +45,7 @@ export default {
         dt: {
             immediate: true,
             handler(newValue, oldValue) {
-                ThemeService.off('theme:change', this._themeScopedListener);
+                this.$primevueStyled.ThemeService.off('theme:change', this._themeScopedListener);
 
                 if (newValue) {
                     this._loadScopedThemeStyles(newValue);
@@ -126,11 +123,11 @@ export default {
         },
         _load() {
             // @todo
-            if (!Base.isStyleNameLoaded('base')) {
-                BaseStyle.loadCSS(this.$styleOptions);
+            if (!this.$primevueBase.isStyleNameLoaded('base')) {
+                this.$primevueBaseStyle.loadCSS(this.$styleOptions);
                 this._loadGlobalStyles();
 
-                Base.setLoadedStyleName('base');
+                this.$primevueBase.setLoadedStyleName('base');
             }
 
             this._loadThemeStyles();
@@ -140,11 +137,11 @@ export default {
             this._themeChangeListener(this._load);
         },
         _loadCoreStyles() {
-            if (!Base.isStyleNameLoaded(this.$style?.name) && this.$style?.name) {
-                BaseComponentStyle.loadCSS(this.$styleOptions);
+            if (!this.$primevueBase.isStyleNameLoaded(this.$style?.name) && this.$style?.name) {
+                this.$primevueBaseComponentStyle.loadCSS(this.$styleOptions);
                 this.$options.style && this.$style.loadCSS(this.$styleOptions);
 
-                Base.setLoadedStyleName(this.$style.name);
+                this.$primevueBase.setLoadedStyleName(this.$style.name);
             }
         },
         _loadGlobalStyles() {
@@ -160,40 +157,40 @@ export default {
 
             const globalCSS = this._useGlobalPT(this._getOptionValue, 'global.css', this.$params);
 
-            isNotEmpty(globalCSS) && BaseStyle.load(globalCSS, { name: 'global', ...this.$styleOptions });
+            isNotEmpty(globalCSS) && this.$primevueBaseStyle.load(globalCSS, { name: 'global', ...this.$styleOptions });
         },
         _loadThemeStyles() {
             if (this.isUnstyled || this.$theme === 'none') return;
 
             // common
-            if (!Theme.isStyleNameLoaded('common')) {
+            if (!this.$primevueStyled.Theme.isStyleNameLoaded('common')) {
                 const { primitive, semantic, global, style } = this.$style?.getCommonTheme?.() || {};
 
-                BaseStyle.load(primitive?.css, { name: 'primitive-variables', ...this.$styleOptions });
-                BaseStyle.load(semantic?.css, { name: 'semantic-variables', ...this.$styleOptions });
-                BaseStyle.load(global?.css, { name: 'global-variables', ...this.$styleOptions });
-                BaseStyle.loadStyle({ name: 'global-style', ...this.$styleOptions }, style);
+                this.$primevueBaseStyle.load(primitive?.css, { name: 'primitive-variables', ...this.$styleOptions });
+                this.$primevueBaseStyle.load(semantic?.css, { name: 'semantic-variables', ...this.$styleOptions });
+                this.$primevueBaseStyle.load(global?.css, { name: 'global-variables', ...this.$styleOptions });
+                this.$primevueBaseStyle.loadStyle({ name: 'global-style', ...this.$styleOptions }, style);
 
-                Theme.setLoadedStyleName('common');
+                this.$primevueStyled.Theme.setLoadedStyleName('common');
             }
 
             // component
-            if (!Theme.isStyleNameLoaded(this.$style?.name) && this.$style?.name) {
+            if (!this.$primevueStyled.Theme.isStyleNameLoaded(this.$style?.name) && this.$style?.name) {
                 const { css, style } = this.$style?.getComponentTheme?.() || {};
 
                 this.$style?.load(css, { name: `${this.$style.name}-variables`, ...this.$styleOptions });
                 this.$style?.loadStyle({ name: `${this.$style.name}-style`, ...this.$styleOptions }, style);
 
-                Theme.setLoadedStyleName(this.$style.name);
+                this.$primevueStyled.Theme.setLoadedStyleName(this.$style.name);
             }
 
             // layer order
-            if (!Theme.isStyleNameLoaded('layer-order')) {
+            if (!this.$primevueStyled.Theme.isStyleNameLoaded('layer-order')) {
                 const layerOrder = this.$style?.getLayerOrderThemeCSS?.();
 
-                BaseStyle.load(layerOrder, { name: 'layer-order', first: true, ...this.$styleOptions });
+                this.$primevueBaseStyle.load(layerOrder, { name: 'layer-order', first: true, ...this.$styleOptions });
 
-                Theme.setLoadedStyleName('layer-order');
+                this.$primevueStyled.Theme.setLoadedStyleName('layer-order');
             }
         },
         _loadScopedThemeStyles(preset) {
@@ -206,13 +203,13 @@ export default {
             this.scopedStyleEl?.value?.remove();
         },
         _themeChangeListener(callback = () => {}) {
-            Base.clearLoadedStyleNames();
-            ThemeService.on('theme:change', callback);
+            this.$primevueBase.clearLoadedStyleNames();
+            this.$primevueStyled.ThemeService.on('theme:change', callback);
         },
         _removeThemeListeners() {
-            ThemeService.off('theme:change', this._loadCoreStyles);
-            ThemeService.off('theme:change', this._load);
-            ThemeService.off('theme:change', this._themeScopedListener);
+            this.$primevueStyled.ThemeService.off('theme:change', this._loadCoreStyles);
+            this.$primevueStyled.ThemeService.off('theme:change', this._load);
+            this.$primevueStyled.ThemeService.off('theme:change', this._themeScopedListener);
         },
         _getHostInstance(instance) {
             return instance ? (this.$options.hostName ? (instance.$.type.name === this.$options.hostName ? instance : this._getHostInstance(instance.$parentInstance)) : instance.$parentInstance) : undefined;
@@ -318,7 +315,7 @@ export default {
         sx(key = '', when = true, params = {}) {
             if (when) {
                 const self = this._getOptionValue(this.$style.inlineStyles, key, { ...this.$params, ...params });
-                const base = this._getOptionValue(BaseComponentStyle.inlineStyles, key, { ...this.$params, ...params });
+                const base = this._getOptionValue(this.$primevueBaseComponentStyle.inlineStyles, key, { ...this.$params, ...params });
 
                 return [base, self];
             }
@@ -348,13 +345,33 @@ export default {
             return this.$primevueConfig?.theme;
         },
         $style() {
-            return { classes: undefined, inlineStyles: undefined, load: () => {}, loadCSS: () => {}, loadStyle: () => {}, ...(this._getHostInstance(this) || {}).$style, ...this.$options.style };
+            return {
+                classes: undefined,
+                inlineStyles: undefined,
+                load: () => {},
+                loadCSS: () => {},
+                loadStyle: () => {},
+                ...(this._getHostInstance(this) || {}).$style,
+                ...(this.$options.style && this.$options.style.bindInstance(this.$primevueBaseStyle))
+            };
         },
         $styleOptions() {
-            return { nonce: this.$primevueConfig?.csp?.nonce };
+            return { nonce: this.$primevueConfig?.csp?.nonce, prefix: this.$primevueConfig?.prefix, root: this.$primevue.root };
         },
         $primevueConfig() {
-            return this.$primevue?.config;
+            return this.$primevue.config;
+        },
+        $primevueStyled() {
+            return this.$primevue.styled;
+        },
+        $primevueBase() {
+            return this.$primevue.Base;
+        },
+        $primevueBaseStyle() {
+            return this.$primevue.BaseStyle;
+        },
+        $primevueBaseComponentStyle() {
+            return BaseComponentStyle.bindInstance(this.$primevueBaseStyle);
         },
         $name() {
             return this.$options.hostName || this.$.type.name;

--- a/packages/core/src/config/PrimeVue.d.ts
+++ b/packages/core/src/config/PrimeVue.d.ts
@@ -1,4 +1,8 @@
-import { Plugin } from 'vue';
+import { Plugin, VueElementConstructor as VueElementConstructorType } from 'vue';
+import { getStyledInstance } from '@primeuix/styled';
+import { getBaseInstance } from '@primevue/core/base';
+import { getBaseStyleInstance } from '@primevue/core/base/style';
+import { getPrimeVueServiceInstance } from '@primevue/core/service';
 
 export interface PrimeVueConfiguration {
     ripple?: boolean;
@@ -15,6 +19,7 @@ export interface PrimeVueConfiguration {
     pt?: any;
     ptOptions?: any;
     csp?: PrimeVueCSPOptions;
+    prefix?: string;
 }
 
 export declare const defaultOptions: PrimeVueConfiguration;
@@ -165,6 +170,13 @@ declare module 'vue' {
     interface ComponentCustomProperties {
         $primevue: {
             config: PrimeVueConfiguration;
+            styled: ReturnType<typeof getStyledInstance>;
+            Base: ReturnType<typeof getBaseInstance>;
+            BaseStyle: ReturnType<typeof getBaseStyleInstance>;
+            PrimeVueService: ReturnType<typeof getPrimeVueServiceInstance>;
+            root?: ShadowRoot | HTMLElement;
         };
     }
 }
+
+export declare function wrapCustomElement(VueElementConstructor: VueElementConstructorType): VueElementConstructorType;

--- a/packages/core/src/service/PrimeVueService.d.ts
+++ b/packages/core/src/service/PrimeVueService.d.ts
@@ -1,3 +1,5 @@
 import type { EventBusOptions } from '@primeuix/utils/eventbus';
 
 export interface PrimeVueService extends EventBusOptions {}
+
+export declare const getPrimeVueServiceInstance: () => EventBusOptions;

--- a/packages/core/src/service/PrimeVueService.js
+++ b/packages/core/src/service/PrimeVueService.js
@@ -1,3 +1,7 @@
 import { EventBus } from '@primeuix/utils/eventbus';
 
-export default EventBus();
+export const getPrimeVueServiceInstance = () => EventBus();
+
+const PrimeVueService = getPrimeVueServiceInstance();
+
+export default PrimeVueService;

--- a/packages/core/src/usestyle/UseStyle.d.ts
+++ b/packages/core/src/usestyle/UseStyle.d.ts
@@ -1,5 +1,7 @@
 export interface StyleOptions {
-    document?: HTMLElement;
+    document?: Document;
+    root?: ShadowRoot | HTMLElement;
+    prefix?: string;
     immediate?: boolean;
     manual?: boolean;
     name?: string;

--- a/packages/metadata/src/components/index.ts
+++ b/packages/metadata/src/components/index.ts
@@ -98,7 +98,8 @@ export const misc: MetaType[] = toMeta(['Avatar', 'AvatarGroup', 'Badge', 'Block
 
 export const extensions: MetaType[] = toMeta([
     { name: 'Form', from: '@primevue/forms/form' },
-    { name: 'FormField', from: '@primevue/forms/formfield' }
+    { name: 'FormField', from: '@primevue/forms/formfield' },
+    { name: 'BaseIcon', from: '@primevue/icons/baseicon' }
 ]);
 
 // All PrimeVue Components

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -101,12 +101,15 @@ const config = runtimeConfig?.public?.primevue ?? {};
 const { options = {} } = config;
 
 const stylesToTop = [${registered.injectStylesAsStringToTop.join('')}].join('');
+const styleParams = {
+    ${options?.prefix ? `prefix: '${options?.prefix}'` : ''}
+}
 const styleProps = {
-    ${options?.csp?.nonce ? `nonce: ${options?.csp?.nonce}` : ''}
+    ${options?.csp?.nonce ? `nonce: '${options?.csp?.nonce}'` : ''}
 }
 const styles = [
     ${registered.injectStylesAsString.join('')},
-    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getStyleSheet ? ${item.as}.getStyleSheet(undefined, styleProps) : ''`).join(',')}
+    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getStyleSheet ? ${item.as}.getStyleSheet(undefined, styleParams, styleProps) : ''`).join(',')}
 ].join('');
 
 ${hasTheme ? `Theme.setTheme(${importTheme?.as} || options?.theme)` : ''}
@@ -116,8 +119,8 @@ const themes = ${
                     ? `[]`
                     : `
 [
-    ${`${uniqueRegisteredStyles?.[0].as} && ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet ? ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet(undefined, styleProps) : ''`},
-    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getThemeStyleSheet ? ${item.as}.getThemeStyleSheet(undefined, styleProps) : ''`).join(',')}
+    ${uniqueRegisteredStyles?.[0].as} && ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet ? ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet(styleParams, styleProps) : '',
+    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getThemeStyleSheet ? ${item.as}.getThemeStyleSheet(styleParams, styleProps) : ''`).join(',')}
 ].join('');`
             }
 

--- a/packages/nuxt-module/src/register.ts
+++ b/packages/nuxt-module/src/register.ts
@@ -143,7 +143,7 @@ function registerInjectStylesAsString(moduleOptions: ModuleOptions) {
 
 function registerInjectStylesAsStringToTop(moduleOptions: any) {
     // @todo - Remove `cssLayerOrder`
-    return [Utils.object.createStyleAsString(moduleOptions.cssLayerOrder ? `@layer ${moduleOptions.cssLayerOrder}` : undefined, { name: 'layer-order' })];
+    return [Utils.object.createStyleAsString(moduleOptions.cssLayerOrder ? `@layer ${moduleOptions.cssLayerOrder};` : undefined, { name: 'layer-order', prefix: moduleOptions.options?.prefix })];
 }
 
 export function register(moduleOptions: ModuleOptions) {

--- a/packages/nuxt-module/src/utils.ts
+++ b/packages/nuxt-module/src/utils.ts
@@ -11,10 +11,15 @@ export const Utils = {
         getPath(fn: any, options: ResolvePathOptions) {
             return isFunction(fn) ? fn(options) : options.from;
         },
-        createStyleAsString(css: string, options = { name: '' }) {
-            const { name, ...rest } = options;
+        createStyleAsString(css: string, options = { name: '', prefix: undefined }) {
+            const { name, prefix, ...rest } = options;
+            let id = name;
 
-            return createStyleAsString(css, { 'data-primevue-style-id': name, ...rest });
+            if (prefix) {
+                id = id ? `${prefix}_${id}` : id;
+            }
+
+            return createStyleAsString(css, { 'data-primevue-style-id': id, ...rest });
         }
     }
 };

--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -824,7 +824,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.overlay && this.isOutsideClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.overlay && this.isOutsideClicked(target)) {
                         this.hide();
                     }
                 };
@@ -871,15 +872,15 @@ export default {
                 this.resizeListener = null;
             }
         },
-        isOutsideClicked(event) {
-            return !this.overlay.contains(event.target) && !this.isInputClicked(event) && !this.isDropdownClicked(event);
+        isOutsideClicked(target) {
+            return !this.overlay.contains(target) && !this.isInputClicked(target) && !this.isDropdownClicked(target);
         },
-        isInputClicked(event) {
-            if (this.multiple) return event.target === this.$refs.multiContainer || this.$refs.multiContainer.contains(event.target);
-            else return event.target === this.$refs.focusInput.$el;
+        isInputClicked(target) {
+            if (this.multiple) return target === this.$refs.multiContainer || this.$refs.multiContainer.contains(target);
+            else return target === this.$refs.focusInput.$el;
         },
-        isDropdownClicked(event) {
-            return this.$refs.dropdownButton ? event.target === this.$refs.dropdownButton || this.$refs.dropdownButton.contains(event.target) : false;
+        isDropdownClicked(target) {
+            return this.$refs.dropdownButton ? target === this.$refs.dropdownButton || this.$refs.dropdownButton.contains(target) : false;
         },
         isOptionMatched(option, value) {
             return this.isValidOption(option) && this.getOptionLabel(option)?.toLocaleLowerCase(this.searchLocale) === value.toLocaleLowerCase(this.searchLocale);

--- a/packages/primevue/src/blockui/BlockUI.vue
+++ b/packages/primevue/src/blockui/BlockUI.vue
@@ -52,7 +52,7 @@ export default {
                 });
 
                 document.body.appendChild(this.mask);
-                blockBodyScroll();
+                blockBodyScroll(this.$primevue.styled.$dt);
                 document.activeElement.blur();
             } else {
                 this.mask = createElement('div', {
@@ -103,7 +103,7 @@ export default {
 
             if (this.fullScreen) {
                 document.body.removeChild(this.mask);
-                unblockBodyScroll();
+                unblockBodyScroll(this.$primevue.styled.$dt);
             } else {
                 this.$refs.container?.removeChild(this.mask);
             }

--- a/packages/primevue/src/cascadeselect/CascadeSelect.vue
+++ b/packages/primevue/src/cascadeselect/CascadeSelect.vue
@@ -571,7 +571,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.overlay && !this.$el.contains(event.target) && !this.overlay.contains(event.target)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.overlay && !this.$el.contains(target) && !this.overlay.contains(target)) {
                         this.hide();
                     }
                 };

--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -465,8 +465,8 @@ export default {
             !this.isUnstyled && addClass(this.$el, 'p-colorpicker-dragging');
             event.preventDefault();
         },
-        isInputClicked(event) {
-            return this.$refs.input && this.$refs.input.isSameNode(event.target);
+        isInputClicked(target) {
+            return this.$refs.input && this.$refs.input.isSameNode(target);
         },
         bindDragListeners() {
             this.bindDocumentMouseMoveListener();
@@ -479,7 +479,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.picker && !this.picker.contains(event.target) && !this.isInputClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.picker && !this.picker.contains(target) && !this.isInputClicked(target)) {
                         this.overlayVisible = false;
                     }
                 };

--- a/packages/primevue/src/config/Config.d.ts
+++ b/packages/primevue/src/config/Config.d.ts
@@ -147,6 +147,7 @@ export interface PrimeVueConfiguration {
     pt?: PassThrough<PrimeVuePTOptions>;
     ptOptions?: PassThroughOptions;
     csp?: PrimeVueCSPOptions;
+    prefix?: string;
 }
 
 export interface PrimeVuePTOptions {

--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -58,7 +58,6 @@
 </template>
 
 <script>
-import { $dt } from '@primeuix/styled';
 import { absolutePosition, addClass, focus, getOffset, isTouchDevice } from '@primeuix/utils/dom';
 import { ZIndex } from '@primeuix/utils/zindex';
 import { ConnectedOverlayScrollHandler } from '@primevue/core/utils';
@@ -212,7 +211,7 @@ export default {
                 arrowLeft = targetOffset.left - containerOffset.left;
             }
 
-            this.container.style.setProperty($dt('confirmpopup.arrow.left').name, `${arrowLeft}px`);
+            this.container.style.setProperty(this.$primevue.styled.$dt('confirmpopup.arrow.left').name, `${arrowLeft}px`);
 
             if (containerOffset.top < targetOffset.top) {
                 this.container.setAttribute('data-p-confirmpopup-flipped', 'true');
@@ -222,7 +221,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.visible && this.container && !this.container.contains(event.target) && !this.isTargetClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.visible && this.container && !this.container.contains(target) && !this.isTargetClicked(target)) {
                         if (this.confirmation.onHide) {
                             this.confirmation.onHide();
                         }
@@ -282,8 +282,8 @@ export default {
                 focusTarget.focus({ preventScroll: true }); // Firefox requires preventScroll
             }
         },
-        isTargetClicked(event) {
-            return this.target && (this.target === event.target || this.target.contains(event.target));
+        isTargetClicked(target) {
+            return this.target && (this.target === target || this.target.contains(target));
         },
         containerRef(el) {
             this.container = el;

--- a/packages/primevue/src/contextmenu/ContextMenu.vue
+++ b/packages/primevue/src/contextmenu/ContextMenu.vue
@@ -420,8 +420,9 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const isOutsideContainer = this.container && !this.container.contains(event.target);
-                    const isOutsideTarget = this.visible ? !(this.target && (this.target === event.target || this.target.contains(event.target))) : true;
+                    const target = event.composedPath()[0];
+                    const isOutsideContainer = this.container && !this.container.contains(target);
+                    const isOutsideTarget = this.visible ? !(this.target && (this.target === target || this.target.contains(target))) : true;
 
                     if (isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -584,7 +584,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(event.target)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(target)) {
                         this.overlayVisible = false;
                     }
 

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1038,7 +1038,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.isOutsideClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.isOutsideClicked(target)) {
                         this.overlayVisible = false;
                     }
                 };
@@ -1126,12 +1127,11 @@ export default {
                 this.matchMediaOrientationListener = null;
             }
         },
-        isOutsideClicked(event) {
-            const composedPath = event.composedPath();
-            return !(this.$el.isSameNode(event.target) || this.isNavIconClicked(event) || composedPath.includes(this.$el) || composedPath.includes(this.overlay));
+        isOutsideClicked(target) {
+            return !(this.$el.isSameNode(target) || this.isNavIconClicked(target) || this.$el.contains(target) || (this.overlay && this.overlay.contains(target)));
         },
-        isNavIconClicked(event) {
-            return (this.previousButton && (this.previousButton.isSameNode(event.target) || this.previousButton.contains(event.target))) || (this.nextButton && (this.nextButton.isSameNode(event.target) || this.nextButton.contains(event.target)));
+        isNavIconClicked(target) {
+            return (this.previousButton && (this.previousButton.isSameNode(target) || this.previousButton.contains(target))) || (this.nextButton && (this.nextButton.isSameNode(target) || this.nextButton.contains(target)));
         },
         alignOverlay() {
             if (this.overlay) {

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -224,17 +224,17 @@ export default {
             }
 
             if (!this.modal) {
-                this.maximized ? blockBodyScroll() : unblockBodyScroll();
+                this.maximized ? blockBodyScroll(this.$primevue.styled.$dt) : unblockBodyScroll(this.$primevue.styled.$dt);
             }
         },
         enableDocumentSettings() {
             if (this.modal || (!this.modal && this.blockScroll) || (this.maximizable && this.maximized)) {
-                blockBodyScroll();
+                blockBodyScroll(this.$primevue.styled.$dt);
             }
         },
         unbindDocumentState() {
             if (this.modal || (!this.modal && this.blockScroll) || (this.maximizable && this.maximized)) {
-                unblockBodyScroll();
+                unblockBodyScroll(this.$primevue.styled.$dt);
             }
         },
         onKeyDown(event) {

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -164,14 +164,14 @@ export default {
             }
 
             if (this.blockScroll) {
-                blockBodyScroll();
+                blockBodyScroll(this.$primevue.styled.$dt);
             }
         },
         disableDocumentSettings() {
             this.unbindOutsideClickListener();
 
             if (this.blockScroll) {
-                unblockBodyScroll();
+                unblockBodyScroll(this.$primevue.styled.$dt);
             }
         },
         onKeydown(event) {
@@ -212,7 +212,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.isOutsideClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.isOutsideClicked(target)) {
                         this.hide();
                     }
                 };
@@ -226,8 +227,8 @@ export default {
                 this.outsideClickListener = null;
             }
         },
-        isOutsideClicked(event) {
-            return this.container && !this.container.contains(event.target);
+        isOutsideClicked(target) {
+            return this.container && !this.container.contains(target);
         }
     },
     computed: {

--- a/packages/primevue/src/galleria/Galleria.vue
+++ b/packages/primevue/src/galleria/Galleria.vue
@@ -39,7 +39,7 @@ export default {
     },
     beforeUnmount() {
         if (this.fullScreen) {
-            unblockBodyScroll();
+            unblockBodyScroll(this.$primevue.styled.$dt);
         }
 
         this.mask = null;
@@ -56,7 +56,7 @@ export default {
         onEnter(el) {
             this.target = document.activeElement;
             this.mask.style.zIndex = String(parseInt(el.style.zIndex, 10) - 1);
-            blockBodyScroll();
+            blockBodyScroll(this.$primevue.styled.$dt);
             this.focus();
             this.bindGlobalListeners();
         },
@@ -70,7 +70,7 @@ export default {
         onAfterLeave(el) {
             ZIndex.clear(el);
             this.containerVisible = false;
-            unblockBodyScroll();
+            unblockBodyScroll(this.$primevue.styled.$dt);
             this.unbindGlobalListeners();
         },
         onActiveItemChange(index) {

--- a/packages/primevue/src/image/Image.vue
+++ b/packages/primevue/src/image/Image.vue
@@ -97,7 +97,7 @@ export default {
         },
         onImageClick() {
             if (this.preview) {
-                blockBodyScroll();
+                blockBodyScroll(this.$primevue.styled.$dt);
                 this.maskVisible = true;
                 setTimeout(() => {
                     this.previewVisible = true;
@@ -163,7 +163,7 @@ export default {
             !this.isUnstyled && addClass(this.mask, 'p-overlay-mask-leave');
         },
         onLeave() {
-            unblockBodyScroll();
+            unblockBodyScroll(this.$primevue.styled.$dt);
             this.$emit('hide');
         },
         onAfterLeave(el) {
@@ -181,7 +181,7 @@ export default {
             this.previewVisible = false;
             this.rotate = 0;
             this.scale = 1;
-            unblockBodyScroll();
+            unblockBodyScroll(this.$primevue.styled.$dt);
         }
     },
     computed: {

--- a/packages/primevue/src/imagecompare/ImageCompare.vue
+++ b/packages/primevue/src/imagecompare/ImageCompare.vue
@@ -7,7 +7,6 @@
 </template>
 
 <script>
-import { $dt } from '@primeuix/styled';
 import { setCSSProperty } from '@primeuix/utils/dom';
 import BaseImageCompare from './BaseImageCompare.vue';
 
@@ -19,7 +18,7 @@ export default {
             const value = event.target.value;
             const image = event.target.previousElementSibling;
 
-            setCSSProperty(image, $dt('imagecompare.scope.x').name, `${value}%`);
+            setCSSProperty(image, this.$primevue.styled.$dt('imagecompare.scope.x').name, `${value}%`);
         }
     }
 };

--- a/packages/primevue/src/knob/BaseKnob.vue
+++ b/packages/primevue/src/knob/BaseKnob.vue
@@ -1,5 +1,5 @@
 <script>
-import { $dt } from '@primeuix/styled';
+import { usePrimeVue } from '@primevue/core';
 import BaseEditableHolder from '@primevue/core/baseeditableholder';
 import KnobStyle from 'primevue/knob/style';
 
@@ -30,19 +30,19 @@ export default {
         valueColor: {
             type: String,
             default: () => {
-                return $dt('knob.value.background').variable;
+                return usePrimeVue().styled.$dt('knob.value.background').variable;
             }
         },
         rangeColor: {
             type: String,
             default: () => {
-                return $dt('knob.range.background').variable;
+                return usePrimeVue().styled.$dt('knob.range.background').variable;
             }
         },
         textColor: {
             type: String,
             default: () => {
-                return $dt('knob.text.color').variable;
+                return usePrimeVue().styled.$dt('knob.text.color').variable;
             }
         },
         strokeWidth: {

--- a/packages/primevue/src/megamenu/MegaMenu.vue
+++ b/packages/primevue/src/megamenu/MegaMenu.vue
@@ -455,8 +455,9 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const isOutsideContainer = this.container && !this.container.contains(event.target);
-                    const isOutsideTarget = !(this.target && (this.target === event.target || this.target.contains(event.target)));
+                    const target = event.composedPath()[0];
+                    const isOutsideContainer = this.container && !this.container.contains(target);
+                    const isOutsideTarget = !(this.target && (this.target === target || this.target.contains(target)));
 
                     if (isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/primevue/src/menu/Menu.vue
+++ b/packages/primevue/src/menu/Menu.vue
@@ -298,8 +298,9 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const isOutsideContainer = this.container && !this.container.contains(event.target);
-                    const isOutsideTarget = !(this.target && (this.target === event.target || this.target.contains(event.target)));
+                    const target = event.composedPath()[0];
+                    const isOutsideContainer = this.container && !this.container.contains(target);
+                    const isOutsideTarget = !(this.target && (this.target === target || this.target.contains(target)));
 
                     if (this.overlayVisible && isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/primevue/src/menubar/Menubar.vue
+++ b/packages/primevue/src/menubar/Menubar.vue
@@ -443,8 +443,9 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const isOutsideContainer = this.container && !this.container.contains(event.target);
-                    const isOutsideTarget = !(this.target && (this.target === event.target || this.target.contains(event.target)));
+                    const target = event.composedPath()[0];
+                    const isOutsideContainer = this.container && !this.container.contains(target);
+                    const isOutsideTarget = !(this.target && (this.target === target || this.target.contains(target)));
 
                     if (isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -773,7 +773,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.isOutsideClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.isOutsideClicked(target)) {
                         this.hide();
                     }
                 };
@@ -820,8 +821,8 @@ export default {
                 this.resizeListener = null;
             }
         },
-        isOutsideClicked(event) {
-            return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)));
+        isOutsideClicked(target) {
+            return !(this.$el.isSameNode(target) || this.$el.contains(target) || (this.overlay && this.overlay.contains(target)));
         },
         getLabelByValue(value) {
             const options = this.optionGroupLabel ? this.flatOptions(this.options) : this.options || [];

--- a/packages/primevue/src/popover/Popover.vue
+++ b/packages/primevue/src/popover/Popover.vue
@@ -14,7 +14,6 @@
 </template>
 
 <script>
-import { $dt } from '@primeuix/styled';
 import { absolutePosition, addClass, addStyle, focus, getOffset, isClient, isTouchDevice, setAttribute } from '@primeuix/utils/dom';
 import { ZIndex } from '@primeuix/utils/zindex';
 import { ConnectedOverlayScrollHandler } from '@primevue/core/utils';
@@ -156,7 +155,7 @@ export default {
                 arrowLeft = targetOffset.left - containerOffset.left;
             }
 
-            this.container.style.setProperty($dt('popover.arrow.left').name, `${arrowLeft}px`);
+            this.container.style.setProperty(this.$primevue.styled.$dt('popover.arrow.left').name, `${arrowLeft}px`);
 
             if (containerOffset.top < targetOffset.top) {
                 this.container.setAttribute('data-p-popover-flipped', 'true');
@@ -208,7 +207,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener && isClient()) {
                 this.outsideClickListener = (event) => {
-                    if (this.visible && !this.selfClick && !this.isTargetClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.visible && !this.selfClick && !this.isTargetClicked(target)) {
                         this.visible = false;
                     }
 
@@ -258,8 +258,8 @@ export default {
                 this.resizeListener = null;
             }
         },
-        isTargetClicked(event) {
-            return this.eventTarget && (this.eventTarget === event.target || this.eventTarget.contains(event.target));
+        isTargetClicked(target) {
+            return this.eventTarget && (this.eventTarget === target || this.eventTarget.contains(target));
         },
         containerRef(el) {
             this.container = el;

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -757,8 +757,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const composedPath = event.composedPath();
-                    if (this.overlayVisible && this.overlay && !composedPath.includes(this.$el) && !composedPath.includes(this.overlay)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && this.overlay && !this.$el.contains(target) && !this.overlay.contains(target)) {
                         this.hide();
                     }
                 };

--- a/packages/primevue/src/speeddial/SpeedDial.vue
+++ b/packages/primevue/src/speeddial/SpeedDial.vue
@@ -65,7 +65,6 @@
 </template>
 
 <script>
-import { $dt } from '@primeuix/styled';
 import { find, findSingle, focus, hasClass } from '@primeuix/utils/dom';
 import PlusIcon from '@primevue/icons/plus';
 import Button from 'primevue/button';
@@ -106,8 +105,8 @@ export default {
                 const wDiff = Math.abs(button.offsetWidth - firstItem.offsetWidth);
                 const hDiff = Math.abs(button.offsetHeight - firstItem.offsetHeight);
 
-                this.list.style.setProperty($dt('item.diff.x').name, `${wDiff / 2}px`);
-                this.list.style.setProperty($dt('item.diff.y').name, `${hDiff / 2}px`);
+                this.list.style.setProperty(this.$primevue.styled.$dt('item.diff.x').name, `${wDiff / 2}px`);
+                this.list.style.setProperty(this.$primevue.styled.$dt('item.diff.y').name, `${hDiff / 2}px`);
             }
         }
 
@@ -363,14 +362,14 @@ export default {
                     const step = (2 * Math_PI) / length;
 
                     return {
-                        left: `calc(${radius * Math.cos(step * index)}px + ${$dt('item.diff.x', '0px').variable})`,
-                        top: `calc(${radius * Math.sin(step * index)}px + ${$dt('item.diff.y', '0px').variable})`
+                        left: `calc(${radius * Math.cos(step * index)}px + ${this.$primevue.styled.$dt('item.diff.x', '0px').variable})`,
+                        top: `calc(${radius * Math.sin(step * index)}px + ${this.$primevue.styled.$dt('item.diff.y', '0px').variable})`
                     };
                 } else if (type === 'semi-circle') {
                     const direction = this.direction;
                     const step = Math_PI / (length - 1);
-                    const x = `calc(${radius * Math.cos(step * index)}px + ${$dt('item.diff.x', '0px').variable})`;
-                    const y = `calc(${radius * Math.sin(step * index)}px + ${$dt('item.diff.y', '0px').variable})`;
+                    const x = `calc(${radius * Math.cos(step * index)}px + ${this.$primevue.styled.$dt('item.diff.x', '0px').variable})`;
+                    const y = `calc(${radius * Math.sin(step * index)}px + ${this.$primevue.styled.$dt('item.diff.y', '0px').variable})`;
 
                     if (direction === 'up') {
                         return { left: x, bottom: y };
@@ -384,8 +383,8 @@ export default {
                 } else if (type === 'quarter-circle') {
                     const direction = this.direction;
                     const step = Math_PI / (2 * (length - 1));
-                    const x = `calc(${radius * Math.cos(step * index)}px + ${$dt('item.diff.x', '0px').variable})`;
-                    const y = `calc(${radius * Math.sin(step * index)}px + ${$dt('item.diff.y', '0px').variable})`;
+                    const x = `calc(${radius * Math.cos(step * index)}px + ${this.$primevue.styled.$dt('item.diff.x', '0px').variable})`;
+                    const y = `calc(${radius * Math.sin(step * index)}px + ${this.$primevue.styled.$dt('item.diff.y', '0px').variable})`;
 
                     if (direction === 'up-left') {
                         return { right: x, bottom: y };

--- a/packages/primevue/src/tieredmenu/TieredMenu.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenu.vue
@@ -455,8 +455,9 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    const isOutsideContainer = this.container && !this.container.contains(event.target);
-                    const isOutsideTarget = this.popup ? !(this.target && (this.target === event.target || this.target.contains(event.target))) : true;
+                    const target = event.composedPath()[0];
+                    const isOutsideContainer = this.container && !this.container.contains(target);
+                    const isOutsideTarget = this.popup ? !(this.target && (this.target === target || this.target.contains(target))) : true;
 
                     if (isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -384,7 +384,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(event)) {
+                    const target = event.composedPath()[0];
+                    if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(target)) {
                         this.hide();
                     }
 
@@ -433,8 +434,8 @@ export default {
                 this.resizeListener = null;
             }
         },
-        isOutsideClicked(event) {
-            return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)));
+        isOutsideClicked(target) {
+            return !(this.$el.isSameNode(target) || this.$el.contains(target) || (this.overlay && this.overlay.contains(target)));
         },
         overlayRef(el) {
             this.overlay = el;

--- a/packages/primevue/src/utils/Utils.d.ts
+++ b/packages/primevue/src/utils/Utils.d.ts
@@ -5,5 +5,7 @@
  * @module utils
  *
  */
-export declare function blockBodyScroll(): void;
-export declare function unblockBodyScroll(): void;
+import { $dt as $dtSingleton } from '@primeuix/styled';
+
+export declare function blockBodyScroll($dt: typeof $dtSingleton): void;
+export declare function unblockBodyScroll($dt: typeof $dtSingleton): void;

--- a/packages/primevue/src/utils/Utils.js
+++ b/packages/primevue/src/utils/Utils.js
@@ -1,10 +1,9 @@
-import { $dt } from '@primeuix/styled';
 import * as utils from '@primeuix/utils';
 
-export function blockBodyScroll() {
+export function blockBodyScroll($dt) {
     utils.blockBodyScroll({ variableName: $dt('scrollbar.width').name });
 }
 
-export function unblockBodyScroll() {
+export function unblockBodyScroll($dt) {
     utils.unblockBodyScroll({ variableName: $dt('scrollbar.width').name });
 }

--- a/packages/primevue/src/virtualscroller/BaseVirtualScroller.vue
+++ b/packages/primevue/src/virtualscroller/BaseVirtualScroller.vue
@@ -95,7 +95,7 @@ export default {
         };
     },
     beforeMount() {
-        VirtualScrollerStyle.loadCSS({ nonce: this.$primevueConfig?.csp?.nonce });
+        VirtualScrollerStyle.loadCSS({ nonce: this.$primevueConfig?.csp?.nonce, prefix: this.$primevueConfig?.prefix, root: this.$primevue.root });
     }
 };
 </script>


### PR DESCRIPTION
Hi, I am a developer representing Cambridge University Press & Assessment (https://www.cambridge.org/). A couple of weeks ago, we contacted you about the lack of support of for custom elements in PrimeVue, that is required for us to switch to PrimeVue as a main front end framework for our products. We offered to help with implementation of this support. This MR is implementing such support, hopefully you will find it useful. Changes were tested in our products and were working properly. Please note, that there is a visible interest in the community about the PrimeVue support for custom elements.

Summary of the changes:
- Base, BaseStyle and PrimeVueService instances keeping current state of the styling from now on can be both global and scoped. With the global approach, multiple instances of the same custom element were not loading style tags properly.
- All places using global versions of the services were switched to use instances provided by the PrimeVue in globalProperties. Depending on whether we are in shadowRoot=true mode or not, the setup function in PrimeVue is providing global or scoped instances of those services.
- New prefix property was added to PrimeVue properties to avoid conflicts in shadowRoot=false mode.
- New wrapCustomElement function, that is hacking around a lack of root property in app instance provided by Vue, since root property is required in the PrimeVue itself in different places. Most probably such change will have to be requested in Vue project to avoid this hack, but for now it's the only way of implementing it.
- UseStyle function was changed to take into consideration, that the PrimeVue may be loaded in custom element.
- Some changes were introduced to nuxt-module to allow usage of a new prefix property.
- Fixed outsideClickListener implementation in multiple components to take into consideration Shadow DOM.
- Other smaller changes, like switching to transformCSS function and adding a prefix to data-primevue-style-id values to avoid conflicts on style tag level for shadowRoot=false mode.

Please note, that those changes depend on changes introduced in MR for PrimeUix repository.

In case of any questions, please let me know, thanks.