### PR TITLE
fix(datatable): make headercheckboxicon work again

### DIFF
--- a/packages/primevue/src/datatable/DataTable.spec.js
+++ b/packages/primevue/src/datatable/DataTable.spec.js
@@ -1439,4 +1439,68 @@ describe('DataTable.vue', () => {
     // contextmenu
 
     // row styling
+    it('should render custom headercheckboxicon slot in Column', () => {
+        wrapper = mount(DataTable, {
+            global: {
+                plugins: [PrimeVue],
+                components: {
+                    Column
+                }
+            },
+            props: {
+                value: smallData,
+                selection: null
+            },
+            slots: {
+                default: `
+                    <Column selectionMode="multiple">
+                        <template #headercheckboxicon>
+                            <span class="custom-header-checkbox-icon">CustomIcon</span>
+                        </template>
+                    </Column>
+                    <Column field="code" header="Code"></Column>
+                    <Column field="name" header="Name"></Column>
+                `
+            }
+        });
+
+        const headerCheckboxIcon = wrapper.find('.custom-header-checkbox-icon');
+
+        expect(headerCheckboxIcon.exists()).toBe(true);
+        expect(headerCheckboxIcon.text()).toBe('CustomIcon');
+    });
+
+    it('should render custom rowcheckboxicon slot in Column', () => {
+        wrapper = mount(DataTable, {
+            global: {
+                plugins: [PrimeVue],
+                components: {
+                    Column
+                }
+            },
+            props: {
+                value: smallData,
+                selection: null
+            },
+            slots: {
+                default: `
+                    <Column selectionMode="multiple">
+                        <template #rowcheckboxicon>
+                            <span class="custom-row-checkbox-icon">CustomIcon</span>
+                        </template>
+                    </Column>
+                    <Column field="code" header="Code"></Column>
+                    <Column field="name" header="Name"></Column>
+                `
+            }
+        });
+
+        // custom-row-checkbox-icon should be rendered in each row, so 3 times
+        const rowCheckboxIcons = wrapper.findAll('.custom-row-checkbox-icon');
+
+        expect(rowCheckboxIcons.length).toBe(3);
+        expect(rowCheckboxIcons[0].text()).toBe('CustomIcon');
+        expect(rowCheckboxIcons[1].text()).toBe('CustomIcon');
+        expect(rowCheckboxIcons[2].text()).toBe('CustomIcon');
+    });
 });

--- a/packages/primevue/src/datatable/HeaderCheckbox.vue
+++ b/packages/primevue/src/datatable/HeaderCheckbox.vue
@@ -1,9 +1,9 @@
 <template>
     <Checkbox :modelValue="checked" :binary="true" :disabled="disabled" :aria-label="headerCheckboxAriaLabel" @change="onChange" :unstyled="unstyled" :pt="getColumnPT('pcHeaderCheckbox')">
-        <!--<template #icon="slotProps">
+        <template #icon="slotProps">
             <component v-if="headerCheckboxIconTemplate" :is="headerCheckboxIconTemplate" :checked="slotProps.checked" :class="slotProps.class" />
             <CheckIcon v-else-if="!headerCheckboxIconTemplate && slotProps.checked" :class="slotProps.class" v-bind="getColumnPT('pcHeaderCheckbox')['icon']" />
-        </template>-->
+        </template>
     </Checkbox>
 </template>
 


### PR DESCRIPTION
### Defect Fixes

There were commented out lines in the HeaderCheckbox component's template that prevented the rendering of the content of the `headercheckboxicon` slot of the `Column` component. Uncommented those lines and added test cases to check that this slot is rendered correctly (and the `rowcheckboxicon` slot as well).