### PR TITLE
chore(menu): enable to point out the exact `event.currentTarget` for the `show` and `toggle` methods

### DIFF
--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -348,10 +348,11 @@ export interface MenuMethods {
     /**
      * Toggles the visibility of the overlay.
      * @param {Event} event - Browser event.
+     * @param {*} [target] - Target element
      *
      * @memberof Menu
      */
-    toggle(event: Event): void;
+    toggle(event: Event, target?: any): void;
     /**
      * Shows the overlay.
      * @param {Event} event - Browser event.

--- a/packages/primevue/src/menu/Menu.vue
+++ b/packages/primevue/src/menu/Menu.vue
@@ -247,13 +247,13 @@ export default {
 
             order > -1 && (this.focusedOptionIndex = links[order].getAttribute('id'));
         },
-        toggle(event) {
+        toggle(event, target) {
             if (this.overlayVisible) this.hide();
-            else this.show(event);
+            else this.show(event, target);
         },
-        show(event) {
+        show(event, target) {
             this.overlayVisible = true;
-            this.target = event.currentTarget;
+            this.target = target ?? event.currentTarget;
         },
         hide() {
             this.overlayVisible = false;


### PR DESCRIPTION
### Defect Fixes
Fix #7556 
