### PR TITLE
Fix DataTable expander button triggering unwanted row-click events

### DIFF
--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -68,7 +68,7 @@
                 :aria-expanded="isRowExpanded"
                 :aria-controls="ariaControls"
                 :aria-label="expandButtonAriaLabel"
-                @click="toggleRow"
+                @click.stop="toggleRow"
                 data-p-selected="selected"
                 v-bind="getColumnPT('rowToggleButton')"
                 data-pc-group-section="rowactionbutton"


### PR DESCRIPTION
# DataTable 展开按钮触发了不必要的行点击事件
# DataTable expander button triggers unwanted row-click events

## 问题描述
## Description
当点击 DataTable 行中的展开按钮时，点击事件会冒泡并触发行点击事件处理器，导致意外行为。
When clicking the expander button in a DataTable row, the click event bubbles up and triggers the row-click event handler, causing unintended behavior.

## 重现步骤
## Steps to Reproduce
1. 创建一个带有可展开行的 DataTable（使用 `expander` 列）
   Create a DataTable with expandable rows (using `expander` column)
2. 为 DataTable 添加行点击事件处理器
   Add a row-click event handler to the DataTable
3. 点击展开按钮来展开/折叠行
   Click on the expander button to expand/collapse a row
4. 观察到行点击事件也被触发了
   Observe that the row-click event is also triggered

## 期望行为
## Expected Behavior
- 点击展开按钮应该只触发展开/折叠功能
  Clicking the expander button should only trigger the expand/collapse functionality
- 点击展开按钮时不应触发行点击事件
  Row-click events should NOT be triggered when clicking the expander button
- 只有直接点击行（操作按钮外）才应触发行点击事件
  Only direct clicks on the row (outside of action buttons) should trigger row-click events

## 实际行为
## Actual Behavior
- 点击展开按钮会同时触发展开/折叠动作和行点击事件
  Clicking the expander button triggers both the expand/collapse action AND the row-click event
- 这会导致不必要的副作用并与预期的用户交互产生冲突
  This causes unwanted side effects and conflicts with intended user interactions

## 根本原因
## Root Cause
展开按钮的点击事件冒泡到父级 `<td>` 元素，该元素有处理行点击的 `@click="onClick"` 事件处理器。
The expander button's click event bubbles up to the parent `<td>` element, which has a `@click="onClick"` event handler that processes row clicks.

## 解决方案
## Solution
为展开按钮的点击处理器添加 `.stop` 事件修饰符以阻止事件冒泡：
Add the `.stop` event modifier to the expander button's click handler to prevent event bubbling:
```vue
@click.stop="toggleRow"
```

## 环境信息
## Environment
- PrimeVue 版本 / PrimeVue Version: [当前版本 / current version]
- Vue 版本 / Vue Version: [当前版本 / current version]
- 浏览器 / Browser: [受影响的浏览器 / affected browsers]

## 代码位置
## Code Location
文件 / File: `packages/primevue/src/datatable/BodyCell.vue`
行数 / Line: ~71 (expander button template)