### PR TITLE
Make sure overlayVisible check only applies for non inline color picker

### DIFF
--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -343,7 +343,7 @@ export default {
                 hsb = this.HEXtoHSB(this.defaultColor);
             }
 
-            if (this.localHue == null || !this.overlayVisible) {
+            if (this.localHue == null || (!this.overlayVisible && !this.inline)) {
                 this.localHue = hsb.h;
             } else {
                 hsb.h = this.localHue;


### PR DESCRIPTION
### Defect Fixes

Fix https://github.com/primefaces/primevue/issues/7933

Solving issue where previous PR 7511 is looking at overlayVisible, however this will always be false if inline.

To recreate bug:
In apps/showcase/doc/colorpicker/InlineDoc.vue
add 
`<div :style="{ backgroundColor: `#${color}` }">{{ color }}</div>`
And check that i gets wrong color selections by dragging selection to left and then back to middle.
