### PR TITLE
Accept readonly options in Select

### DIFF
--- a/packages/primevue/src/select/Select.d.ts
+++ b/packages/primevue/src/select/Select.d.ts
@@ -306,7 +306,7 @@ export interface SelectProps {
     /**
      * An array of select items to display as the available options.
      */
-    options?: any[];
+    options?: readonly any[];
     /**
      * Property name or getter function to use as the label of an option.
      */


### PR DESCRIPTION
The `Select` component in typescript currently accepts only modifiable arrays as the `options` prop. This doesn't have to be the case though, since the `Select` implementation (to my knowledge) doesn't seem to modify the array in any way.

Add `readonly` to the typescript type.

This supports a use-case of having the options being a const array. Consider the input being a readonly array of defined countries that you want to let the user select from.

This PR is very similar to #7803, but for `Select` instead of `DataTable`. 

---
I would like to create an issue for this PR and link them together, but I don't think that I'm able to provide half of the required fields in order to create the issue, since this is technically not a bug, doesn't have a reproducer, and only touches typescript.
