### PR TITLE
Fix for missing Overlay & Panel Event Catches to Edit Cell in Data Table

### DIFF
--- a/apps/showcase/doc/datatable/edit/CellEditDoc.vue
+++ b/apps/showcase/doc/datatable/edit/CellEditDoc.vue
@@ -19,14 +19,20 @@
             >
                 <Column v-for="col of columns" :key="col.field" :field="col.field" :header="col.header" style="width: 25%">
                     <template #body="{ data, field }">
-                        {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
+                        {{ field === 'price' ? formatCurrency(data[field]) : field === 'date' ? new Date(data[field]).toDateString() : data[field] }}
                     </template>
                     <template #editor="{ data, field }">
-                        <template v-if="field !== 'price'">
-                            <InputText v-model="data[field]" autofocus fluid />
+                        <template v-if="field == 'date'">
+                            <DatePicker v-model="data[field]" fluid />
+                        </template>
+                        <template v-else-if="field === 'name'">
+                            <AutoComplete v-model="data[field]" :suggestions="items" @complete="search" fluid />
+                        </template>
+                        <template v-else-if="field === 'price'">
+                            <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
                         </template>
                         <template v-else>
-                            <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
+                            <InputText v-model="data[field]" autofocus fluid />
                         </template>
                     </template>
                 </Column>
@@ -43,9 +49,12 @@ export default {
     data() {
         return {
             products: null,
+            value: '',
+            items: [],
             columns: [
                 { field: 'code', header: 'Code' },
                 { field: 'name', header: 'Name' },
+                { field: 'date', header: 'Last Updated' },
                 { field: 'quantity', header: 'Quantity' },
                 { field: 'price', header: 'Price' }
             ],
@@ -63,14 +72,20 @@ export default {
 >
     <Column v-for="col of columns" :key="col.field" :field="col.field" :header="col.header" style="width: 25%">
         <template #body="{ data, field }">
-            {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
+            {{ field === 'price' ? formatCurrency(data[field]) : field === 'date' ? new Date(data[field]).toDateString() : data[field] }}
         </template>
         <template #editor="{ data, field }">
-            <template v-if="field !== 'price'">
-                <InputText v-model="data[field]" autofocus fluid />
+            <template v-if="field == 'date'">
+                <DatePicker v-model="data[field]" fluid />
+            </template>
+            <template v-else-if="field === 'name'">
+                <AutoComplete v-model="data[field]" :suggestions="items" @complete="search" fluid />
+            </template>
+            <template v-else-if="field === 'price'">
+                <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
             </template>
             <template v-else>
-                <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
+                <InputText v-model="data[field]" autofocus fluid />
             </template>
         </template>
     </Column>
@@ -91,14 +106,20 @@ export default {
         >
             <Column v-for="col of columns" :key="col.field" :field="col.field" :header="col.header" style="width: 25%">
                 <template #body="{ data, field }">
-                    {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
+                    {{ field === 'price' ? formatCurrency(data[field]) : field === 'date' ? new Date(data[field]).toDateString() : data[field] }}
                 </template>
                 <template #editor="{ data, field }">
-                    <template v-if="field !== 'price'">
-                        <InputText v-model="data[field]" autofocus fluid />
+                    <template v-if="field == 'date'">
+                        <DatePicker v-model="data[field]" fluid />
+                    </template>
+                    <template v-else-if="field === 'name'">
+                        <AutoComplete v-model="data[field]" :suggestions="items" @complete="search" fluid />
+                    </template>
+                    <template v-else-if="field === 'price'">
+                        <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
                     </template>
                     <template v-else>
-                        <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
+                        <InputText v-model="data[field]" autofocus fluid />
                     </template>
                 </template>
             </Column>
@@ -177,14 +198,20 @@ export default {
         >
             <Column v-for="col of columns" :key="col.field" :field="col.field" :header="col.header" style="width: 25%">
                 <template #body="{ data, field }">
-                    {{ field === 'price' ? formatCurrency(data[field]) : data[field] }}
+                    {{ field === 'price' ? formatCurrency(data[field]) : field === 'date' ? new Date(data[field]).toDateString() : data[field] }}
                 </template>
                 <template #editor="{ data, field }">
-                    <template v-if="field !== 'price'">
-                        <InputText v-model="data[field]" autofocus fluid />
+                    <template v-if="field == 'date'">
+                        <DatePicker v-model="data[field]" fluid />
+                    </template>
+                    <template v-else-if="field === 'name'">
+                        <AutoComplete v-model="data[field]" :suggestions="items" @complete="search" fluid />
+                    </template>
+                    <template v-else-if="field === 'price'">
+                        <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
                     </template>
                     <template v-else>
-                        <InputNumber v-model="data[field]" mode="currency" currency="USD" locale="en-US" autofocus fluid />
+                        <InputText v-model="data[field]" autofocus fluid />
                     </template>
                 </template>
             </Column>
@@ -266,16 +293,20 @@ const formatCurrency = (value) => {
         loadDemoData() {
             ProductService.getProductsMini().then((data) => (this.products = data));
         },
+        search(event) {
+            this.items = [...Array(10).keys()].map((item) => event.query + '-' + item);
+        },
         onCellEditComplete(event) {
             let { data, newValue, field } = event;
-
             switch (field) {
                 case 'quantity':
+                case 'date':
+                    data[field] = newValue;
+                    break;
                 case 'price':
                     if (this.isPositiveInteger(newValue)) data[field] = newValue;
                     else event.preventDefault();
                     break;
-
                 default:
                     if (newValue.trim().length > 0) data[field] = newValue;
                     else event.preventDefault();

--- a/apps/showcase/service/ProductService.js
+++ b/apps/showcase/service/ProductService.js
@@ -11,7 +11,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 24,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1001',
@@ -23,7 +24,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 61,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1002',
@@ -35,7 +37,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 2,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1003',
@@ -47,7 +50,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 25,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1004',
@@ -59,7 +63,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 73,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1005',
@@ -71,7 +76,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 0,
                 inventoryStatus: 'OUTOFSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1006',
@@ -83,7 +89,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 5,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1007',
@@ -95,7 +102,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 23,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1008',
@@ -107,7 +115,8 @@ export const ProductService = {
                 category: 'Electronics',
                 quantity: 2,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1009',
@@ -119,7 +128,8 @@ export const ProductService = {
                 category: 'Electronics',
                 quantity: 63,
                 inventoryStatus: 'INSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1010',
@@ -131,7 +141,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 0,
                 inventoryStatus: 'OUTOFSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1011',
@@ -143,7 +154,8 @@ export const ProductService = {
                 category: 'Electronics',
                 quantity: 23,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1012',
@@ -155,7 +167,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 74,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1013',
@@ -167,7 +180,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 0,
                 inventoryStatus: 'OUTOFSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1014',
@@ -179,7 +193,8 @@ export const ProductService = {
                 category: 'Electronics',
                 quantity: 8,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1015',
@@ -191,7 +206,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 34,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1016',
@@ -203,7 +219,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 12,
                 inventoryStatus: 'INSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1017',
@@ -215,7 +232,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 42,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1018',
@@ -227,7 +245,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 41,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1019',
@@ -239,7 +258,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 63,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1020',
@@ -251,7 +271,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 0,
                 inventoryStatus: 'OUTOFSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1021',
@@ -263,7 +284,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 6,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1022',
@@ -275,7 +297,8 @@ export const ProductService = {
                 category: 'Accessories',
                 quantity: 62,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1023',
@@ -287,7 +310,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 2,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1024',
@@ -299,7 +323,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 0,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1025',
@@ -311,7 +336,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 52,
                 inventoryStatus: 'INSTOCK',
-                rating: 4
+                rating: 4,
+                date: new Date()
             },
             {
                 id: '1026',
@@ -323,7 +349,8 @@ export const ProductService = {
                 category: 'Clothing',
                 quantity: 3,
                 inventoryStatus: 'LOWSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1027',
@@ -335,7 +362,8 @@ export const ProductService = {
                 category: 'Electronics',
                 quantity: 35,
                 inventoryStatus: 'INSTOCK',
-                rating: 3
+                rating: 3,
+                date: new Date()
             },
             {
                 id: '1028',
@@ -347,7 +375,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 15,
                 inventoryStatus: 'INSTOCK',
-                rating: 5
+                rating: 5,
+                date: new Date()
             },
             {
                 id: '1029',
@@ -359,7 +388,8 @@ export const ProductService = {
                 category: 'Fitness',
                 quantity: 25,
                 inventoryStatus: 'INSTOCK',
-                rating: 8
+                rating: 8,
+                date: new Date()
             }
         ];
     },

--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -310,6 +310,17 @@ export default {
                 this.documentEditListener = (event) => {
                     this.selfClick = this.$el && this.$el.contains(event.target);
 
+                    if (!this.selfClick) {
+                        let overlay = event.target.closest('[data-pc-section="overlay"]');
+                        if (overlay) {
+                            this.selfClick = true;
+                        }
+                        let panel = event.target.closest('[data-pc-section="panel"]');
+                        if (panel) {
+                            this.selfClick = true;
+                        }
+                    }
+
                     if (this.editCompleteTimeout) {
                         clearTimeout(this.editCompleteTimeout);
                     }


### PR DESCRIPTION
###Defect Fixes
There have been a number of reported issues with different overlay/panel/dropdown style components within edit cell mode of a datatable component:

#7710 
#7647 
#7598 

The problem looks to be the determination of a click event being part of the datatable element or not. Overlays of child components don't end up being contained by the datatable element and thus are treated like an "outside click event" which "closes edit mode" instead of accepting the event as an updated value.

This PR includes a applied fix that looks up overlay and panel elements that may be open on the page when determining if this is a selfClick as part of the BodyCell.vue component. This is looking for closest elements with attributes data-pc-section="overlay" and data-pc-section="panel"

Updated EditCell Doc component to include an AutoComplete as well as a DatePicker for easy confirmation of functionality:
![DataTableEditCell_Docs](https://github.com/user-attachments/assets/0916a042-3beb-483d-88e1-8194939a86b8)


