### PR TITLE
fix: Add Backspace and Enter key support for mobile Editable Select

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -366,9 +366,25 @@ export default {
             }, 100);
         },
         onKeyDown(event) {
-            if (this.disabled || isAndroid()) {
+            if (this.disabled) {
                 event.preventDefault();
 
+                return;
+            }
+
+            const keyCode = event.keyCode || event.which;
+            const isAllowedKey = [ 8, 13, 190 ]; // Backspace, Enter, NumpadEnter
+
+            if (isAndroid() && isAllowedKey.includes(keyCode)) {
+                switch (keyCode) {
+                    case 8:
+                        this.onBackspaceKey(event, this.editable);
+                        break;
+                    case 13:
+                    case 190:
+                        this.onEnterKey(event);
+                        break;
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
Added support for Backspace and Enter keys in the Editable Select component for mobile devices.

## Problem
On mobile devices, keydown events were being blocked, preventing users from deleting text or confirming selections.

## Solution
Modified the keyboard event handler to check for keyCode values (8 for Backspace, 13 for Enter) and allow these essential keys on mobile.

## Testing
Tested on Android devices - backspace and enter keys now function properly.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
