### PR TITLE
fix(FileUpload): clear file list after successful custom upload

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -172,7 +172,6 @@ export default {
                 }
 
                 this.$emit('uploader', { files: this.files });
-                this.clear();
             } else {
                 let xhr = new XMLHttpRequest();
                 let formData = new FormData();


### PR DESCRIPTION
### Description

This PR fixes an issue where the `FileUpload` component automatically clear its file list after a successful custom upload (`@uploader`). The fix ensures that `clear()` is not called on case of custom upload, improving UX consistency with the standard upload flow.

### Related issue
Fixes [#7664](https://github.com/primefaces/primevue/pull/7662)
 