### PR TITLE
Made up and down propagation optional for TreeSelect

### DIFF
--- a/packages/primevue/scripts/components/tree.js
+++ b/packages/primevue/scripts/components/tree.js
@@ -73,6 +73,18 @@ const TreeProps = [
         description: "Locale to use in filtering. The default locale is the host environment's current locale."
     },
     {
+      name: 'propagateSelectionDown',
+      type: 'boolean',
+      default: 'true',
+      description: 'Whether checkbox selections propagate to descendant nodes.'
+    },
+    {
+        name: 'propagateSelectionUp',
+        type: 'boolean',
+        default: 'true',
+        description: 'Whether checkbox selections propagate to ancestor nodes.'
+    },
+    {
         name: 'highlightOnSelect',
         type: 'boolean',
         default: 'false',

--- a/packages/primevue/scripts/components/treeselect.js
+++ b/packages/primevue/scripts/components/treeselect.js
@@ -90,6 +90,18 @@ const TreeSelectProps = [
         description: 'Text to display when there are no options available. Defaults to value from PrimeVue locale configuration.'
     },
     {
+        name: 'propagateSelectionDown',
+        type: 'boolean',
+        default: 'true',
+        description: 'Whether checkbox selections propagate to descendant nodes.'
+    },
+    {
+        name: 'propagateSelectionUp',
+        type: 'boolean',
+        default: 'true',
+        description: 'Whether checkbox selections propagate to ancestor nodes.'
+    },
+    {
         name: 'display',
         type: 'string',
         default: 'comma',

--- a/packages/primevue/src/tree/BaseTree.vue
+++ b/packages/primevue/src/tree/BaseTree.vue
@@ -77,6 +77,14 @@ export default {
         ariaLabel: {
             type: String,
             default: null
+        },
+        propagateDownSelection: {
+            type: Boolean,
+            default: true
+        },
+        propagateUpSelection: {
+            type: Boolean,
+            default: true
         }
     },
     style: TreeStyle,

--- a/packages/primevue/src/tree/Tree.d.ts
+++ b/packages/primevue/src/tree/Tree.d.ts
@@ -304,6 +304,14 @@ export interface TreeProps {
      */
     filterLocale?: string | undefined;
     /**
+     * Whether checkbox selections propagate to descendant nodes.
+     */
+    propagateSelectionDown?: boolean | true;
+    /**
+     * Whether checkbox selections propagate to ancestor nodes.
+     */
+    propagateSelectionUp?: boolean | true;
+    /**
      *  Highlights automatically the first item.
      *  @defaultValue false
      */

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -36,6 +36,8 @@
                     :loadingMode="loadingMode"
                     :unstyled="unstyled"
                     :pt="pt"
+                    :propagate-down-selection="propagateDownSelection"
+                    :propagate-up-selection="propagateUpSelection"
                 ></TreeNode>
             </ul>
             <slot name="footer" :value="value" :expandedKeys="expandedKeys" :selectionKeys="selectionKeys" />

--- a/packages/primevue/src/treeselect/BaseTreeSelect.vue
+++ b/packages/primevue/src/treeselect/BaseTreeSelect.vue
@@ -122,6 +122,14 @@ export default {
         expandedKeys: {
             type: null,
             default: null
+        },
+        propagateDownSelection: {
+            type: Boolean,
+            default: true
+        },
+        propagateUpSelection: {
+            type: Boolean,
+            default: true
         }
     },
     style: TreeSelectStyle,

--- a/packages/primevue/src/treeselect/TreeSelect.d.ts
+++ b/packages/primevue/src/treeselect/TreeSelect.d.ts
@@ -284,6 +284,14 @@ export interface TreeSelectProps {
      */
     emptyMessage?: string | undefined;
     /**
+     * Whether checkbox selections propagate to descendant nodes.
+     */
+    propagateSelectionDown?: boolean | true;
+    /**
+     * Whether checkbox selections propagate to ancestor nodes.
+     */
+    propagateSelectionUp?: boolean | true;
+    /**
      * Label to display when there are no selections.
      */
     placeholder?: string | undefined;

--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -92,6 +92,8 @@
                             :level="0"
                             :unstyled="unstyled"
                             :pt="ptm('pcTree')"
+                            :propagate-down-selection="propagateDownSelection"
+                            :propagate-up-selection="propagateUpSelection"
                         >
                             <template v-if="$slots.option" #default="optionSlotProps">
                                 <slot name="option" :node="optionSlotProps.node" :expanded="optionSlotProps.expanded" :selected="optionSlotProps.selected" />


### PR DESCRIPTION
Unlike PrimeNG, PrimeVue does not have an optional prop to disable/enable up and down propagation for the TreeSelect Component
