### PR TITLE
Fixed "multiple select" checkbox wrong listener in TableHeader

### DIFF
--- a/packages/primevue/src/datatable/TableHeader.vue
+++ b/packages/primevue/src/datatable/TableHeader.vue
@@ -97,7 +97,7 @@
                     @constraint-add="$emit('constraint-add', $event)"
                     @constraint-remove="$emit('constraint-remove', $event)"
                     @apply-click="$emit('apply-click', $event)"
-                    @change="$emit('checkbox-change', $event)"
+                    @checkbox-change="$emit('checkbox-change', $event)"
                     :unstyled="unstyled"
                     :pt="pt"
                 />


### PR DESCRIPTION
**Issue**: `TableHeader.vue` was listening for `@change` from `FilterHeaderCell.vue`, but `FilterHeaderCell.vue` actually emits `checkbox-change`.

**Problem**: Since `TableHeader.vue` was expecting the wrong event, this was causing the event object arriving with undefined values, causing checkboxes to only unselect but never select.

**Fix**: This PR updates `TableHeader.vue` to listen for `checkbox-change`, ensuring checkboxes work correctly.

**Resolves**: [#7409](https://github.com/primefaces/primevue/issues/7409)