### PR TITLE
fix(MultiSelect): prevent toggling disabled option when using toggle all

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.spec.js
+++ b/packages/primevue/src/multiselect/MultiSelect.spec.js
@@ -213,4 +213,62 @@ describe('MultiSelect.vue', () => {
             expect(wrapper.find('.p-multiselect-option-group').text()).toBe('Germany');
         });
     });
+
+    describe('disabled options', () => {
+        it('should not select disabled options when toggle all is clicked', async () => {
+            await wrapper.setProps({
+                modelValue: ['NY', 'RM'],
+                options: [
+                    { name: 'New York', code: 'NY', disabled: true },
+                    { name: 'Rome', code: 'RM' },
+                    { name: 'London', code: 'LDN', disabled: true },
+                    { name: 'Istanbul', code: 'IST' },
+                    { name: 'Paris', code: 'PRS', disabled: true }
+                ],
+                optionValue: 'code',
+                optionDisabled: 'disabled',
+                showToggleAll: true
+            });
+
+            await wrapper.vm.onToggleAll({});
+
+            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([['NY', 'RM', 'IST']]);
+
+            await wrapper.vm.$refs.container.click();
+
+            expect(wrapper.findAll('li.p-multiselect-option')[0].attributes()['data-p-selected']).toBe('true');
+            expect(wrapper.findAll('li.p-multiselect-option')[1].attributes()['data-p-selected']).toBe('true');
+            expect(wrapper.findAll('li.p-multiselect-option')[2].attributes()['data-p-selected']).toBe('false');
+            expect(wrapper.findAll('li.p-multiselect-option')[3].attributes()['data-p-selected']).toBe('true');
+            expect(wrapper.findAll('li.p-multiselect-option')[4].attributes()['data-p-selected']).toBe('false');
+        });
+
+        it('should not unselect disabled options when toggle all is clicked', async () => {
+            await wrapper.setProps({
+                modelValue: ['NY', 'RM', 'IST'],
+                options: [
+                    { name: 'New York', code: 'NY', disabled: true },
+                    { name: 'Rome', code: 'RM' },
+                    { name: 'London', code: 'LDN', disabled: true },
+                    { name: 'Istanbul', code: 'IST' },
+                    { name: 'Paris', code: 'PRS', disabled: true }
+                ],
+                optionValue: 'code',
+                optionDisabled: 'disabled',
+                showToggleAll: true
+            });
+
+            await wrapper.vm.onToggleAll({});
+
+            expect(wrapper.emitted()['update:modelValue'][0]).toEqual([['NY']]);
+
+            await wrapper.vm.$refs.container.click();
+
+            expect(wrapper.findAll('li.p-multiselect-option')[0].attributes()['data-p-selected']).toBe('true');
+            expect(wrapper.findAll('li.p-multiselect-option')[1].attributes()['data-p-selected']).toBe('false');
+            expect(wrapper.findAll('li.p-multiselect-option')[2].attributes()['data-p-selected']).toBe('false');
+            expect(wrapper.findAll('li.p-multiselect-option')[3].attributes()['data-p-selected']).toBe('false');
+            expect(wrapper.findAll('li.p-multiselect-option')[4].attributes()['data-p-selected']).toBe('false');
+        });
+    });
 });

--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -848,7 +848,9 @@ export default {
             if (this.selectAll !== null) {
                 this.$emit('selectall-change', { originalEvent: event, checked: !this.allSelected });
             } else {
-                const value = this.allSelected ? [] : this.visibleOptions.filter((option) => this.isValidOption(option)).map((option) => this.getOptionValue(option));
+                const value = this.allSelected
+                    ? this.visibleOptions.filter((option) => this.isDisabledSelectedOption(option)).map((option) => this.getOptionValue(option))
+                    : this.visibleOptions.filter((option) => this.isValidOption(option) || this.isDisabledSelectedOption(option)).map((option) => this.getOptionValue(option));
 
                 this.updateModel(event, value);
             }
@@ -873,6 +875,9 @@ export default {
         },
         isValidSelectedOption(option) {
             return this.isValidOption(option) && this.isSelected(option);
+        },
+        isDisabledSelectedOption(option) {
+            return this.isOptionDisabled(option) && this.isSelected(option);
         },
         isEquals(value1, value2) {
             return equals(value1, value2, this.equalityKey);


### PR DESCRIPTION
**Related issue:** https://github.com/primefaces/primevue/issues/7881

**Context**

This PR intends to fix disabled options being updated when using the "toggle all" checkbox from the MultiSelect component.

**Proposed solution**

When `onToggleAll` event occurs, we should always include the disabled options when updating the modelValue, either when selecting all or unselecting all.

**Testing**

I've added some unit tests using the existing code structure as much as possible :heart: 

**Additional notes**

I noticed there is no documentation about disabled options in the current MultiSelect docs, I'd be happy to add some in the **Disabled** section if needed.