### PR TITLE
FIX - Multiselect slot schema

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.d.ts
+++ b/packages/primevue/src/multiselect/MultiSelect.d.ts
@@ -787,7 +787,7 @@ export interface MultiSelectSlots {
         /**
          * Options of the loader items for virtualscroller
          */
-        allSelected: boolean;
+        checked: boolean;
         /**
          * Style class of the loading icon.
          */


### PR DESCRIPTION
headercheckboxicon schema does not corresponds to the actual object return by slotProps.

`allSelected -> checked`

```ts
<MultiSelect>
  <template #headercheckboxicon="slotProps">
    {{ console.log(slotProps.checked) }}
  </template>
</MultiSelect>
```

### Defect Fixes
When submitting a PR, please also create an issue documenting the error.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
