### PR TITLE
Volt - Use slot naming shorthand to avoid eslint warnings

### DIFF
--- a/apps/volt/volt/AutoComplete.vue
+++ b/apps/volt/volt/AutoComplete.vue
@@ -9,7 +9,7 @@
         <template #dropdownicon>
             <ChevronDownIcon />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </AutoComplete>

--- a/apps/volt/volt/Avatar.vue
+++ b/apps/volt/volt/Avatar.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Avatar>

--- a/apps/volt/volt/AvatarGroup.vue
+++ b/apps/volt/volt/AvatarGroup.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </AvatarGroup>

--- a/apps/volt/volt/Badge.vue
+++ b/apps/volt/volt/Badge.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Badge>

--- a/apps/volt/volt/Breadcrumb.vue
+++ b/apps/volt/volt/Breadcrumb.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Breadcrumb>

--- a/apps/volt/volt/Button.vue
+++ b/apps/volt/volt/Button.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Button>

--- a/apps/volt/volt/ButtonGroup.vue
+++ b/apps/volt/volt/ButtonGroup.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </ButtonGroup>

--- a/apps/volt/volt/Card.vue
+++ b/apps/volt/volt/Card.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Card>

--- a/apps/volt/volt/Chip.vue
+++ b/apps/volt/volt/Chip.vue
@@ -13,7 +13,7 @@
                 @keydown="keydownCallback"
             />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Chip>

--- a/apps/volt/volt/ContrastButton.vue
+++ b/apps/volt/volt/ContrastButton.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Button>

--- a/apps/volt/volt/DangerButton.vue
+++ b/apps/volt/volt/DangerButton.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Button>

--- a/apps/volt/volt/DataTable.vue
+++ b/apps/volt/volt/DataTable.vue
@@ -39,7 +39,7 @@
         <template #loadingicon>
             <SpinnerIcon class="animate-spin text-[2rem] w-8 h-8" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </DataTable>

--- a/apps/volt/volt/DataView.vue
+++ b/apps/volt/volt/DataView.vue
@@ -35,7 +35,7 @@
                 </SecondaryButton>
             </div>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </DataView>

--- a/apps/volt/volt/DatePicker.vue
+++ b/apps/volt/volt/DatePicker.vue
@@ -88,7 +88,7 @@
                 </template>
             </SecondaryButton>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </DatePicker>

--- a/apps/volt/volt/Dialog.vue
+++ b/apps/volt/volt/Dialog.vue
@@ -21,7 +21,7 @@
                 </template>
             </SecondaryButton>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Dialog>

--- a/apps/volt/volt/Divider.vue
+++ b/apps/volt/volt/Divider.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Divider>

--- a/apps/volt/volt/Drawer.vue
+++ b/apps/volt/volt/Drawer.vue
@@ -13,7 +13,7 @@
                 </template>
             </SecondaryButton>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Drawer>

--- a/apps/volt/volt/Fieldset.vue
+++ b/apps/volt/volt/Fieldset.vue
@@ -10,7 +10,7 @@
             <PlusIcon v-if="collapsed" :class="theme.toggleIcon" />
             <MinusIcon v-else :class="theme.toggleIcon" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Fieldset>

--- a/apps/volt/volt/Inplace.vue
+++ b/apps/volt/volt/Inplace.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Inplace>

--- a/apps/volt/volt/InputNumber.vue
+++ b/apps/volt/volt/InputNumber.vue
@@ -12,7 +12,7 @@
         <template #decrementicon>
             <AngleDownIcon />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </InputNumber>

--- a/apps/volt/volt/InputOtp.vue
+++ b/apps/volt/volt/InputOtp.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </InputOtp>

--- a/apps/volt/volt/Listbox.vue
+++ b/apps/volt/volt/Listbox.vue
@@ -9,7 +9,7 @@
         <template #filtericon>
             <SearchIcon class="text-surface-400" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Listbox>

--- a/apps/volt/volt/Menu.vue
+++ b/apps/volt/volt/Menu.vue
@@ -7,7 +7,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Menu>

--- a/apps/volt/volt/Message.vue
+++ b/apps/volt/volt/Message.vue
@@ -9,7 +9,7 @@
         <template #closeicon>
             <TimesIcon />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Message>

