### PR TITLE
fix: allow dialog to close on escape when closable is false 

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -326,7 +326,7 @@ export default {
                 this.bindDocumentDragEndListener();
             }
 
-            if (this.closeOnEscape && this.closable) {
+            if (this.closeOnEscape) {
                 this.bindDocumentKeyDownListener();
             }
         },


### PR DESCRIPTION
Fixes #7867 