### PR TITLE
fix: move unmaskIcon and maskIcon  class from slot to component to ap…

### DIFF
--- a/packages/primevue/src/password/Password.vue
+++ b/packages/primevue/src/password/Password.vue
@@ -31,10 +31,10 @@
             :unstyled="unstyled"
         />
         <!-- TODO: hideicon and showicon slots are deprecated since v4.0-->
-        <slot v-if="toggleMask && unmasked" :name="$slots.maskicon ? 'maskicon' : 'hideicon'" :toggleCallback="onMaskToggle">
+        <slot v-if="toggleMask && unmasked" :name="$slots.maskicon ? 'maskicon' : 'hideicon'" :toggleCallback="onMaskToggle" v-bind="ptm('maskIcon')" :class="[cx('maskIcon'), maskIcon]">
             <component :is="maskIcon ? 'i' : 'EyeSlashIcon'" :class="[cx('maskIcon'), maskIcon]" @click="onMaskToggle" v-bind="ptm('maskIcon')" />
         </slot>
-        <slot v-if="toggleMask && !unmasked" :name="$slots.unmaskicon ? 'unmaskicon' : 'showicon'" :toggleCallback="onMaskToggle">
+        <slot v-if="toggleMask && !unmasked" :name="$slots.unmaskicon ? 'unmaskicon' : 'showicon'" :toggleCallback="onMaskToggle" :class="[cx('unmaskIcon')]" v-bind="ptm('unmaskIcon')">
             <component :is="unmaskIcon ? 'i' : 'EyeIcon'" :class="[cx('unmaskIcon'), unmaskIcon]" @click="onMaskToggle" v-bind="ptm('unmaskIcon')" />
         </slot>
         <span class="p-hidden-accessible" aria-live="polite" v-bind="ptm('hiddenAccesible')" :data-p-hidden-accessible="true">


### PR DESCRIPTION
 In this way, we can pass the desired component into the slot, the style properties will be preserved.
<Password v-model="value" toggleMask>
  <template #maskicon="slotProps">
  <EyeSlashIcon :class="['size-5', slotProps.class]" @click="slotProps.toggleCallback" />
</template>

<template #unmaskicon="slotProps">
  <EyeIcon :class="['size-5', slotProps.class]" @click="slotProps.toggleCallback" />
  </template>
</Password>  

Related issue

https://github.com/primefaces/primevue/issues/7543