### PR TITLE
Fix expand button aria label

### DIFF
--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -565,7 +565,7 @@ export default {
             );
         },
         expandButtonAriaLabel() {
-            return this.$primevue.config.locale.aria ? (this.isRowExpanded ? this.$primevue.config.locale.aria.expandRow : this.$primevue.config.locale.aria.collapseRow) : undefined;
+            return this.$primevue.config.locale.aria ? (this.isRowExpanded ? this.$primevue.config.locale.aria.collapseRow : this.$primevue.config.locale.aria.expandRow) : undefined;
         },
         initButtonAriaLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.editRow : undefined;


### PR DESCRIPTION
It seems like the aria labels for the expand button in the datatable were mixed up.