### PR TITLE
fix: when allowEmpty='false' component is unusable

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -799,7 +799,7 @@ export default {
 
             if (valueStr != null) {
                 newValue = this.parseValue(valueStr);
-                newValue = !newValue && !this.allowEmpty ? this.min || 0 : newValue;
+                newValue = !newValue && !this.allowEmpty ? 0 : newValue;
                 this.updateInput(newValue, insertedValueStr, operation, valueStr);
 
                 this.handleOnInput(event, currentValue, newValue);


### PR DESCRIPTION
### Defect Fixes

Fix https://github.com/primefaces/primevue/issues/7725

function `validateValue` would detect this.min and this.max and correct it, there's no need to do it before blur.