### PR TITLE
fix: tablist prev/next button type

### DIFF
--- a/packages/primevue/src/tablist/TabList.vue
+++ b/packages/primevue/src/tablist/TabList.vue
@@ -3,6 +3,7 @@
         <button
             v-if="showNavigators && isPrevButtonEnabled"
             ref="prevButton"
+            type="button"
             v-ripple
             :class="cx('prevButton')"
             :aria-label="prevButtonAriaLabel"
@@ -14,14 +15,17 @@
             <component :is="templates.previcon || 'ChevronLeftIcon'" aria-hidden="true" v-bind="ptm('prevIcon')" />
         </button>
         <div ref="content" :class="cx('content')" @scroll="onScroll" v-bind="ptm('content')">
-            <div ref="tabs" :class="cx('tabList')" role="tablist" :aria-orientation="$pcTabs.orientation || 'horizontal'" v-bind="ptm('tabList')">
+            <div ref="tabs" :class="cx('tabList')" role="tablist"
+                 :aria-orientation="$pcTabs.orientation || 'horizontal'" v-bind="ptm('tabList')">
                 <slot></slot>
-                <span ref="inkbar" :class="cx('activeBar')" role="presentation" aria-hidden="true" v-bind="ptm('activeBar')"></span>
+                <span ref="inkbar" :class="cx('activeBar')" role="presentation" aria-hidden="true"
+                      v-bind="ptm('activeBar')"></span>
             </div>
         </div>
         <button
             v-if="showNavigators && isNextButtonEnabled"
             ref="nextButton"
+            type="button"
             v-ripple
             :class="cx('nextButton')"
             :aria-label="nextButtonAriaLabel"


### PR DESCRIPTION
Adds type="button" to the prev/next buttons in a tab list so that when used in a form these buttons do not submit the form
