### PR TITLE
Fix the memory leak of the tooltip directive.

### DIFF
--- a/packages/primevue/src/tooltip/Tooltip.js
+++ b/packages/primevue/src/tooltip/Tooltip.js
@@ -116,7 +116,10 @@ const Tooltip = BaseTooltip.extend('tooltip', {
                 el.addEventListener('click', el.$_ptooltipClickEvent);
             }
 
-            el.addEventListener('keydown', this.onKeydown.bind(this));
+            el.$_ptooltipKeydownEvent = this.onKeydown.bind(this);
+            el.addEventListener('keydown', el.$_ptooltipKeydownEvent);
+
+            el.$_pWindowResizeEvent = this.onWindowResize.bind(this, el);
         },
         unbindEvents(el) {
             const modifiers = el.$_ptooltipModifiers;
@@ -138,7 +141,8 @@ const Tooltip = BaseTooltip.extend('tooltip', {
                 el.$_ptooltipClickEvent = null;
             }
 
-            el.removeEventListener('keydown', this.onKeydown.bind(this));
+            el.removeEventListener('keydown', el.$_ptooltipKeydownEvent);
+            window.removeEventListener('resize', el.$_pWindowResizeEvent);
         },
         bindScrollListener(el) {
             if (!el.$_ptooltipScrollHandler) {
@@ -203,6 +207,13 @@ const Tooltip = BaseTooltip.extend('tooltip', {
 
             event.code === 'Escape' && this.hide(event.currentTarget, hideDelay);
         },
+        onWindowResize(el) {
+            if (!isTouchDevice()) {
+                this.hide(el);
+            }
+
+            window.removeEventListener('resize', el.$_pWindowResizeEvent);
+        },
         tooltipActions(el, options) {
             if (el.$_ptooltipDisabled || !isExist(el)) {
                 return;
@@ -215,13 +226,7 @@ const Tooltip = BaseTooltip.extend('tooltip', {
 
             const $this = this;
 
-            window.addEventListener('resize', function onWindowResize() {
-                if (!isTouchDevice()) {
-                    $this.hide(el);
-                }
-
-                window.removeEventListener('resize', onWindowResize);
-            });
+            window.addEventListener('resize', el.$_pWindowResizeEvent);
 
             tooltipElement.addEventListener('mouseleave', function onTooltipLeave() {
                 $this.hide(el);
@@ -244,6 +249,7 @@ const Tooltip = BaseTooltip.extend('tooltip', {
         tooltipRemoval(el) {
             this.remove(el);
             this.unbindScrollListener(el);
+            window.removeEventListener('resize', el.$_pWindowResizeEvent);
         },
         hide(el, hideDelay) {
             clearTimeout(this.timer);


### PR DESCRIPTION
### Defect Fixes

![image](https://github.com/user-attachments/assets/391da63d-d3f0-41a6-afec-04faf87e6f5a)

I found a memory leak when using the tooltip directive and located the following code snippet:

![image](https://github.com/user-attachments/assets/ce0d3e22-4a12-451f-91ea-8c3b761460ae)

In addition, a keydown event was not destroyed correctly.

![image](https://github.com/user-attachments/assets/b1bf4a61-a17b-4f21-a239-a3b6162f24a8)

### Solution

I extracted the “onWindowResize“ method and handled it in a similar way to the other event listeners in the original code.

### Modified Version

![image](https://github.com/user-attachments/assets/a7763c2d-f90d-40df-bc12-2052875c58c0)

Of course, I also ran unit tests: 

![image](https://github.com/user-attachments/assets/01b41cd4-a8fe-41ef-ad16-525e946e28ad)
