### PR TITLE
Fix/textarea autoresize

### DIFF
--- a/apps/showcase/doc/textarea/AutoResizeDoc.vue
+++ b/apps/showcase/doc/textarea/AutoResizeDoc.vue
@@ -3,7 +3,7 @@
         <p>When <i>autoResize</i> is enabled, textarea grows instead of displaying a scrollbar.</p>
     </DocSectionText>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize rows="5" cols="30" />
+        <Textarea v-model="value" autoResize />
     </div>
     <DocSectionCode :code="code" />
 </template>
@@ -15,12 +15,12 @@ export default {
             value: '',
             code: {
                 basic: `
-<Textarea v-model="value" autoResize rows="5" cols="30" />
+<Textarea v-model="value" autoResize />
 `,
                 options: `
 <template>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize rows="5" cols="30" />
+        <Textarea v-model="value" autoResize />
     </div>
 </template>
 
@@ -37,7 +37,7 @@ export default {
                 composition: `
 <template>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize rows="5" cols="30" />
+        <Textarea v-model="value" autoResize />
     </div>
 </template>
 

--- a/apps/showcase/doc/textarea/AutoResizeDoc.vue
+++ b/apps/showcase/doc/textarea/AutoResizeDoc.vue
@@ -3,7 +3,7 @@
         <p>When <i>autoResize</i> is enabled, textarea grows instead of displaying a scrollbar.</p>
     </DocSectionText>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize />
+        <Textarea v-model="value" autoResize style="width: 285px" />
     </div>
     <DocSectionCode :code="code" />
 </template>
@@ -15,12 +15,12 @@ export default {
             value: '',
             code: {
                 basic: `
-<Textarea v-model="value" autoResize />
+<Textarea v-model="value" autoResize style="width:285px" />
 `,
                 options: `
 <template>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize />
+        <Textarea v-model="value" autoResize style="width:285px"/>
     </div>
 </template>
 
@@ -37,7 +37,7 @@ export default {
                 composition: `
 <template>
     <div class="card flex justify-center">
-        <Textarea v-model="value" autoResize />
+        <Textarea v-model="value" autoResize style="width:285px" />
     </div>
 </template>
 

--- a/packages/primevue/src/textarea/Textarea.vue
+++ b/packages/primevue/src/textarea/Textarea.vue
@@ -55,14 +55,19 @@ export default {
         resize() {
             if (!this.$el.offsetParent) return;
 
-            this.$el.style.height = 'auto';
-            this.$el.style.height = this.$el.scrollHeight + 'px';
+            // Current height before resize
+            const currentHeight = this.$el.style.height;
+            const currentHeightValue = parseInt(currentHeight) || 0;
+            const initialScrollHeight = this.$el.scrollHeight;
 
-            if (parseFloat(this.$el.style.height) >= parseFloat(this.$el.style.maxHeight)) {
-                this.$el.style.overflowY = 'scroll';
-                this.$el.style.height = this.$el.style.maxHeight;
-            } else {
-                this.$el.style.overflow = 'hidden';
+            const needsExpanding = !currentHeightValue || initialScrollHeight > currentHeightValue;
+            const needsShrinking = currentHeightValue && initialScrollHeight < currentHeightValue;
+
+            if (needsShrinking) {
+                this.$el.style.height = 'auto'; // reset
+                this.$el.style.height = `${this.$el.scrollHeight}px`;
+            } else if (needsExpanding) {
+                this.$el.style.height = `${initialScrollHeight}px`;
             }
         },
         onInput(event) {


### PR DESCRIPTION
### Defect Fix: Unexpected Scrolling Behavior on Auto-Resizing Textarea

This PR addresses [Issue #4189](https://github.com/primefaces/primevue/issues/4189), where an auto-resizing <Textarea> triggers unexpected scrolling when its bottom edge reaches the viewport limit or when the element is not visible.

🔗 References
- Issue: https://github.com/primefaces/primevue/issues/4189
- Video reproduction: https://github.com/user-attachments/assets/da1ea014-30c8-4a21-8dd4-ad0d1e33fd63
- Repro on Stackblitz: https://stackblitz.com/edit/primevue-textarea-autoresize-issue?file=src%2FApp.vue&terminal=dev

✅ Fix Summary
- Added support for the new field-sizing: content CSS property in modern browsers to handle native auto-resizing more predictably.
- Improved logic for setting the height style:
  - Adjust height only when shrinking or expanding.
  - Avoid always forcing height: auto, which might cause the scroll jump.

Tested on
- Firefox 141.0 
- Brave 1.80.124 based on Chrome 138.0 (has field-sizing:content support)