### PR TITLE
fix(ExampleDoc.vue): theme reference

### DIFF
--- a/apps/showcase/doc/cdn/ExampleDoc.vue
+++ b/apps/showcase/doc/cdn/ExampleDoc.vue
@@ -44,7 +44,7 @@ export default {
 
       app.use(PrimeVue.Config, {
         theme: {
-            preset: PrimeVue.Themes.Aura
+            preset: PrimeUIX.Themes.Aura
         }
       });
 


### PR DESCRIPTION
In one of the examples, `PrimeUIX.Themes.Aura` should be used instead of `PrimeVue.Themes.Aura`