### PR TITLE
add possibility of number array to slider events values

### DIFF
--- a/packages/primevue/src/slider/Slider.d.ts
+++ b/packages/primevue/src/slider/Slider.d.ts
@@ -90,7 +90,7 @@ export interface SliderSlideEndEvent {
     /**
      * New value.
      */
-    value: number;
+    value: number | number[];
 }
 
 /**
@@ -202,9 +202,9 @@ export interface SliderEmitsOptions {
     'value-change'(value: number | number[]): void;
     /**
      * Callback to invoke on value change.
-     * @param {number} value - New value
+     * @param {number | number[]} value - New value
      */
-    change(value: number): void;
+    change(value: number | number[]): void;
     /**
      * Callback to invoke when slide ends.
      * @param {SliderSlideEndEvent} event - Custom slide end event.


### PR DESCRIPTION
Error in type of the slider event prevents using event type with a slider that has a start and end value.
Type can currently be set to any to circumvent, but that's against the point of using TypeScript.
Adding `| number[]` fixes that.