### PR TITLE
Fix (toggleswitch): respect controlled state modelValue change

### DIFF
--- a/packages/primevue/src/toggleswitch/ToggleSwitch.vue
+++ b/packages/primevue/src/toggleswitch/ToggleSwitch.vue
@@ -65,7 +65,8 @@ export default {
     },
     computed: {
         checked() {
-            return this.d_value === this.trueValue;
+            const value = this.controlled ? this.modelValue : this.d_value;
+            return value === this.trueValue;
         },
         dataP() {
             return cn({


### PR DESCRIPTION
Fix ToggleSwitch. Respecting controlled state `modelValue`, so the switch visual always in sync with controlled model. (Resolve #6961 )