### PR TITLE
feat: Add allRowsPerPageOption to display an All option inside rows per page dropdown

### DIFF
--- a/packages/primevue/src/datatable/BaseDataTable.vue
+++ b/packages/primevue/src/datatable/BaseDataTable.vue
@@ -300,7 +300,11 @@ export default {
                     cancel: { severity: 'secondary', text: true, rounded: true }
                 };
             }
-        }
+        },
+        allRowsPerPageOption: {
+            type: Boolean,
+            default: false
+        },
     },
     style: DataTableStyle,
     provide() {

--- a/packages/primevue/src/datatable/DataTable.d.ts
+++ b/packages/primevue/src/datatable/DataTable.d.ts
@@ -1248,6 +1248,10 @@ export interface DataTableProps<T = any> {
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * When enabled, it adds an All option to display inside rows per page dropdown.
+     */
+    allRowsPerPageOption?: boolean | undefined;
 }
 
 /**

--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -27,6 +27,7 @@
             :unstyled="unstyled"
             :data-p-top="true"
             :pt="ptm('pcPaginator')"
+            :allRowsPerPageOption="allRowsPerPageOption"
         >
             <template v-if="$slots.paginatorcontainer" #container="slotProps">
                 <slot
@@ -263,6 +264,7 @@
             :unstyled="unstyled"
             :data-p-bottom="true"
             :pt="ptm('pcPaginator')"
+            :allRowsPerPageOption="allRowsPerPageOption"
         >
             <template v-if="$slots.paginatorcontainer" #container="slotProps">
                 <slot

--- a/packages/primevue/src/paginator/BasePaginator.vue
+++ b/packages/primevue/src/paginator/BasePaginator.vue
@@ -37,7 +37,11 @@ export default {
         alwaysShow: {
             type: Boolean,
             default: true
-        }
+        },
+        allRowsPerPageOption: {
+            type: Boolean,
+            default: false
+        },
     },
     style: PaginatorStyle,
     provide() {

--- a/packages/primevue/src/paginator/Paginator.d.ts
+++ b/packages/primevue/src/paginator/Paginator.d.ts
@@ -284,6 +284,10 @@ export interface PaginatorProps {
      * @type {PassThroughOptions}
      */
     ptOptions?: PassThroughOptions;
+    /**
+     * When enabled, it adds an All option to display inside rows per page dropdown.
+     */
+    allRowsPerPageOption?: boolean | undefined;
 }
 
 /**

--- a/packages/primevue/src/paginator/Paginator.vue
+++ b/packages/primevue/src/paginator/Paginator.vue
@@ -84,6 +84,7 @@
                             :templates="$slots"
                             :unstyled="unstyled"
                             :pt="pt"
+                            :allRowsPerPageOption="allRowsPerPageOption"
                         />
                         <JumpToPageDropdown
                             v-else-if="item === 'JumpToPageDropdown'"
@@ -193,7 +194,8 @@ export default {
             event.preventDefault();
         },
         onRowChange(value) {
-            this.d_rows = value;
+            this.d_rows = value !== -1 ? value : this.totalRecords;
+
             this.changePage(this.page);
         },
         createStyle() {

--- a/packages/primevue/src/paginator/RowsPerPageDropdown.vue
+++ b/packages/primevue/src/paginator/RowsPerPageDropdown.vue
@@ -27,6 +27,7 @@ export default {
     extends: BaseComponent,
     emits: ['rows-change'],
     props: {
+        allRowsPerPageOption: Boolean,
         options: Array,
         rows: Number,
         disabled: Boolean,
@@ -44,6 +45,10 @@ export default {
             if (this.options) {
                 for (let i = 0; i < this.options.length; i++) {
                     opts.push({ label: String(this.options[i]), value: this.options[i] });
+                }
+
+                if (this.allRowsPerPageOption) {
+                    opts.push({ label: 'All', value: -1 });
                 }
             }
 


### PR DESCRIPTION
### Feature Request
When enabled, it adds an "All" option to display inside rows per page dropdown.

## How to use
Add the boolean value `allRowsPerPageOptions` to your DataTable to use it.

Example:
```
<DataTable
    :value="customers"
    paginator
    :rows="5"
    :rowsPerPageOptions="[5, 10, 20, 50]"
    tableStyle="min-width: 50rem"
    currentPageReportTemplate="{first} to {last} of {totalRecords}"
    :allRowsPerPageOption="true"
>
    <Column field="name" header="Name" style="width: 25%"></Column>
    <Column field="country.name" header="Country" style="width: 25%"></Column>
    <Column field="company" header="Company" style="width: 25%"></Column>
    <Column field="representative.name" header="Representative" style="width: 25%"></Column>
</DataTable>
```
Discussion: [DataTable: rowsPerPageOptions only accepts number](https://github.com/orgs/primefaces/discussions/3805)

