### PR TITLE
Fix(ColumnHeader): pass `filterInputProps` & `filterButtonProps` to HeaderCell

### DIFF
--- a/packages/primevue/src/datatable/TableHeader.vue
+++ b/packages/primevue/src/datatable/TableHeader.vue
@@ -71,6 +71,8 @@
                         :filters="filters"
                         :filterDisplay="filterDisplay"
                         :filtersStore="filtersStore"
+                        :filterInputProps="filterInputProps"
+                        :filterButtonProps="filterButtonProps"
                         @filter-change="$emit('filter-change', $event)"
                         @filter-apply="$emit('filter-apply')"
                         @operator-change="$emit('operator-change', $event)"


### PR DESCRIPTION
### Defect Fixes

Fixes https://github.com/primefaces/primevue/issues/6313 (Thanks @DrumsnChocolate)

This PR fixes an issue regarding the reading of undefined filters in `ColumnGroup.vue`. When passing the initial `headerFilterButtonProps` to `TableHeader.vue`, the second occurrence of `DTHeaderCell` misses `filterButtonProps` and `filterInputProps`.
