### PR TITLE
fix: add resize observer on VirtualScroller component

### DIFF
--- a/packages/primevue/src/virtualscroller/VirtualScroller.vue
+++ b/packages/primevue/src/virtualscroller/VirtualScroller.vue
@@ -81,6 +81,7 @@ export default {
     isRangeChanged: false,
     lazyLoadState: {},
     resizeListener: null,
+    resizeObserver: null,
     initialized: false,
     watch: {
         numToleratedItems(newValue) {
@@ -117,6 +118,7 @@ export default {
         }
     },
     mounted() {
+        this.bindResizeListener();
         this.viewInit();
 
         this.lastScrollPos = this.isBoth() ? { top: 0, left: 0 } : 0;
@@ -136,7 +138,6 @@ export default {
                 this.setContentEl(this.content);
                 this.init();
                 this.calculateAutoSize();
-                this.bindResizeListener();
 
                 this.defaultWidth = getWidth(this.element);
                 this.defaultHeight = getHeight(this.element);
@@ -588,6 +589,11 @@ export default {
 
                 window.addEventListener('resize', this.resizeListener);
                 window.addEventListener('orientationchange', this.resizeListener);
+
+                this.resizeObserver = new ResizeObserver(() => {
+                    this.onResize();
+                });
+                this.resizeObserver.observe(this.element);
             }
         },
         unbindResizeListener() {
@@ -595,6 +601,11 @@ export default {
                 window.removeEventListener('resize', this.resizeListener);
                 window.removeEventListener('orientationchange', this.resizeListener);
                 this.resizeListener = null;
+            }
+
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
             }
         },
         getOptions(renderedIndex) {


### PR DESCRIPTION
### Defect Fixes
Fix for this issue: https://github.com/primefaces/primevue/issues/7354

### Notes
Since the VirtualScroller is not rendering the list on resize and on visibility change, I was thinking adding both a ResizeObserver and an IntersectionObserver. For the visibility, it seems counter intuitive to me adding an IntersectionObserver inside a Vue component. I think we could make a better usage of Vue `onMounted` hook.  
For now, I've added only a ResizeObserver that fixes the issue for both, resizing and conditional rendering (a v-show will necessarily trigger a resizing of the element).
 
