### PR TITLE
Fix: suffix problem after selecting all text

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -404,7 +404,6 @@ export default {
             let inputValue = event.target.value;
             let newValueStr = null;
             const code = event.code || event.key;
-
             switch (code) {
                 case 'ArrowUp':
                     this.spin(event, 1);
@@ -451,6 +450,11 @@ export default {
                     event.preventDefault();
 
                     if (selectionStart === selectionEnd) {
+                        if (selectionStart >= inputValue.length && this.suffixChar !== null) {
+                            selectionStart = inputValue.length - this.suffixChar.length;
+                            this.$refs.input.$el.setSelectionRange(selectionStart, selectionStart);
+                        }
+
                         const deleteChar = inputValue.charAt(selectionStart - 1);
                         const { decimalCharIndex, decimalCharIndexWithoutPrefix } = this.getDecimalCharIndexes(inputValue);
 

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -404,6 +404,7 @@ export default {
             let inputValue = event.target.value;
             let newValueStr = null;
             const code = event.code || event.key;
+
             switch (code) {
                 case 'ArrowUp':
                     this.spin(event, 1);


### PR DESCRIPTION
### Defect Fixes
Fix [InputNumber - suffix problems after selecting all text](https://github.com/primefaces/primevue/issues/7724)

This issue occurs because `selectionStart` is positioned at the end of the `suffix`, causing `InputNumber` to attempt deleting the `suffix` instead of thevalue. The fix adjusts `selectionStart` to the end of thevalue when the `Backspace` key is pressed, allowing the subsequent behavior to correctly delete the intended user input.