### PR TITLE
test(primevue): fix the failure about the `maximizable` of the `Dialog` component

### DIFF
--- a/packages/primevue/src/dialog/Dialog.spec.js
+++ b/packages/primevue/src/dialog/Dialog.spec.js
@@ -111,11 +111,13 @@ describe('maximizable', () => {
         await wrapper.setProps({ visible: true });
         await wrapper.setData({ maximized: false });
 
-        const icon = wrapper.find('.p-dialog-maximize-button .p-button-icon');
+        let icon = wrapper.find('.p-dialog-maximize-button .p-button-icon');
 
         expect(icon.classes()).toContain('pi-discord');
 
         await wrapper.setData({ maximized: true });
+
+        icon = wrapper.find('.p-dialog-maximize-button .p-button-icon');
 
         expect(icon.classes()).toContain('pi-facebook');
     });


### PR DESCRIPTION
Fix #7437 


Pr checker will fail due to another reason, please refer to https://github.com/primefaces/primevue/pull/7436.

It due to the `packages\nuxt-module\README.md` has some contents annotated under a list item, I've fixed it in that PR.
