### PR TITLE
fix: Allow wrapped datatable columns

### DIFF
--- a/packages/core/src/utils/HelperSet.js
+++ b/packages/core/src/utils/HelperSet.js
@@ -38,7 +38,7 @@ export default class {
 
         children.forEach((child) => {
             if (child.children instanceof Array) {
-                components = components.concat(this._recursive(components, child.children));
+                components = components.concat(this._recursive(helpers, child.children));
             } else if (child.type.name === this.type) {
                 components.push(child);
             } else if (isNotEmpty(child.key)) {

--- a/packages/primevue/src/datatable/DataTable.spec.js
+++ b/packages/primevue/src/datatable/DataTable.spec.js
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils';
 import Button from 'primevue/button';
 import PrimeVue from 'primevue/config';
 import InputText from 'primevue/inputtext';
+import { defineComponent, nextTick } from 'vue';
 import Column from '../column/Column.vue';
 import ColumnGroup from '../columngroup/ColumnGroup.vue';
 import Row from '../row/Row.vue';
@@ -175,6 +176,42 @@ describe('DataTable.vue', () => {
     });
 
     // column templating
+
+    it('should allow column wrappers', async () => {
+        const ColumnWrapper = defineComponent({
+            name: 'ColumnWrapper',
+            components: { Column },
+            template: `<Column sortable></Column>`
+        });
+
+        wrapper = mount(DataTable, {
+            global: {
+                plugins: [PrimeVue],
+                components: {
+                    ColumnWrapper
+                }
+            },
+            props: {
+                value: smallData
+            },
+            slots: {
+                default: `
+                    <ColumnWrapper key="code" field="code" header="Code"></ColumnWrapper>
+                    <ColumnWrapper key="name" field="name" header="Name"></ColumnWrapper>
+                `
+            }
+        });
+
+        // Helpers are registered on Column mount, it is not immediate
+        await nextTick();
+
+        expect(wrapper.findAll('.p-datatable-column-header-content').length).toEqual(2);
+        const tbody = wrapper.find('.p-datatable-tbody');
+        const rows = tbody.findAll('tr');
+
+        expect(rows[0].findAll('td').length).toEqual(2);
+        expect(wrapper.findAll('.p-datatable-sortable-column').length).toEqual(2);
+    });
 
     // column grouping
     it('should exist', () => {

--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -401,8 +401,8 @@ export default {
     ],
     provide() {
         return {
-            $columns: this.d_columns.get(),
-            $columnGroups: this.d_columnGroups.get()
+            $columns: this.d_columns,
+            $columnGroups: this.d_columnGroups
         };
     },
     data() {


### PR DESCRIPTION
### Defect Fixes

Fixes #4940 
Fixes #5190
Fixes #4646 again

This enables primevue users to Column defaults like sorticons once.

Unfortunately this reverts the (unreleased) changes from this commit: https://github.com/primefaces/primevue/commit/9bdf762746b509cb9041aff54ed505a9315cb826
The columns first needs to be rendered before they are added to the column helperset, only then their helpers can be used to filter the DataTable computed columns. 

I'm open to suggestions how this can be achieved without the extra computed tick.



