### PR TITLE
separate CSV generation from exportCSV method

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -1203,7 +1203,7 @@ export default {
 
             this.$emit('update:selection', _selection);
         },
-        exportCSV(options, data) {
+        generateCSV(options, data) {
             let csv = '\ufeff';
 
             if (!data) {
@@ -1273,6 +1273,10 @@ export default {
                 }
             }
 
+            return csv;
+        },
+        exportCSV(options, data) {
+            const csv = this.generateCSV(options, data);
             exportCSV(csv, this.exportFilename);
         },
         resetPage() {


### PR DESCRIPTION
Refactored the exportCSV(options, data) method to separate concerns. The new generateCSV(options, data) method now returns the CSV string without triggering a download. The updated exportCSV() method delegates CSV generation to generateCSV() and handles only the export logic. This makes the CSV data reusable for other purposes like copying, previewing, or sending via API.