### PR TITLE
fix(ThemingDoc): tailwind presets link broken

### DIFF
--- a/apps/showcase/doc/introduction/ThemingDoc.vue
+++ b/apps/showcase/doc/introduction/ThemingDoc.vue
@@ -3,7 +3,7 @@
         <p class="mb-0">
             PrimeVue can be styled in two modes; styled or unstyled. Styled mode is based on pre-skinned components with opinionated theme variants of PrimeOne design like Aura, Lara or Nora presets. Unstyled mode on the other hand, leaves the
             styling to you while implementing the functionality and accessibility. Unstyled mode provides full control over the styling with no boundaries by implementing a pluggable architecture to utilize CSS libraries like Tailwind CSS, Bootstrap,
-            Bulma or your own custom CSS. We've even further built the <a href="tailwind.primevue.org" target="_blank" rel="noopener noreferrer">Tailwind Presets</a> library to skin the UI library with utility classes of Tailwind. This design is
+            Bulma or your own custom CSS. We've even further built the <a href="https://tailwind.primevue.org" target="_blank" rel="noopener noreferrer">Tailwind Presets</a> library to skin the UI library with utility classes of Tailwind. This design is
             future proof as PrimeVue can be styled with any CSS library without actually depending on it in its core.
         </p>
     </DocSectionText>


### PR DESCRIPTION
###Defect Fixes

This PR fixes a broken link to the Tailwind Presets documentation in the Styling section.

