### PR TITLE
Defect Fix: DataTable Cell Edit Issue with Overlay Components

### DIFF
--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -308,7 +308,13 @@ export default {
         bindDocumentEditListener() {
             if (!this.documentEditListener) {
                 this.documentEditListener = (event) => {
-                    this.selfClick = this.$el && this.$el.contains(event.target);
+                    const isClickInsideOverlay = event.target.closest('.p-datepicker-panel') || event.target.closest('.p-autocomplete-overlay') || event.target.closest('.p-select-overlay');
+
+                    if (isClickInsideOverlay) {
+                        this.selfClick = true;
+                    } else {
+                        this.selfClick = this.$el && this.$el.contains(event.target);
+                    }
 
                     if (this.editCompleteTimeout) {
                         clearTimeout(this.editCompleteTimeout);


### PR DESCRIPTION
**Related Issues:** #7710 #7520 

This Pull Request addresses a defect in the PrimeVue DataTable component, specifically when using cell edit mode with overlay-based components such as DatePicker, AutoComplete, and Select. The issue, as reported in #7520 and #7710, manifests as the cell editor prematurely closing when a user interacts with the overlay of these components. This prevents the selected value from being properly saved, leading to a frustrating user experience and data loss.

**Proposed Solution**
I'm not sure if that's the best solution, but maybe it can help on fixing the issue.
To rectify this behavior, the bindDocumentEditListener method has been enhanced to explicitly account for clicks originating from the overlays of DatePicker, AutoComplete, and Select components. The solution involves modifying the selfClick determination logic to include checks for the specific CSS classes associated with these component overlays.

**Changes Made:**
The bindDocumentEditListener in node_modules/primevue/datatable/BodyCell.vue has been updated as follows:

```javascript
bindDocumentEditListener() {
    if (!this.documentEditListener) {
        this.documentEditListener = (event) => {
            const isClickInsideOverlay = event.target.closest(".p-datepicker-panel") || event.target.closest(".p-autocomplete-overlay") || event.target.closest(".p-select-overlay");

            if (isClickInsideOverlay) {
                this.selfClick = true; // Treat clicks inside overlays as self clicks
            } else {
                this.selfClick = this.$el && this.$el.contains(event.target);
            }

            if (this.editCompleteTimeout) {
                clearTimeout(this.editCompleteTimeout);
            }

            if (!this.selfClick) {
                this.editCompleteTimeout = setTimeout(() => {
                    this.completeEdit(event, 'outside');
                }, 1);
            }
        };

        document.addEventListener('mousedown', this.documentEditListener);
    }
},
``` 

**Testing**

This solution has been tested locally by linking the modified PrimeVue source to a sample application. The tests confirm that:
• Interacting with the DatePicker calendar overlay no longer closes the cell editor.
• Selecting an option from the AutoComplete suggestion list no longer closes the cell editor.
• Choosing an item from the Select dropdown no longer closes the cell editor.
• The selected values from these components are correctly passed to the cell-edit-complete callback.
• The general cell edit functionality for other input types remains unaffected.

While I'm not entirely sure if this is the ideal solution, I hope it can serve as a good starting point to resolve issue #7520 and #7710. 
I'm available to collaborate on any further refinements, thanks!