### PR TITLE
fix(fileupload): prevent automatic clearing of files after custom upload

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -172,7 +172,6 @@ export default {
                 }
 
                 this.$emit('uploader', { files: this.files });
-                this.clear();
             } else {
                 let xhr = new XMLHttpRequest();
                 let formData = new FormData();


### PR DESCRIPTION
This commit removes the this.clear() call inside the uploader method of the FileUpload component when customUpload is enabled. PrimeVue previously cleared the file list immediately after the custom uploader was invoked, which caused selected images (like previews) to disappear before the upload process was completed or handled manually. By skipping this.clear() in custom upload mode, the component now allows developers to manage file state and cleanup more precisely in their own handlers.

###Defect Fixesh
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
