### PR TITLE
Fix paginator container slot props in DataTable component

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -27,7 +27,7 @@
             :unstyled="unstyled"
             :pt="ptm('pcPaginator')"
         >
-            <template v-if="$slots.paginatorcontainer" #container>
+            <template v-if="$slots.paginatorcontainer" #container="slotProps">
                 <slot
                     name="paginatorcontainer"
                     :first="slotProps.first"


### PR DESCRIPTION
## Issue description
In the PrimeVue DataTable component, the top paginator's container template is missing the slotProps parameter. This causes a JavaScript error when users implement a custom paginatorcontainer slot because slotProps is referenced but not defined.

## Solution
Add `="slotProps"` to the template definition for the container slot in both paginators to ensure consistent behavior and prevent errors when using custom paginator container templates.

## Changes made
Updated the template definition in the top paginator:

The bottom paginator already had the correct implementation: `#container="slotProps"`. This PR ensures both instances capture the slot props consistently.