### PR TITLE
fix(TreeTable): role treegrid

### DIFF
--- a/packages/primevue/src/treetable/TreeTable.vue
+++ b/packages/primevue/src/treetable/TreeTable.vue
@@ -68,7 +68,7 @@
             </template>
         </TTPaginator>
         <div :class="cx('tableContainer')" :style="[sx('tableContainer'), { maxHeight: scrollHeight }]" v-bind="ptm('tableContainer')">
-            <table ref="table" role="table" :class="[cx('table'), tableClass]" :style="tableStyle" v-bind="{ ...tableProps, ...ptm('table') }">
+            <table ref="table" role="treegrid" :class="[cx('table'), tableClass]" :style="tableStyle" v-bind="{ ...tableProps, ...ptm('table') }">
                 <thead :class="cx('thead')" :style="sx('thead')" role="rowgroup" v-bind="ptm('thead')">
                     <tr role="row" v-bind="ptm('headerRow')">
                         <template v-for="(col, i) of columns" :key="columnProp(col, 'columnKey') || columnProp(col, 'field') || i">


### PR DESCRIPTION
###Defect Fixes

Fixes an accessibility with TreeTable having the wrong aria `role` attribute. It should have `treegrid` role in order to rows to have the attribute `aria-expanded`.

See: https://dequeuniversity.com/rules/axe/4.10/aria-conditional-attr

