### PR TITLE
fix: update clear button to use defaultValue instead of formDefaultValue

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1493,7 +1493,7 @@ export default {
             event.preventDefault();
         },
         onClearButtonClick(event) {
-            this.updateModel(this.$formDefaultValue || null);
+            this.updateModel(this.defaultValue || null);
             this.overlayVisible = false;
             this.$emit('clear-click', event);
             event.preventDefault();


### PR DESCRIPTION
###Defect Fixes
Fixes a bug where the clear button in the DatePicker component was not working as expected.

-   **Issue:** [will be provided after I opened the issue]
-   **Description:** The clear button in the DatePicker component was not resetting the selected date. This PR corrects the `onClearButtonClick` method to properly update the model and clear the selected date.
