### PR TITLE
Fix regression inserted by #7291 on ColorPicker

### DIFF
--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -567,8 +567,6 @@ export default {
             this.colorHandle = null;
             this.hueView = null;
             this.hueHandle = null;
-            // this.localHue = null;
-            // console.log('CLEAR refs', this.localHue);
         },
         onOverlayClick(event) {
             OverlayEventBus.emit('overlay-click', {

--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -343,7 +343,7 @@ export default {
                 hsb = this.HEXtoHSB(this.defaultColor);
             }
 
-            if (this.localHue == null) {
+            if (this.localHue == null || !this.overlayVisible) {
                 this.localHue = hsb.h;
             } else {
                 hsb.h = this.localHue;
@@ -567,6 +567,8 @@ export default {
             this.colorHandle = null;
             this.hueView = null;
             this.hueHandle = null;
+            // this.localHue = null;
+            // console.log('CLEAR refs', this.localHue);
         },
         onOverlayClick(event) {
             OverlayEventBus.emit('overlay-click', {


### PR DESCRIPTION
Closes #7503
This PR resolves the regression added by #7291.

To test the proposed solution, add an input that will modify the color from outside the ColorPicker component.

```js
// apps/showcase/doc/colorpicker/BasicDoc.vue
<input type="text" v-model="color" />
```