### PR TITLE
make allowEmpty compatible with multiple on SelectButton

### DIFF
--- a/packages/primevue/src/selectbutton/SelectButton.vue
+++ b/packages/primevue/src/selectbutton/SelectButton.vue
@@ -8,7 +8,7 @@
                 :disabled="disabled || isOptionDisabled(option)"
                 :unstyled="unstyled"
                 :size="size"
-                :readonly="!allowEmpty && isSelected(option)"
+                :readonly="isOptionReadonly(option)"
                 @change="onOptionSelect($event, option, index)"
                 :pt="ptm('pcToggleButton')"
             >
@@ -46,24 +46,34 @@ export default {
         isOptionDisabled(option) {
             return this.optionDisabled ? resolveFieldData(option, this.optionDisabled) : false;
         },
+        isOptionReadonly(option) {
+            if (this.allowEmpty) return false;
+
+            let selected = this.isSelected(option);
+
+            if (this.multiple) {
+                return selected && this.d_value.length === 1;
+            } else {
+                return selected;
+            }
+        },
         onOptionSelect(event, option, index) {
-            if (this.disabled || this.isOptionDisabled(option)) {
+            if (this.disabled || this.isOptionDisabled(option) || this.isOptionReadonly(option)) {
                 return;
             }
 
             let selected = this.isSelected(option);
 
-            if (selected && !this.allowEmpty) {
-                return;
-            }
-
             let optionValue = this.getOptionValue(option);
             let newValue;
 
             if (this.multiple) {
-                if (selected) newValue = this.d_value.filter((val) => !equals(val, optionValue, this.equalityKey));
-                else newValue = this.d_value ? [...this.d_value, optionValue] : [optionValue];
+                if (selected) {
+                    newValue = this.d_value.filter((val) => !equals(val, optionValue, this.equalityKey));
+                    if (!this.allowEmpty && newValue.length === 0) return;
+                } else newValue = this.d_value ? [...this.d_value, optionValue] : [optionValue];
             } else {
+                if (selected && !this.allowEmpty) return;
                 newValue = selected ? null : optionValue;
             }
 


### PR DESCRIPTION
Makes the allowEmpty=false prop have different logic when the multiple prop is true. Prevents you from having an empty list 

[Issue#7358](https://github.com/primefaces/primevue/issues/7358)

