### PR TITLE
fix: pass index to child TreeNodes

### DIFF
--- a/packages/primevue/src/tree/TreeNode.vue
+++ b/packages/primevue/src/tree/TreeNode.vue
@@ -52,11 +52,12 @@
         </div>
         <ul v-if="hasChildren && expanded" :class="cx('nodeChildren')" role="group" v-bind="ptm('nodeChildren')">
             <TreeNode
-                v-for="childNode of node.children"
+                v-for="(childNode, index) of node.children"
                 :key="childNode.key"
                 :node="childNode"
                 :templates="templates"
                 :level="level + 1"
+                :index="index"
                 :loadingMode="loadingMode"
                 :expandedKeys="expandedKeys"
                 @node-toggle="onChildNodeToggle"


### PR DESCRIPTION
Fixes #7905 
Fixes #7899 

The `TreeNode` component did not pass the `index` value to child nodes leading to accessibility issues with the `aria-posinset` value being set to the default value (i.e., `NaN`). 

This change passes the `index` value to child nodes in the `TreeNode` component such that the `aria-posinset` value is set correctly. 