### PR TITLE
fix: render empty `td` when `FilterHeaderCell` contains no filter.

### DIFF
--- a/packages/primevue/src/datatable/FilterHeaderCell.vue
+++ b/packages/primevue/src/datatable/FilterHeaderCell.vue
@@ -1,5 +1,6 @@
 <template>
-    <th
+    <component
+        :is="column.children?.filter ? 'th' : 'td'"
         v-if="!columnProp('hidden') && (rowGroupMode !== 'subheader' || groupRowsBy !== columnProp('field'))"
         :style="getFilterColumnHeaderStyle"
         :class="getFilterColumnHeaderClass"
@@ -46,7 +47,7 @@
             :unstyled="unstyled"
             :pt="pt"
         />
-    </th>
+    </component>
 </template>
 
 <script>


### PR DESCRIPTION
Attempts to resolve #7763.
