### PR TITLE
Fixed #7779. DocSectionNav fits the screen and no longer scrolls out of control

### DIFF
--- a/apps/showcase/assets/styles/layout/_doc.scss
+++ b/apps/showcase/assets/styles/layout/_doc.scss
@@ -179,13 +179,16 @@
     padding-block: 0.25rem;
     padding-inline: 0;
     margin-inline-start: 4rem;
-    overflow-y: auto;
-    overflow-x: hidden;
     align-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 7rem);
 }
 
 .doc-section-nav {
     list-style: none;
+    overflow-y: scroll;
+    overflow-x: hidden;
 
     >.navbar-item {
         .navbar-item-content {


### PR DESCRIPTION
## Defect Fixes

As seen on #7779, when reaching the “Scroll” section of the Datatable documentation, the page unexpectedly jumps to the bottom.

This prevents users from reading intermediate sections like “Row Group” or "Column Group."

## Root cause
In DocSectionNav.vue, the sidebar attempts to scroll the .active-navbar-item into view via:

https://github.com/primefaces/primevue/blob/188d8ab90bde7348e686539702133a061cb43436/apps/volt/components/doc/DocSectionNav.vue#L70-L77

However, due to the height and overflow settings of .doc-section-nav-container, the scrollIntoView call forces the entire page to scroll, not just the sidebar.

This results in a loss of scroll control and creates a frustrating user experience, which I fixed on this pull request.

## What this PR changes

- Moves overflow-y: scroll to .doc-section-nav, rather than the container.
- Limits the height of the container with: `max-height: calc(100vh - 7rem);` ensuring it respects the viewport and does not overflow uncontrollably.
- Uses display: flex and flex-direction: column to make the layout clean and predictable.

By separating the scrollable area and properly bounding its height, it prevents the scrollIntoView() behavior from affecting the page-level scroll. Now users can scroll the sections independly and there are no more jumps to the bottom of the page.