### PR TITLE
doc: fix TWMergeDoc section input going out of card

### DIFF
--- a/apps/volt/doc/overview/TWMergeDoc.vue
+++ b/apps/volt/doc/overview/TWMergeDoc.vue
@@ -26,7 +26,7 @@ import { ref } from 'vue';
 
 const code = ref(`
 <template>
-   <div class="card flex justify-center gap-4">
+   <div class="card grid grid-cols-2 gap-4">
         <InputText class="bg-primary text-primary-contrast" value="Fails" />
         <InputText pt:root:class="bg-primary text-primary-contrast" value="Works" />
     </div>

--- a/apps/volt/doc/overview/TWMergeDoc.vue
+++ b/apps/volt/doc/overview/TWMergeDoc.vue
@@ -13,7 +13,7 @@
             <i>pt:root:class</i> attribute in the second case will merge the custom classes with the default classes perfectly.
         </p>
     </DocSectionText>
-    <div class="card flex justify-center gap-4">
+    <div class="card grid grid-cols-2 gap-4">
         <InputText class="bg-primary text-primary-contrast" value="Fails" />
         <InputText pt:root:class="bg-primary text-primary-contrast" value="Works" />
     </div>


### PR DESCRIPTION
This PR fixes UI issues on mobile inside 'overview' route, in this section of tw-merge section where inputs go outside of the box on Mobile

before
![image](https://github.com/user-attachments/assets/796c08a9-d812-49bb-9af9-354bf3f0d0f1)

After
![image](https://github.com/user-attachments/assets/02ed39f8-1ab0-4950-8a24-9701e69b7a58)
