### PR TITLE
fix: partial or full check should refer to original value

### DIFF
--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -28,6 +28,7 @@
                     :level="level + 1"
                     :index="index"
                     :expandedKeys="d_expandedKeys"
+                    :treeNodeChildrenMap="treeNodeChildrenMap"
                     @node-toggle="onNodeToggle"
                     @node-click="onNodeClick"
                     :selectionMode="selectionMode"
@@ -61,6 +62,7 @@ export default {
     emits: ['node-expand', 'node-collapse', 'update:expandedKeys', 'update:selectionKeys', 'node-select', 'node-unselect', 'filter'],
     data() {
         return {
+            treeNodeChildrenMap: {},
             d_expandedKeys: this.expandedKeys || {},
             filterValue: null
         };
@@ -69,6 +71,9 @@ export default {
         expandedKeys(newValue) {
             this.d_expandedKeys = newValue;
         }
+    },
+    created() {
+        this.treeNodeChildrenMap = this.initTreeNodeChildrenMap();
     },
     methods: {
         onNodeToggle(node) {
@@ -220,6 +225,24 @@ export default {
             }
 
             return matched;
+        },
+        initTreeNodeChildrenMap() {
+            const result = {};
+
+            function traverse(nodes) {
+                if (!nodes) return;
+
+                for (const node of nodes) {
+                    result[node.key] = node.children ? node.children.map((n) => n.key) : [];
+
+                    if (node.children && node.children.length > 0) {
+                        traverse(node.children);
+                    }
+                }
+            }
+
+            traverse(this.value);
+            return result;
         }
     },
     computed: {

--- a/packages/primevue/src/tree/TreeNode.vue
+++ b/packages/primevue/src/tree/TreeNode.vue
@@ -55,6 +55,7 @@
                 v-for="childNode of node.children"
                 :key="childNode.key"
                 :node="childNode"
+                :treeNodeChildrenMap="treeNodeChildrenMap"
                 :templates="templates"
                 :level="level + 1"
                 :loadingMode="loadingMode"
@@ -91,6 +92,10 @@ export default {
         node: {
             type: null,
             default: null
+        },
+        treeNodeChildrenMap: {
+            type: null,
+            default: () => ({})
         },
         expandedKeys: {
             type: null,
@@ -365,20 +370,24 @@ export default {
             let _selectionKeys = { ...event.selectionKeys };
             let checkedChildCount = 0;
             let childPartialSelected = false;
+            const children = this.treeNodeChildrenMap[this.node.key] || [];
 
-            for (let child of this.node.children) {
-                if (_selectionKeys[child.key] && _selectionKeys[child.key].checked) checkedChildCount++;
-                else if (_selectionKeys[child.key] && _selectionKeys[child.key].partialChecked) childPartialSelected = true;
+            for (let key of children) {
+                if (_selectionKeys[key] && _selectionKeys[key].checked) {
+                    checkedChildCount++;
+                } else if (_selectionKeys[key] && _selectionKeys[key].partialChecked) {
+                    childPartialSelected = true;
+                }
             }
 
-            if (check && checkedChildCount === this.node.children.length) {
+            if (check && checkedChildCount === children.length) {
                 _selectionKeys[this.node.key] = { checked: true, partialChecked: false };
             } else {
                 if (!check) {
                     delete _selectionKeys[this.node.key];
                 }
 
-                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== this.node.children.length)) _selectionKeys[this.node.key] = { checked: false, partialChecked: true };
+                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== children.length)) _selectionKeys[this.node.key] = { checked: false, partialChecked: true };
                 else delete _selectionKeys[this.node.key];
             }
 


### PR DESCRIPTION
### Defect Fixes

Fix #7662 

The issue occurred because, in the `Tree` component, node rendering depends on `valueToRender`. This means that values filtered out will not be rendered in `TreeNode`. As a result, when `propagateUp` is called, it checks against the filtered tree, leading to incorrect state propagation.
The fix involves creating a reference hash map based on the original data so that `partialChecked` and `checked` states refer to the original child nodes during evaluation, rather than the filtered ones.
