### PR TITLE
FileUpload: If the image preview does not load then remove it

### DIFF
--- a/packages/primevue/src/fileupload/FileContent.vue
+++ b/packages/primevue/src/fileupload/FileContent.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-for="(file, index) of files" :key="file.name + file.type + file.size" :class="cx('file')" v-bind="ptm('file')">
-        <img role="presentation" :class="cx('fileThumbnail')" :alt="file.name" :src="file.objectURL" :width="previewWidth" v-bind="ptm('fileThumbnail')" />
+        <img role="presentation" :class="cx('fileThumbnail')" :alt="file.name" :src="file.objectURL" :width="previewWidth" onerror="this.remove()" v-bind="ptm('fileThumbnail')" />
         <div :class="cx('fileInfo')" v-bind="ptm('fileInfo')">
             <div :class="cx('fileName')" v-bind="ptm('fileName')">{{ file.name }}</div>
             <span :class="cx('fileSize')" v-bind="ptm('fileSize')">{{ formatSize(file.size) }}</span>


### PR DESCRIPTION
Relevant issues:

#3367
#5625

Here is a before and after comparison:

Before:

<img width="401" alt="Before" src="https://github.com/user-attachments/assets/18b65837-8218-4fe8-aee2-1afde8e9b5e4" />

After:

<img width="401" alt="After" src="https://github.com/user-attachments/assets/9f374c5f-ef50-4a46-87f4-5e6060d99e00" />