### PR TITLE
fix(select): fix the issue that cannot hide the overlay when `appendTo` equals `self`

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -144,6 +144,7 @@
                                             :aria-posinset="getAriaPosInset(getOptionIndex(i, getItemOptions))"
                                             @mousedown="onOptionSelect($event, option)"
                                             @mousemove="onOptionMouseMove($event, getOptionIndex(i, getItemOptions))"
+                                            @click.stop
                                             :data-p-selected="!checkmark && isSelected(option)"
                                             :data-p-focused="focusedOptionIndex === getOptionIndex(i, getItemOptions)"
                                             :data-p-disabled="isOptionDisabled(option)"


### PR DESCRIPTION
### Defect Fixes
Fix #7526 

At beginning, I want to change the `@mousedown` to `@click`, I found that here do exists a pr #7404  about it, so:

Use the `@click.stop` to stop the click event propagation to not to trigger the click event of the `.container` - `onContainerClick`