--- a/apps/volt/volt/MeterGroup.vue
+++ b/apps/volt/volt/MeterGroup.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </MeterGroup>

--- a/apps/volt/volt/MultiSelect.vue
+++ b/apps/volt/volt/MultiSelect.vue
@@ -18,7 +18,7 @@
         <template #clearicon>
             <TimesIcon class="text-surface-400 absolute top-1/2 -mt-2 end-10" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </MultiSelect>

--- a/apps/volt/volt/Paginator.vue
+++ b/apps/volt/volt/Paginator.vue
@@ -35,7 +35,7 @@
                 </SecondaryButton>
             </div>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Paginator>

--- a/apps/volt/volt/Panel.vue
+++ b/apps/volt/volt/Panel.vue
@@ -14,7 +14,7 @@
                 </template>
             </SecondaryButton>
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Panel>

--- a/apps/volt/volt/Password.vue
+++ b/apps/volt/volt/Password.vue
@@ -12,7 +12,7 @@
         <template #unmaskicon="{ toggleCallback }">
             <EyeIcon @click="toggleCallback" class="end-3 text-surface-500 dark:text-surface-400 absolute top-1/2 -mt-2 w-4 h-4" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Password>

--- a/apps/volt/volt/Popover.vue
+++ b/apps/volt/volt/Popover.vue
@@ -7,7 +7,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Popover>

--- a/apps/volt/volt/ProgressBar.vue
+++ b/apps/volt/volt/ProgressBar.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </ProgressBar>

--- a/apps/volt/volt/Rating.vue
+++ b/apps/volt/volt/Rating.vue
@@ -12,7 +12,7 @@
         <template #officon="{ toggleCallback }">
             <StarIcon @click="toggleCallback" class="text-surface-500 dark:text-surface-400 text-base w-4 h-4 transition-colors duration-200" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Rating>

--- a/apps/volt/volt/SecondaryButton.vue
+++ b/apps/volt/volt/SecondaryButton.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Button>

--- a/apps/volt/volt/Select.vue
+++ b/apps/volt/volt/Select.vue
@@ -18,7 +18,7 @@
         <template #clearicon>
             <TimesIcon class="text-surface-400 absolute top-1/2 -mt-2 end-10" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Select>

--- a/apps/volt/volt/SelectButton.vue
+++ b/apps/volt/volt/SelectButton.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </SelectButton>

--- a/apps/volt/volt/Step.vue
+++ b/apps/volt/volt/Step.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Step>

--- a/apps/volt/volt/StepPanel.vue
+++ b/apps/volt/volt/StepPanel.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </StepPanel>

--- a/apps/volt/volt/Tag.vue
+++ b/apps/volt/volt/Tag.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Tag>

--- a/apps/volt/volt/Timeline.vue
+++ b/apps/volt/volt/Timeline.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Timeline>

--- a/apps/volt/volt/Toast.vue
+++ b/apps/volt/volt/Toast.vue
@@ -9,7 +9,7 @@
         <template #closeicon>
             <TimesIcon />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Toast>

--- a/apps/volt/volt/ToggleButton.vue
+++ b/apps/volt/volt/ToggleButton.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </ToggleButton>

--- a/apps/volt/volt/ToggleSwitch.vue
+++ b/apps/volt/volt/ToggleSwitch.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </ToggleSwitch>

--- a/apps/volt/volt/Toolbar.vue
+++ b/apps/volt/volt/Toolbar.vue
@@ -6,7 +6,7 @@
             mergeProps: ptViewMerge
         }"
     >
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Toolbar>

--- a/apps/volt/volt/Tree.vue
+++ b/apps/volt/volt/Tree.vue
@@ -13,7 +13,7 @@
         <template #filtericon>
             <SearchIcon class="text-surface-400" />
         </template>
-        <template v-for="(_, slotName) in $slots" v-slot:[slotName]="slotProps">
+        <template v-for="(_, slotName) in $slots" #[slotName]="slotProps">
             <slot :name="slotName" v-bind="slotProps ?? {}" />
         </template>
     </Tree>


### PR DESCRIPTION
I ran a basic find/replace within the `./apps/volt/volt` dir.
