### PR TITLE
fix(accordionheader): declare active prop in type definition for AccordionHeader

### DIFF
--- a/packages/primevue/src/accordionheader/AccordionHeader.d.ts
+++ b/packages/primevue/src/accordionheader/AccordionHeader.d.ts
@@ -115,7 +115,7 @@ export interface AccordionHeaderSlots {
     /**
      * Custom content template.
      */
-    default(): VNode[];
+    default(scope: AccordionHeaderContext): VNode[];
     /**
      * Custom toggleicon template.
      */


### PR DESCRIPTION
###Defect Fixes
Addresses: #7591

Update type definition of AccordionHeader with active prop to avoid linting errors.


With this PR in place - no more linting red squiggle:

![Screenshot From 2025-04-10 07-33-28](https://github.com/user-attachments/assets/5287bae0-582b-489f-9df7-e76ee50f7214)

