### PR TITLE
fix(fileupload): fix the missing slot prop named `files` for the `filelabel` slot

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -75,8 +75,8 @@
                 </slot>
             </template>
         </Button>
-        <slot v-if="!auto" name="filelabel" :class="cx('filelabel')">
-            <span :class="cx('filelabel')" :files="files">
+        <slot v-if="!auto" name="filelabel" :class="cx('filelabel')" :files="files">
+            <span :class="cx('filelabel')">
                 {{ basicFileChosenLabel }}
             </span>
         </slot>


### PR DESCRIPTION
### Defect Fixes
Fix #7552
