### PR TITLE
Fix  #7735

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.spec.js
+++ b/packages/primevue/src/inputnumber/InputNumber.spec.js
@@ -18,24 +18,40 @@ describe('InputNumber.vue', () => {
     });
 
     it('is keydown called when down and up keys pressed', async () => {
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowUp', target: { value: 1 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowUp',
+            target: { value: 1 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([2]);
 
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowDown', target: { value: 2 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowDown',
+            target: { value: 2 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][1]).toEqual([1]);
     });
 
     it('is keydown called when tab key pressed', async () => {
-        await wrapper.vm.onInputKeyDown({ code: 'Tab', target: { value: '12' }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'Tab',
+            target: { value: '12' },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([12]);
         expect(wrapper.find('input.p-inputnumber-input').attributes()['aria-valuenow']).toBe('12');
     });
 
     it('is keydown called when enter key pressed', async () => {
-        await wrapper.vm.onInputKeyDown({ code: 'Enter', target: { value: '12' }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'Enter',
+            target: { value: '12' },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([12]);
         expect(wrapper.find('input.p-inputnumber-input').attributes()['aria-valuenow']).toBe('12');
@@ -44,7 +60,10 @@ describe('InputNumber.vue', () => {
     it('is keypress called when pressed a number', async () => {
         wrapper.find('input.p-inputnumber-input').element.setSelectionRange(2, 2);
 
-        await wrapper.vm.onInputKeyPress({ key: '1', preventDefault: () => {} });
+        await wrapper.vm.onInputKeyPress({
+            key: '1',
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted().input[0][0].value).toBe(11);
     });
@@ -52,7 +71,10 @@ describe('InputNumber.vue', () => {
     it('is keypress called when pressed minus', async () => {
         wrapper.find('input.p-inputnumber-input').element.setSelectionRange(0, 0);
 
-        await wrapper.vm.onInputKeyPress({ key: '-', preventDefault: () => {} });
+        await wrapper.vm.onInputKeyPress({
+            key: '-',
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted().input[0][0].value).toBe(-1);
     });
@@ -60,11 +82,19 @@ describe('InputNumber.vue', () => {
     it('should have min boundary', async () => {
         await wrapper.setProps({ modelValue: 95, min: 95 });
 
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowDown', target: { value: 96 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowDown',
+            target: { value: 96 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([95]);
 
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowDown', target: { value: 95 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowDown',
+            target: { value: 95 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][1]).toEqual([95]);
     });
@@ -72,11 +102,19 @@ describe('InputNumber.vue', () => {
     it('should have max boundary', async () => {
         await wrapper.setProps({ modelValue: 99, max: 100 });
 
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowUp', target: { value: 99 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowUp',
+            target: { value: 99 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][0]).toEqual([100]);
 
-        await wrapper.vm.onInputKeyDown({ code: 'ArrowUp', target: { value: 100 }, preventDefault: () => {} });
+        await wrapper.vm.onInputKeyDown({
+            code: 'ArrowUp',
+            target: { value: 100 },
+            preventDefault: () => {}
+        });
 
         expect(wrapper.emitted()['update:modelValue'][1]).toEqual([100]);
     });
@@ -91,5 +129,43 @@ describe('InputNumber.vue', () => {
         await wrapper.setProps({ modelValue: 20, prefix: '%' });
 
         expect(wrapper.find('input.p-inputnumber-input').element._value).toBe('%20');
+    });
+
+    it('should emit correct events when user types a value', async () => {
+        await wrapper.setProps({ modelValue: 1980 });
+        const input = await wrapper.find('input.p-inputnumber-input');
+
+        input.trigger('keydown', { key: 'Backspace' });
+        expect(wrapper.emitted()['update:modelValue'][0]).toEqual([198]);
+        expect(wrapper.emitted()['value-change'][0]).toEqual([198]);
+        expect(wrapper.emitted().input[0]).toEqual([expect.objectContaining({ value: 198, formattedValue: '1,980' })]);
+        expect(input.element.value).toBe('198');
+
+        input.trigger('keypress', { key: '5' });
+        expect(wrapper.emitted()['update:modelValue'][1]).toEqual([1985]);
+        expect(wrapper.emitted()['value-change'][1]).toEqual([1985]);
+        expect(wrapper.emitted().input[1]).toEqual([expect.objectContaining({ value: 1985, formattedValue: '198' })]);
+        expect(input.element.value).toBe('1,985');
+    });
+
+    it('should only emit one of each event type when typing values', async () => {
+        await wrapper.setProps({ modelValue: 1234 });
+        const input = await wrapper.find('input.p-inputnumber-input');
+
+        expect(input.element.value).toBe('1,234');
+
+        input.trigger('keydown', { key: 'Backspace' });
+
+        expect(wrapper.emitted()['update:modelValue'].length).toBe(1);
+        expect(wrapper.emitted()['value-change'].length).toBe(1);
+        expect(wrapper.emitted().input.length).toBe(1);
+
+        input.trigger('keypress', { key: '5' });
+
+        expect(wrapper.emitted()['update:modelValue'].length).toBe(2);
+        expect(wrapper.emitted()['value-change'].length).toBe(2);
+        expect(wrapper.emitted().input.length).toBe(2);
+
+        expect(input.element.value).toBe('1,235');
     });
 });

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -801,6 +801,7 @@ export default {
                 newValue = this.parseValue(valueStr);
                 newValue = !newValue && !this.allowEmpty ? this.min || 0 : newValue;
                 this.updateInput(newValue, insertedValueStr, operation, valueStr);
+                this.updateModel(event, newValue);
 
                 this.handleOnInput(event, currentValue, newValue);
             }


### PR DESCRIPTION
###Defect Fixes #7735 

The internal model wasn't being set when a user typed a numeric value and therefore was out of sync with the value of the HTML input field.

This caused an inconsistent experience with the InputText field. It also meant it was impossible to reliably monitor live input when the user typed numbers.

I also created a couple of tests around this bug.

