### PR TITLE
fix(MenubarSub): aria-level invalid attribute for role menuitem

### DIFF
--- a/packages/primevue/src/menubar/MenubarSub.vue
+++ b/packages/primevue/src/menubar/MenubarSub.vue
@@ -11,7 +11,6 @@
                 :aria-disabled="isItemDisabled(processedItem) || undefined"
                 :aria-expanded="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
                 :aria-haspopup="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
-                :aria-level="level + 1"
                 :aria-setsize="getAriaSetSize"
                 :aria-posinset="getAriaPosInset(index)"
                 v-bind="getPTOptions(processedItem, index, 'item')"


### PR DESCRIPTION
###Defect Fixes
fix #7704


Fixes accessibility issue on menu items of component MenuBar, the `aria-level` attribute is not valid for the role `menuitem`.

Check https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level documentation for reference.

![Capture d’écran 2025-05-14 à 10 25 20](https://github.com/user-attachments/assets/e98a2260-a325-4207-868a-c2818609a5bf)
