### PR TITLE
DatePicker & MultiSelect: esc keypress propagates and triggers close in dialogs

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2240,6 +2240,7 @@ export default {
                 case 'Escape': {
                     this.overlayVisible = false;
                     event.preventDefault();
+                    event.stopPropagation();
                     break;
                 }
 
@@ -2417,6 +2418,7 @@ export default {
                 case 'Escape': {
                     this.overlayVisible = false;
                     event.preventDefault();
+                    event.stopPropagation();
                     break;
                 }
 
@@ -2511,6 +2513,7 @@ export default {
                 case 'Escape': {
                     this.overlayVisible = false;
                     event.preventDefault();
+                    event.stopPropagation();
                     break;
                 }
 
@@ -2652,6 +2655,7 @@ export default {
                 case 'Escape':
                     this.overlayVisible = false;
                     event.preventDefault();
+                    event.stopPropagation();
                     break;
 
                 default:
@@ -2708,6 +2712,7 @@ export default {
                 if (this.overlayVisible) {
                     this.overlayVisible = false;
                     event.preventDefault();
+                    event.stopPropagation();
                 }
             } else if (event.code === 'Tab') {
                 if (this.overlay) {

--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -710,6 +710,9 @@ export default {
             event.preventDefault();
         },
         onEscapeKey(event) {
+            if (this.overlayVisible) {
+                event.stopPropagation();
+            }
             this.overlayVisible && this.hide(true);
             event.preventDefault();
         },


### PR DESCRIPTION
###Defect Fixes
DatePicker & MultiSelect fixed
https://github.com/primefaces/primevue/issues/7661

###Feature Requests
When using keyboard navigation within a dialog, pressing the "ESC" key after interacting with a DatePicker or MultiSelect component closes the entire dialog instead of just closing the DatePicker or MultiSelect. This behavior makes it difficult for users to continue working within the dialog after dismissing these components.
