### PR TITLE
Fix: Datepicker manualInput not working as expected

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1811,6 +1811,23 @@ export default {
 
             return isValid;
         },
+        updateWithInputValue() {
+            try {
+                let value = this.parseValue(this.inputValue);
+                if (this.isValidSelection(value)) {
+                    this.typeUpdate = true;
+                    this.updateModel(value);
+                    this.updateCurrentMetaData();
+                }
+
+                if (this.isValidSelection(value)) {
+                    this.overlayVisible = false;
+                }
+                this.inputValue = null;
+            } catch (err) {
+                /* NoOp */
+            }
+        },
         parseValue(text) {
             if (!text || text.trim().length === 0) {
                 return null;
@@ -2704,7 +2721,12 @@ export default {
             this.formField.onBlur?.();
 
             this.focused = false;
-            event.target.value = this.formatValue(this.d_value);
+
+            if (this.manualInput && this.inputValue && this.inputValue.trim() !== '') {
+                this.updateWithInputValue();
+            } else {
+                event.target.value = this.formatValue(this.d_value);
+            }
         },
         onKeyDown(event) {
             if (event.code === 'ArrowDown' && this.overlay) {
@@ -2726,21 +2748,8 @@ export default {
                     this.overlayVisible = false;
                 }
             } else if (event.code === 'Enter') {
-                if (this.manualInput && this.inputValue.trim() !== '') {
-                    try {
-                        let value = this.parseValue(this.inputValue);
-                        if (this.isValidSelection(value)) {
-                            this.typeUpdate = true;
-                            this.updateModel(value);
-                            this.updateCurrentMetaData();
-                        }
-
-                        if (this.isValidSelection(value)) {
-                            this.overlayVisible = false;
-                        }
-                    } catch (err) {
-                        /* NoOp */
-                    }
+                if (this.manualInput && this.inputValue && this.inputValue.trim() !== '') {
+                    this.updateWithInputValue();
                 }
 
                 this.$emit('keydown', event);

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2670,17 +2670,20 @@ export default {
                 this.selectionStart = this.input.selectionStart;
                 this.selectionEnd = this.input.selectionEnd;
 
-                let value = this.parseValue(event.target.value);
+                if (this.manualInput) {
+                    this.inputValue = event.target.value;
+                } else {
+                    let value = this.parseValue(event.target.value);
 
-                if (this.isValidSelection(value)) {
-                    this.typeUpdate = true;
-                    this.updateModel(value);
-                    this.updateCurrentMetaData();
+                    if (this.isValidSelection(value)) {
+                        this.typeUpdate = true;
+                        this.updateModel(value);
+                        this.updateCurrentMetaData();
+                    }
                 }
             } catch (err) {
                 /* NoOp */
             }
-
             this.$emit('input', event);
         },
         onInputClick() {
@@ -2723,9 +2726,14 @@ export default {
                     this.overlayVisible = false;
                 }
             } else if (event.code === 'Enter') {
-                if (this.manualInput && event.target.value !== null && event.target.value?.trim() !== '') {
+                if (this.manualInput && this.inputValue.trim() !== '') {
                     try {
-                        let value = this.parseValue(event.target.value);
+                        let value = this.parseValue(this.inputValue);
+                        if (this.isValidSelection(value)) {
+                            this.typeUpdate = true;
+                            this.updateModel(value);
+                            this.updateCurrentMetaData();
+                        }
 
                         if (this.isValidSelection(value)) {
                             this.overlayVisible = false;


### PR DESCRIPTION
Fixes #7886

The problem is that a value is automatically updating the `modelValue` by `onInput()` meaning that only on keystroke at a time can be added before the `modelValue` is updated. In the case of dates this makes it so that each digit of an attempted two-digit edit will be added to the date causing it to pad it with a zero.

Fixed by storing value ` onInput `and delaying the submission and update of `modelValue` on enter pressed or `onBlur()`