### PR TITLE
fix(DataTable): #7335

### DIFF
--- a/packages/primevue/src/datatable/BodyRow.vue
+++ b/packages/primevue/src/datatable/BodyRow.vue
@@ -349,6 +349,8 @@ export default {
                 const currentRowFieldData = resolveFieldData(this.value[index], field);
                 let nextRowFieldData = currentRowFieldData;
                 let groupRowSpan = 0;
+                
+                if(this.d_rowExpanded) groupRowSpan++;
 
                 while (currentRowFieldData === nextRowFieldData) {
                     groupRowSpan++;
@@ -356,6 +358,12 @@ export default {
 
                     if (nextRowData) {
                         nextRowFieldData = resolveFieldData(nextRowData, field);
+
+                        if(currentRowFieldData === nextRowFieldData){
+                            const nextRowKeyData = resolveFieldData(nextRowData, this.dataKey);
+                            const isNextRowExpanded = resolveFieldData(this.expandedRows, nextRowKeyData) || this.expandedRows?.some?.((d) => this.equals(nextRowData, d)) 
+                            if(isNextRowExpanded) groupRowSpan++;
+                        }
                     } else {
                         break;
                     }


### PR DESCRIPTION
When `groupRowsBy` is set to `rowspan` and row expansion is enabled, the last rows in a group would shift left. This was caused by the hidden columns defined in `groupRowsBy`. The issue became more noticeable as more rows were expanded. This fix ensures consistent table layout regardless of row expansion.
