### PR TITLE
docs(confirmationoptions): fix default value for `modal`

### DIFF
--- a/packages/primevue/src/confirmationoptions/ConfirmationOptions.d.ts
+++ b/packages/primevue/src/confirmationoptions/ConfirmationOptions.d.ts
@@ -50,7 +50,7 @@ export interface ConfirmationOptions {
     appendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
     /**
      * Defines if background should be blocked when confirm dialog is displayed.
-     * @defaultValue false
+     * @defaultValue true
      */
     modal?: boolean | undefined;
     /**


### PR DESCRIPTION
See the implementation:

https://github.com/primefaces/primevue/blob/5139f9f84ccafb82678d108150e29185e9c86a7c/packages/primevue/src/confirmdialog/ConfirmDialog.vue#L136