### PR TITLE
fix(inputmask): fix the wrong default value the `mask` prop

### DIFF
--- a/packages/primevue/src/inputmask/BaseInputMask.vue
+++ b/packages/primevue/src/inputmask/BaseInputMask.vue
@@ -20,7 +20,7 @@ export default {
         },
         mask: {
             type: String,
-            default: null
+            default: ''
         },
         placeholder: {
             type: String,


### PR DESCRIPTION
### Defect Fixes
Fix #7539 

Rather than changing the related `d.ts` file to mark the `mask` prop as `required`,

I think it's bettter to set the default value of the `mask` prop as an empty string.
