### PR TITLE
fix(docs): correct formatting for auto-import config example

### DIFF
--- a/apps/showcase/doc/autoimport/UnpluginDoc.vue
+++ b/apps/showcase/doc/autoimport/UnpluginDoc.vue
@@ -40,7 +40,8 @@ export default defineConfig({
       resolvers: [
         PrimeVueResolver()
       ]
-    })]
+    })
+  ]
 })
 `
             },


### PR DESCRIPTION
### Description
This fixes the code formatting in the UnPluginDoc.vue auto-import config example to improve readability. The previous formatting had an extra closing bracket that was misaligned, which could confuse users copying the example.

