### PR TITLE
Fix: Allow the use of MenuItem in MenuProps.model

### DIFF
--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -195,7 +195,7 @@ export interface MenuProps {
     /**
      * An array of menuitems.
      */
-    model?: MenuItem[] | undefined;
+    model?: MenuItem | MenuItem[] | undefined;
     /**
      * Defines if menu would displayed as a popup.
      * @defaultValue false


### PR DESCRIPTION
Allow the use of MenuItem in MenuProps.model