### PR TITLE
Feat: Toast can't use custom severity

### DIFF
--- a/apps/showcase/assets/data/news.json
+++ b/apps/showcase/assets/data/news.json
@@ -1,7 +1,7 @@
 {
-    "id": 81,
-    "content": "Remastered Avalon Template is now available! 🎉",
-    "linkText": "View Demo",
-    "linkHref": "https://avalon.primevue.org",
+    "id": 82,
+    "content": "PrimeBlocks: One-Time Purchase Replaces Subscription Model 🎉",
+    "linkText": "Learn More",
+    "linkHref": "https://www.primefaces.org/primeblocks-one-time-purchase-replaces-subscription-model",
     "target": "_blank"
 }

--- a/apps/showcase/doc/common/apidoc/index.json
+++ b/apps/showcase/doc/common/apidoc/index.json
@@ -72727,6 +72727,14 @@
                             "description": "Key of the Toast to display the message."
                         },
                         {
+                            "name": "slotContext",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "Record<string, any>",
+                            "default": "",
+                            "description": "Custom data which can be used when using slots."
+                        },
+                        {
                             "name": "styleClass",
                             "optional": true,
                             "readonly": false,

--- a/packages/primevue/src/toast/Toast.d.ts
+++ b/packages/primevue/src/toast/Toast.d.ts
@@ -140,6 +140,10 @@ export interface ToastMessageOptions {
      */
     group?: string | undefined;
     /**
+     * Custom data which can be used when using slots.
+     */
+    slotContext?: Record<string, any> | undefined;
+    /**
      * Style class of the message.
      */
     styleClass?: any;


### PR DESCRIPTION
### Feature Requests

[Toast: can't use custom severity](https://github.com/primefaces/primevue/issues/7332)

This issue highlights that TypeScript users are unable to add custom properties because such additions fail TypeScript’s type checking. This PR introduces a new property named `slotContext`, which accepts a `Record<string, any>`. It enables users to define custom key-value pairs for slots.

If needed, I’m happy to contribute an example to the Toast documentation.