### PR TITLE
fix(datepicker): keep current month visible when selecting a range

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2845,7 +2845,16 @@ export default {
 
             if (propValue && Array.isArray(propValue)) {
                 if (this.isRangeSelection()) {
-                    propValue = propValue[1] || propValue[0];
+                    if (propValue.length === 1) {
+                        propValue = propValue[0];
+                    } else {
+                        let endmostMonth = new Date(propValue[0].getFullYear(), propValue[0].getMonth() + this.numberOfMonths, 1);
+                        if (propValue[1] < endmostMonth) {
+                            propValue = propValue[0];
+                        } else {
+                            propValue = new Date(propValue[1].getFullYear(), propValue[1].getMonth() - this.numberOfMonths + 1, 1);
+                        }
+                    }
                 } else if (this.isMultipleSelection()) {
                     propValue = propValue[propValue.length - 1];
                 }


### PR DESCRIPTION
###Defect Fixes
fix #7691 

In a DatePicker with multiple months, calendars are displayed starting from the `viewDate` for the number of months defined by `numberOfMonths`.

Currently, selecting the second date updates the `viewDate`, which unintentionally shifts the visible calendar and can disrupt the user’s selection flow.

To improve this, I updated the logic to retain the initial `viewDate` if the second date falls within the range from the first selected date to the number of months specified by `numberOfMonths`. However, if the calendar has been navigated using the next button, it will display months starting from the second selected date instead.