### PR TITLE
DataTable: Check filter operator during matchMode assignment

### DIFF
--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -474,7 +474,11 @@ export default {
         onMenuMatchModeChange(value, index) {
             let _filters = { ...this.filters };
 
-            _filters[this.field].constraints[index].matchMode = value;
+            if (_filters[this.field].operator) {
+                _filters[this.field].constraints[index].matchMode = value;
+            } else {
+                _filters[this.field].matchMode = value;
+            }
             this.$emit('matchmode-change', { field: this.field, matchMode: value, index: index });
 
             if (!this.showApplyButton) {


### PR DESCRIPTION
`_filters[this.field]` can potentially not have the `"operator"` and `"constraints"` keys in which case the filter is treated as a single constraint without any operator.

However `onMenuMatchModeChange` always expected the full `"operator"` and `"constraints"` definition.

Decide whether to set the `matchMode` to a certain constraint or directly on the filter by checking for presence of the `"operator"` value.

Resolves https://github.com/primefaces/primevue/issues/7019 (properly), specifically the issue mentioned in https://github.com/primefaces/primevue/issues/7019#issuecomment-2711705862

**Disclaimer: I have not tested this change at all since I don't have the project set up.**

After this change, changing the `matchMode` with a filter defined without operator and constraints should not cause any issues. (see linked issue)