### PR TITLE
fix: show value even if it's not found in options and fix clear button visibility

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -1020,8 +1020,11 @@ export default {
         },
         label() {
             const selectedOptionIndex = this.findSelectedOptionIndex();
+            if (!this.$filled) {
+                return this.placeholder || 'p-emptylabel';
+            }
 
-            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions[selectedOptionIndex]) : this.getOptionLabel(this.d_value);
         },
         editableInputValue() {
             const selectedOptionIndex = this.findSelectedOptionIndex();
@@ -1062,7 +1065,7 @@ export default {
             return this.visibleOptions.filter((option) => !this.isOptionGroup(option)).length;
         },
         isClearIconVisible() {
-            return this.showClear && this.d_value != null && isNotEmpty(this.options);
+            return this.showClear && this.d_value != null;
         },
         virtualScrollerDisabled() {
             return !this.virtualScrollerOptions;


### PR DESCRIPTION
Fix the default value template of the Select component and clear button visibility.
Currently, if the selected value is not found in the options the Select component looks like nothing is selected (it shows a placeholder or is just empty). This doesn't reflect the actual state of the component - it actually has a selected value.
Currently, the visibility of the clear button depends on the length of the option list. It shouldn't.

Connected bug: https://github.com/primefaces/primevue/issues/7833
I checked the issue with version 4.3.6. It still exists. I updated the reproducer mentioned in the connected bug:
https://stackblitz.com/edit/primevue-4-vite-issue-template-bpkmlmzt?file=src%2FApp.vue