### PR TITLE
Add @primeuix/styles dependency to @primevue/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,6 +61,7 @@
     },
     "dependencies": {
         "@primeuix/styled": "catalog:",
+        "@primeuix/styles": "catalog:",
         "@primeuix/utils": "catalog:"
     },
     "peerDependencies": {


### PR DESCRIPTION
In github.com/primefaces/primevue/commit/9ac4c5a07f37d0acc69abc49c7c0d1ff73eff1cb a practical dependency for `@primevue/core` on `@primeuix/styles` was introduced, which was never added as an actual dependency in the (`package.json`) dependencies of the project.

When working with e.g. npm, this works just fine as hoisting will solve this issue. However stricter package managers, e.g. Yarn with PnP mode, will fail when trying to build code with the following message:
```
[vite]: Rollup failed to resolve import "@primeuix/styles/base" from ".../.cache/yarn/@primevue-core-npm-4.3.4-c09e12b8ba-fad8d40ff8.zip/node_modules/@primevue/core/base/style/index.mjs".
This is most likely unintended because it can break your application at runtime.
```

This PR aims to resolve this issue by formally adding the corresponding dependency.

As a (temporary) workaround one can manually patch dependencies for yarn by adding the following to your `.yarnrc.yml` file:
```yaml

packageExtensions:
  "@primevue/core@*":
    dependencies:
      "@primeuix/styles": "^1.1.1"
```