### PR TITLE
Made InputIcon aria-hidden

### DIFF
--- a/packages/primevue/src/inputicon/InputIcon.vue
+++ b/packages/primevue/src/inputicon/InputIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <span :class="containerClass" v-bind="ptmi('root')">
+    <span :class="containerClass" v-bind="ptmi('root')" aria-hidden="true">
         <slot />
     </span>
 </template>


### PR DESCRIPTION
InputIcon will be read by screenreaders but that shouldn't be by default.
