### PR TITLE
fix(MutliSelect): update model to empty array on clear click

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -476,7 +476,7 @@ export default {
             this.clicked = true;
         },
         onClearClick(event) {
-            this.updateModel(event, null);
+            this.updateModel(event, []);
             this.resetFilterOnClear && (this.filterValue = null);
         },
         onFirstHiddenFocus(event) {


### PR DESCRIPTION
Makes the modelValue set to an empty array instead of null when the clear icon is pressed.

This now follows the same logic that happens when you toggle the checkbox at the top to select/deselect all