### PR TITLE
Accept readonly value in DataTable

### DIFF
--- a/packages/primevue/src/datatable/DataTable.d.ts
+++ b/packages/primevue/src/datatable/DataTable.d.ts
@@ -884,7 +884,7 @@ export interface DataTableProps<T = any> {
     /**
      * An array of objects to display.
      */
-    value?: T[] | undefined | null;
+    value?: readonly T[] | undefined | null;
     /**
      * Name of the field that uniquely identifies the a record in the data.
      */


### PR DESCRIPTION
The DataTable component in typescript currently accepts only modifiable arrays. This doesn't have to be the case though, since the DataTable implementation (to my knowledge) doesn't seem to modify the array.

Add `readonly` to the typescript type.

This supports a use-case of having the source data being a const array. Consider the input being a readonly array of defined countries that you want to display in the data table.

Resolves TBD
