### PR TITLE
Add contentProps option for DynamicDialog

### DIFF
--- a/packages/primevue/src/dynamicdialog/DynamicDialog.vue
+++ b/packages/primevue/src/dynamicdialog/DynamicDialog.vue
@@ -2,11 +2,11 @@
     <template v-for="(instance, key) in instanceMap" :key="key">
         <DDialog v-model:visible="instance.visible" :_instance="instance" v-bind="instance.options.props" @hide="onDialogHide(instance)" @after-hide="onDialogAfterHide(instance)">
             <template v-if="instance.options.templates && instance.options.templates.header" #header>
-                <component v-for="(header, index) in getTemplateItems(instance.options.templates.header)" :is="header" :key="index + '_header'" v-on="instance.options.emits"></component>
+                <component v-for="(header, index) in getTemplateItems(instance.options.templates.header)" :is="header" :key="index + '_header'" v-on="instance.options.emits" v-bind="instance.options.contentProps"></component>
             </template>
-            <component :is="instance.content" v-on="instance.options.emits"></component>
+            <component :is="instance.content" v-on="instance.options.emits" v-bind="instance.options.contentProps"></component>
             <template v-if="instance.options.templates && instance.options.templates.footer" #footer>
-                <component v-for="(footer, index) in getTemplateItems(instance.options.templates.footer)" :is="footer" :key="index + '_footer'" v-on="instance.options.emits"></component>
+                <component v-for="(footer, index) in getTemplateItems(instance.options.templates.footer)" :is="footer" :key="index + '_footer'" v-on="instance.options.emits" v-bind="instance.options.contentProps"></component>
             </template>
         </DDialog>
     </template>


### PR DESCRIPTION
This PR adds the ability to pass props directly to DynamicDialog content via the contentProps option. This makes it possible to use components in DynamicDialog without modifying them to use injection.

## Changes
- Added support for instance.options.contentProps to be bound to DynamicDialog content
- Applied the same bindings to header and footer template components for consistency

## Why
Before #7429, props could be passed using `emits` option.
Currently, to pass data to a component rendered in DynamicDialog, the component needs to be explicitly modified to use injection, creating tight coupling between components and the DynamicDialog system.

This change allows any existing component to be used within DynamicDialog without modification, eliminating Vue warnings about missing required props and reducing coupling between components and DynamicDialog.

## Example usage
```js
dialog.open(MyComponent, {
  props: {
    // Dialog props
    header: 'Dialog Title',
    modal: true
  },
  contentProps: {
    // Props passed to MyComponent
    data: myData,
  }
});
```
Related [discussion](https://github.com/orgs/primefaces/discussions/3621) and issue https://github.com/primefaces/primevue/issues/5808