### PR TITLE
FIX: ColorPicker hue selector.

### DIFF
--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -460,6 +460,7 @@ export default {
             this.hueDragging = true;
             this.pickHue(event);
             !this.isUnstyled && addClass(this.$el, 'p-colorpicker-dragging');
+            event.preventDefault();
         },
         isInputClicked(event) {
             return this.$refs.input && this.$refs.input.isSameNode(event.target);


### PR DESCRIPTION
 Added event.preventDefault() to onHueDragStart(). Now by dragging hue selector it doesn't select background text/elements, before it stared selecting background elements when dragging mouse pass selector bounds.
