### PR TITLE
feat: add emptyCompleteOnFocus prop to AutoComplete component

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.d.ts
+++ b/packages/primevue/src/autocomplete/AutoComplete.d.ts
@@ -429,6 +429,11 @@ export interface AutoCompleteProps {
      */
     completeOnFocus?: boolean | undefined;
     /**
+     * Whether to run the completeOnFocus query with an empty value when input receives focus.
+     * @defaultValue false
+     */
+    emptyCompleteOnFocus?: boolean | undefined;
+    /**
      * Identifier of the underlying input element.
      */
     inputId?: string | undefined;

--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -348,7 +348,8 @@ export default {
             }
 
             if (!this.dirty && this.completeOnFocus) {
-                this.search(event, event.target.value, 'focus');
+                const searchValue = this.emptyCompleteOnFocus ? '' : event.target.value;
+                this.search(event, searchValue, 'focus');
             }
 
             this.dirty = true;

--- a/packages/primevue/src/autocomplete/BaseAutoComplete.vue
+++ b/packages/primevue/src/autocomplete/BaseAutoComplete.vue
@@ -62,6 +62,10 @@ export default {
             type: Boolean,
             default: false
         },
+        emptyCompleteOnFocus: {
+            type: Boolean,
+            default: false
+        },
         inputId: {
             type: String,
             default: null


### PR DESCRIPTION
Adds a new Boolean prop emptyCompleteOnFocus to <AutoComplete>:

- When emptyCompleteOnFocus = true *and* completeOnFocus = true, the component will open with the *full* list of suggestions on focus, regardless of the current input value.
- When false (default), it retains the existing behavior of filtering by event.target.value.

### 🛠️ Implementation details

- Declared the new prop in src/autocomplete/AutoComplete.vue.
- Adjusted the onFocus() handler to pass '' instead of event.target.value when emptyCompleteOnFocus is true.
- Updated TypeScript definitions (index.d.ts).