### PR TITLE
fix: Select cannot update(clicking) in Datatable(celledit mode) #7403

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -140,7 +140,7 @@
                                             :aria-disabled="isOptionDisabled(option)"
                                             :aria-setsize="ariaSetSize"
                                             :aria-posinset="getAriaPosInset(getOptionIndex(i, getItemOptions))"
-                                            @click="onOptionSelect($event, option)"
+                                            @mousedown="onOptionSelect($event, option)"
                                             @mousemove="onOptionMouseMove($event, getOptionIndex(i, getItemOptions))"
                                             :data-p-selected="isSelected(option)"
                                             :data-p-focused="focusedOptionIndex === getOptionIndex(i, getItemOptions)"


### PR DESCRIPTION
###Defect Fixes
Fixed the issue that select cannot update value by clicking in datatable celledit mode

###Feature Requests
Replace @click with @mousedown
Resolves: https://github.com/primefaces/primevue/issues/7403
