### PR TITLE
fix: keep focus when enter without any matchings

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -482,7 +482,6 @@ export default {
         },
         onOptionSelect(event, option, isHide = true) {
             const value = this.getOptionValue(option);
-
             this.updateModel(event, value);
             isHide && this.hide(true);
         },
@@ -653,9 +652,9 @@ export default {
             } else {
                 if (this.focusedOptionIndex !== -1) {
                     this.onOptionSelect(event, this.visibleOptions[this.focusedOptionIndex]);
+                } else {
+                    this.hide(true);
                 }
-
-                this.hide();
             }
 
             event.preventDefault();


### PR DESCRIPTION
### Defect Fixes

Fix [#7613 Select: hitting ENTER when filter focused and no results breaks focus](https://github.com/primefaces/primevue/issues/7613)

This issue occurs because `this.hide()` is triggered with `isFocus: false` when the user presses Enter without any matching results, which causes the focused element to be lost. I moved the `this.hide()` call into the else block because, if the user does find a match and presses Enter, `this.hide()` would otherwise be invoked twice.
