### PR TITLE
Update PR template for headings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-###Defect Fixes
+### Defect Fixes
 When submitting a PR, please also create an issue documenting the error.
 
-###Feature Requests
+### Feature Requests
 Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.


### PR DESCRIPTION
### Defect Fixes
I noticed when submitting another PR the headers were written as `###Defect Fixes` and `###Feature Requests` because of missing space.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
