### PR TITLE
fix: call d_columns.get() to avoid duplicate computed execution 

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -401,8 +401,8 @@ export default {
     ],
     provide() {
         return {
-            $columns: this.d_columns,
-            $columnGroups: this.d_columnGroups
+            $columns: this.d_columns.get(),
+            $columnGroups: this.d_columnGroups.get()
         };
     },
     data() {


### PR DESCRIPTION
#Fix: https://github.com/primefaces/primevue/issues/7677

fixed: call d_columns.get() to avoid duplicate computed execution 
