### PR TITLE
chore: remove GlobalComponents type definitions

### DIFF
--- a/packages/forms/src/form/Form.d.ts
+++ b/packages/forms/src/form/Form.d.ts
@@ -330,10 +330,4 @@ export interface FormInstance {
  */
 declare const Form: DefineComponent<FormProps, FormSlots, FormEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Form: DefineComponent<FormProps, FormSlots, FormEmits>;
-    }
-}
-
 export default Form;

--- a/packages/forms/src/formfield/FormField.d.ts
+++ b/packages/forms/src/formfield/FormField.d.ts
@@ -215,10 +215,4 @@ export declare type FormEmits = EmitFn<FormFieldEmitsOptions>;
  */
 declare const FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormEmits>;
-    }
-}
-
 export default FormField;

--- a/packages/icons/src/angledoubledown/AngleDoubleDownIcon.d.ts
+++ b/packages/icons/src/angledoubledown/AngleDoubleDownIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleDoubleDownIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleDoubleDownIcon: DefineComponent<AngleDoubleDownIcon>;
-    }
-}
 
 export default AngleDoubleDownIcon;

--- a/packages/icons/src/angledoubleleft/AngleDoubleLeftIcon.d.ts
+++ b/packages/icons/src/angledoubleleft/AngleDoubleLeftIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleDoubleLeftIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleDoubleLeftIcon: DefineComponent<AngleDoubleLeftIcon>;
-    }
-}
 
 export default AngleDoubleLeftIcon;

--- a/packages/icons/src/angledoubleright/AngleDoubleRightIcon.d.ts
+++ b/packages/icons/src/angledoubleright/AngleDoubleRightIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleDoubleRightIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleDoubleRightIcon: DefineComponent<AngleDoubleRightIcon>;
-    }
-}
 
 export default AngleDoubleRightIcon;

--- a/packages/icons/src/angledoubleup/AngleDoubleUpIcon.d.ts
+++ b/packages/icons/src/angledoubleup/AngleDoubleUpIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleDoubleUpIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleDoubleUpIcon: DefineComponent<AngleDoubleUpIcon>;
-    }
-}
 
 export default AngleDoubleUpIcon;

--- a/packages/icons/src/angledown/AngleDownIcon.d.ts
+++ b/packages/icons/src/angledown/AngleDownIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleDownIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleDownIcon: DefineComponent<AngleDownIcon>;
-    }
-}
 
 export default AngleDownIcon;

--- a/packages/icons/src/angleleft/AngleLeftIcon.d.ts
+++ b/packages/icons/src/angleleft/AngleLeftIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleLeftIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleLeftIcon: DefineComponent<AngleLeftIcon>;
-    }
-}
 
 export default AngleLeftIcon;

--- a/packages/icons/src/angleright/AngleRightIcon.d.ts
+++ b/packages/icons/src/angleright/AngleRightIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleRightIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleRightIcon: DefineComponent<AngleRightIcon>;
-    }
-}
 
 export default AngleRightIcon;

--- a/packages/icons/src/angleup/AngleUpIcon.d.ts
+++ b/packages/icons/src/angleup/AngleUpIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class AngleUpIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        AngleUpIcon: DefineComponent<AngleUpIcon>;
-    }
-}
 
 export default AngleUpIcon;

--- a/packages/icons/src/arrowdown/ArrowDownIcon.d.ts
+++ b/packages/icons/src/arrowdown/ArrowDownIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ArrowDownIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ArrowDownIcon: DefineComponent<ArrowDownIcon>;
-    }
-}
 
 export default ArrowDownIcon;

--- a/packages/icons/src/arrowup/ArrowUpIcon.d.ts
+++ b/packages/icons/src/arrowup/ArrowUpIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ArrowUpIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ArrowUpIcon: DefineComponent<ArrowUpIcon>;
-    }
-}
 
 export default ArrowUpIcon;

--- a/packages/icons/src/ban/BanIcon.d.ts
+++ b/packages/icons/src/ban/BanIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class BanIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        BanIcon: DefineComponent<BanIcon>;
-    }
-}
 
 export default BanIcon;

--- a/packages/icons/src/bars/BarsIcon.d.ts
+++ b/packages/icons/src/bars/BarsIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class BarsIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        BarsIcon: DefineComponent<BarsIcon>;
-    }
-}
 
 export default BarsIcon;

--- a/packages/icons/src/blank/BlankIcon.d.ts
+++ b/packages/icons/src/blank/BlankIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class BlankIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        BlankIcon: DefineComponent<BlankIcon>;
-    }
-}
 
 export default BlankIcon;

--- a/packages/icons/src/calendar/CalendarIcon.d.ts
+++ b/packages/icons/src/calendar/CalendarIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class CalendarIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        CalendarIcon: DefineComponent<CalendarIcon>;
-    }
-}
 
 export default CalendarIcon;

--- a/packages/icons/src/check/CheckIcon.d.ts
+++ b/packages/icons/src/check/CheckIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class CheckIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        CheckIcon: DefineComponent<CheckIcon>;
-    }
-}
 
 export default CheckIcon;

--- a/packages/icons/src/chevrondown/ChevronDownIcon.d.ts
+++ b/packages/icons/src/chevrondown/ChevronDownIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ChevronDownIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ChevronDownIcon: DefineComponent<ChevronDownIcon>;
-    }
-}
 
 export default ChevronDownIcon;

--- a/packages/icons/src/chevronleft/ChevronLeftIcon.d.ts
+++ b/packages/icons/src/chevronleft/ChevronLeftIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ChevronLeftIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ChevronLeftIcon: DefineComponent<ChevronLeftIcon>;
-    }
-}
 
 export default ChevronLeftIcon;

--- a/packages/icons/src/chevronright/ChevronRightIcon.d.ts
+++ b/packages/icons/src/chevronright/ChevronRightIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ChevronRightIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ChevronRightIcon: DefineComponent<ChevronRightIcon>;
-    }
-}
 
 export default ChevronRightIcon;

--- a/packages/icons/src/chevronup/ChevronUpIcon.d.ts
+++ b/packages/icons/src/chevronup/ChevronUpIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ChevronUpIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ChevronUpIcon: DefineComponent<ChevronUpIcon>;
-    }
-}
 
 export default ChevronUpIcon;

--- a/packages/icons/src/exclamationtriangle/ExclamationTriangleIcon.d.ts
+++ b/packages/icons/src/exclamationtriangle/ExclamationTriangleIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ExclamationTriangleIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ExclamationTriangleIcon: DefineComponent<ExclamationTriangleIcon>;
-    }
-}
 
 export default ExclamationTriangleIcon;

--- a/packages/icons/src/eye/EyeIcon.d.ts
+++ b/packages/icons/src/eye/EyeIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class EyeIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        EyeIcon: DefineComponent<EyeIcon>;
-    }
-}
 
 export default EyeIcon;

--- a/packages/icons/src/eyeslash/EyeSlashIcon.d.ts
+++ b/packages/icons/src/eyeslash/EyeSlashIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class EyeSlashIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        EyeSlashIcon: DefineComponent<EyeSlashIcon>;
-    }
-}
 
 export default EyeSlashIcon;

--- a/packages/icons/src/filter/FilterIcon.d.ts
+++ b/packages/icons/src/filter/FilterIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class FilterIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        FilterIcon: DefineComponent<FilterIcon>;
-    }
-}
 
 export default FilterIcon;

--- a/packages/icons/src/filterfill/FilterFillIcon.d.ts
+++ b/packages/icons/src/filterfill/FilterFillIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class FilterFillIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        FilterFillIcon: DefineComponent<FilterFillIcon>;
-    }
-}
 
 export default FilterFillIcon;

--- a/packages/icons/src/filterslash/FilterSlashIcon.d.ts
+++ b/packages/icons/src/filterslash/FilterSlashIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class FilterSlashIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        FilterSlashIcon: DefineComponent<FilterSlashIcon>;
-    }
-}
 
 export default FilterSlashIcon;

--- a/packages/icons/src/infocircle/InfoCircleIcon.d.ts
+++ b/packages/icons/src/infocircle/InfoCircleIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class InfoCircleIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        InfoCircleIcon: DefineComponent<InfoCircleIcon>;
-    }
-}
 
 export default InfoCircleIcon;

--- a/packages/icons/src/minus/MinusIcon.d.ts
+++ b/packages/icons/src/minus/MinusIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class MinusIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        MinusIcon: DefineComponent<MinusIcon>;
-    }
-}
 
 export default MinusIcon;

--- a/packages/icons/src/pencil/PencilIcon.d.ts
+++ b/packages/icons/src/pencil/PencilIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class PencilIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        PencilIcon: DefineComponent<PencilIcon>;
-    }
-}
 
 export default PencilIcon;

--- a/packages/icons/src/plus/PlusIcon.d.ts
+++ b/packages/icons/src/plus/PlusIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class PlusIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        PlusIcon: DefineComponent<PlusIcon>;
-    }
-}
 
 export default PlusIcon;

--- a/packages/icons/src/refresh/RefreshIcon.d.ts
+++ b/packages/icons/src/refresh/RefreshIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class RefreshIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        RefreshIcon: DefineComponent<RefreshIcon>;
-    }
-}
 
 export default RefreshIcon;

--- a/packages/icons/src/search/SearchIcon.d.ts
+++ b/packages/icons/src/search/SearchIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SearchIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SearchIcon: DefineComponent<SearchIcon>;
-    }
-}
 
 export default SearchIcon;

--- a/packages/icons/src/searchminus/SearchMinusIcon.d.ts
+++ b/packages/icons/src/searchminus/SearchMinusIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SearchMinusIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SearchMinusIcon: DefineComponent<SearchMinusIcon>;
-    }
-}
 
 export default SearchMinusIcon;

--- a/packages/icons/src/searchplus/SearchPlusIcon.d.ts
+++ b/packages/icons/src/searchplus/SearchPlusIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SearchPlusIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SearchPlusIcon: DefineComponent<SearchPlusIcon>;
-    }
-}
 
 export default SearchPlusIcon;

--- a/packages/icons/src/sortalt/SortAltIcon.d.ts
+++ b/packages/icons/src/sortalt/SortAltIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SortAltIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SortAltIcon: DefineComponent<SortAltIcon>;
-    }
-}
 
 export default SortAltIcon;

--- a/packages/icons/src/sortamountdown/SortAmountDownIcon.d.ts
+++ b/packages/icons/src/sortamountdown/SortAmountDownIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SortAmountDownIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SortAmountDownIcon: DefineComponent<SortAmountDownIcon>;
-    }
-}
 
 export default SortAmountDownIcon;

--- a/packages/icons/src/sortamountupalt/SortAmountUpAltIcon.d.ts
+++ b/packages/icons/src/sortamountupalt/SortAmountUpAltIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SortAmountUpAltIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SortAmountUpAltIcon: DefineComponent<SortAmountUpAltIcon>;
-    }
-}
 
 export default SortAmountUpAltIcon;

--- a/packages/icons/src/spinner/SpinnerIcon.d.ts
+++ b/packages/icons/src/spinner/SpinnerIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class SpinnerIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        SpinnerIcon: DefineComponent<SpinnerIcon>;
-    }
-}
 
 export default SpinnerIcon;

--- a/packages/icons/src/star/StarIcon.d.ts
+++ b/packages/icons/src/star/StarIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class StarIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        StarIcon: DefineComponent<StarIcon>;
-    }
-}
 
 export default StarIcon;

--- a/packages/icons/src/starfill/StarFillIcon.d.ts
+++ b/packages/icons/src/starfill/StarFillIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class StarFillIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        StarFillIcon: DefineComponent<StarFillIcon>;
-    }
-}
 
 export default StarFillIcon;

--- a/packages/icons/src/thlarge/ThLargeIcon.d.ts
+++ b/packages/icons/src/thlarge/ThLargeIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class ThLargeIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        ThLargeIcon: DefineComponent<ThLargeIcon>;
-    }
-}
 
 export default ThLargeIcon;

--- a/packages/icons/src/times/TimesIcon.d.ts
+++ b/packages/icons/src/times/TimesIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class TimesIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        TimesIcon: DefineComponent<TimesIcon>;
-    }
-}
 
 export default TimesIcon;

--- a/packages/icons/src/timescircle/TimesCircleIcon.d.ts
+++ b/packages/icons/src/timescircle/TimesCircleIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class TimesCircleIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        TimesCircleIcon: DefineComponent<TimesCircleIcon>;
-    }
-}
 
 export default TimesCircleIcon;

--- a/packages/icons/src/trash/TrashIcon.d.ts
+++ b/packages/icons/src/trash/TrashIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class TrashIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        TrashIcon: DefineComponent<TrashIcon>;
-    }
-}
 
 export default TrashIcon;

--- a/packages/icons/src/undo/UndoIcon.d.ts
+++ b/packages/icons/src/undo/UndoIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class UndoIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        UndoIcon: DefineComponent<UndoIcon>;
-    }
-}
 
 export default UndoIcon;

--- a/packages/icons/src/upload/UploadIcon.d.ts
+++ b/packages/icons/src/upload/UploadIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class UploadIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        UploadIcon: DefineComponent<UploadIcon>;
-    }
-}
 
 export default UploadIcon;

--- a/packages/icons/src/windowmaximize/WindowMaximizeIcon.d.ts
+++ b/packages/icons/src/windowmaximize/WindowMaximizeIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class WindowMaximizeIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        WindowMaximizeIcon: DefineComponent<WindowMaximizeIcon>;
-    }
-}
 
 export default WindowMaximizeIcon;

--- a/packages/icons/src/windowminimize/WindowMinimizeIcon.d.ts
+++ b/packages/icons/src/windowminimize/WindowMinimizeIcon.d.ts
@@ -1,12 +1,5 @@
-import type { DefineComponent } from '@primevue/core';
 import type { Icon } from '@primevue/icons/baseicon';
 
 declare class WindowMinimizeIcon extends Icon {}
-
-declare module 'vue' {
-    export interface GlobalComponents {
-        WindowMinimizeIcon: DefineComponent<WindowMinimizeIcon>;
-    }
-}
 
 export default WindowMinimizeIcon;

--- a/packages/primevue/src/accordion/Accordion.d.ts
+++ b/packages/primevue/src/accordion/Accordion.d.ts
@@ -243,10 +243,4 @@ export declare type AccordionEmits = EmitFn<AccordionEmitsOptions>;
  */
 declare const Accordion: DefineComponent<AccordionProps, AccordionSlots, AccordionEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Accordion: DefineComponent<AccordionProps, AccordionSlots, AccordionEmits>;
-    }
-}
-
 export default Accordion;

--- a/packages/primevue/src/accordioncontent/AccordionContent.d.ts
+++ b/packages/primevue/src/accordioncontent/AccordionContent.d.ts
@@ -140,10 +140,4 @@ export declare type AccordionContentEmits = EmitFn<AccordionContentEmitsOptions>
  */
 declare const AccordionContent: DefineComponent<AccordionContentProps, AccordionContentSlots, AccordionContentEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AccordionContent: DefineComponent<AccordionContentProps, AccordionContentSlots, AccordionContentEmits>;
-    }
-}
-
 export default AccordionContent;

--- a/packages/primevue/src/accordionheader/AccordionHeader.d.ts
+++ b/packages/primevue/src/accordionheader/AccordionHeader.d.ts
@@ -145,10 +145,4 @@ export declare type AccordionHeaderEmits = EmitFn<AccordionHeaderEmitsOptions>;
  */
 declare const AccordionHeader: DefineComponent<AccordionHeaderProps, AccordionHeaderSlots, AccordionHeaderEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AccordionHeader: DefineComponent<AccordionHeaderProps, AccordionHeaderSlots, AccordionHeaderEmits>;
-    }
-}
-
 export default AccordionHeader;

--- a/packages/primevue/src/accordionpanel/AccordionPanel.d.ts
+++ b/packages/primevue/src/accordionpanel/AccordionPanel.d.ts
@@ -138,10 +138,4 @@ export declare type AccordionPanelEmits = EmitFn<AccordionPanelEmitsOptions>;
  */
 declare const AccordionPanel: DefineComponent<AccordionPanelProps, AccordionPanelSlots, AccordionPanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AccordionPanel: DefineComponent<AccordionPanelProps, AccordionPanelSlots, AccordionPanelEmits>;
-    }
-}
-
 export default AccordionPanel;

--- a/packages/primevue/src/accordiontab/AccordionTab.d.ts
+++ b/packages/primevue/src/accordiontab/AccordionTab.d.ts
@@ -227,10 +227,4 @@ export declare type AccordionTabEmits = EmitFn<AccordionTabEmitsOptions>;
  */
 declare const AccordionTab: DefineComponent<AccordionTabProps, AccordionTabSlots, AccordionTabEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AccordionTab: DefineComponent<AccordionTabProps, AccordionTabSlots, AccordionTabEmits>;
-    }
-}
-
 export default AccordionTab;

--- a/packages/primevue/src/autocomplete/AutoComplete.d.ts
+++ b/packages/primevue/src/autocomplete/AutoComplete.d.ts
@@ -880,10 +880,4 @@ export declare type AutoCompleteEmits = EmitFn<AutoCompleteEmitsOptions>;
  */
 declare const AutoComplete: DefineComponent<AutoCompleteProps, AutoCompleteSlots, AutoCompleteEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AutoComplete: DefineComponent<AutoCompleteProps, AutoCompleteSlots, AutoCompleteEmits>;
-    }
-}
-
 export default AutoComplete;

--- a/packages/primevue/src/avatar/Avatar.d.ts
+++ b/packages/primevue/src/avatar/Avatar.d.ts
@@ -169,10 +169,4 @@ export declare type AvatarEmits = EmitFn<AvatarEmitsOptions>;
  */
 declare const Avatar: DefineComponent<AvatarProps, AvatarSlots, AvatarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Avatar: DefineComponent<AvatarProps, AvatarSlots, AvatarEmits>;
-    }
-}
-
 export default Avatar;

--- a/packages/primevue/src/avatargroup/AvatarGroup.d.ts
+++ b/packages/primevue/src/avatargroup/AvatarGroup.d.ts
@@ -119,10 +119,4 @@ export declare type AvatarGroupEmits = EmitFn<AvatarGroupEmitsOptions>;
  */
 declare const AvatarGroup: DefineComponent<AvatarGroupProps, AvatarGroupSlots, AvatarGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        AvatarGroup: DefineComponent<AvatarGroupProps, AvatarGroupSlots, AvatarGroupEmits>;
-    }
-}
-
 export default AvatarGroup;

--- a/packages/primevue/src/badge/Badge.d.ts
+++ b/packages/primevue/src/badge/Badge.d.ts
@@ -127,10 +127,4 @@ export declare type BadgeEmits = EmitFn<BadgeEmitsOptions>;
  */
 declare const Badge: DefineComponent<BadgeProps, BadgeSlots, BadgeEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Badge: DefineComponent<BadgeProps, BadgeSlots, BadgeEmits>;
-    }
-}
-
 export default Badge;

--- a/packages/primevue/src/blockui/BlockUI.d.ts
+++ b/packages/primevue/src/blockui/BlockUI.d.ts
@@ -167,10 +167,4 @@ export declare type BlockUIEmits = EmitFn<BlockUIEmitsOptions>;
  */
 declare const BlockUI: DefineComponent<BlockUIProps, BlockUISlots, BlockUIEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        BlockUI: DefineComponent<BlockUIProps, BlockUISlots, BlockUIEmits>;
-    }
-}
-
 export default BlockUI;

--- a/packages/primevue/src/breadcrumb/Breadcrumb.d.ts
+++ b/packages/primevue/src/breadcrumb/Breadcrumb.d.ts
@@ -232,10 +232,4 @@ export declare type BreadcrumbEmits = EmitFn<BreadcrumbEmitsOptions>;
  */
 declare const Breadcrumb: DefineComponent<BreadcrumbProps, BreadcrumbSlots, BreadcrumbEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Breadcrumb: DefineComponent<BreadcrumbProps, BreadcrumbSlots, BreadcrumbEmits>;
-    }
-}
-
 export default Breadcrumb;

--- a/packages/primevue/src/button/Button.d.ts
+++ b/packages/primevue/src/button/Button.d.ts
@@ -281,10 +281,4 @@ export declare type ButtonEmits = EmitFn<ButtonEmitsOptions>;
  */
 declare const Button: DefineComponent<ButtonProps, ButtonSlots, ButtonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Button: DefineComponent<ButtonProps, ButtonSlots, ButtonEmits>;
-    }
-}
-
 export default Button;

--- a/packages/primevue/src/buttongroup/ButtonGroup.d.ts
+++ b/packages/primevue/src/buttongroup/ButtonGroup.d.ts
@@ -111,10 +111,4 @@ export declare type ButtonGroupEmits = EmitFn<ButtonGroupEmitsOptions>;
  */
 declare const ButtonGroup: DefineComponent<ButtonGroupProps, ButtonGroupSlots, ButtonGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ButtonGroup: DefineComponent<ButtonGroupProps, ButtonGroupSlots, ButtonGroupEmits>;
-    }
-}
-
 export default ButtonGroup;

--- a/packages/primevue/src/calendar/Calendar.d.ts
+++ b/packages/primevue/src/calendar/Calendar.d.ts
@@ -118,10 +118,4 @@ export declare type CalendarEmits = EmitFn<CalendarEmitsOptions> & DatePicker.Da
  */
 declare const Calendar: DefineComponent<CalendarProps, CalendarSlots, CalendarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Calendar: DefineComponent<CalendarProps, CalendarSlots, CalendarEmits>;
-    }
-}
-
 export default Calendar;

--- a/packages/primevue/src/card/Card.d.ts
+++ b/packages/primevue/src/card/Card.d.ts
@@ -159,10 +159,4 @@ export declare type CardEmits = EmitFn<CardEmitsOptions>;
  */
 declare const Card: DefineComponent<CardProps, CardSlots, CardEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Card: DefineComponent<CardProps, CardSlots, CardEmits>;
-    }
-}
-
 export default Card;

--- a/packages/primevue/src/carousel/Carousel.d.ts
+++ b/packages/primevue/src/carousel/Carousel.d.ts
@@ -413,10 +413,4 @@ export declare type CarouselEmits = EmitFn<CarouselEmitsOptions>;
  */
 declare const Carousel: DefineComponent<CarouselProps, CarouselSlots, CarouselEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Carousel: DefineComponent<CarouselProps, CarouselSlots, CarouselEmits>;
-    }
-}
-
 export default Carousel;

--- a/packages/primevue/src/cascadeselect/CascadeSelect.d.ts
+++ b/packages/primevue/src/cascadeselect/CascadeSelect.d.ts
@@ -652,10 +652,4 @@ export declare type CascadeSelectEmits = EmitFn<CascadeSelectEmitsOptions>;
  */
 declare const CascadeSelect: DefineComponent<CascadeSelectProps, CascadeSelectSlots, CascadeSelectEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        CascadeSelect: DefineComponent<CascadeSelectProps, CascadeSelectSlots, CascadeSelectEmits>;
-    }
-}
-
 export default CascadeSelect;

--- a/packages/primevue/src/chart/Chart.d.ts
+++ b/packages/primevue/src/chart/Chart.d.ts
@@ -202,10 +202,4 @@ export interface ChartMethods {
  */
 declare const Chart: DefineComponent<ChartProps, ChartSlots, ChartEmits, ChartMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Chart: DefineComponent<ChartProps, ChartSlots, ChartEmits, ChartMethods>;
-    }
-}
-
 export default Chart;

--- a/packages/primevue/src/checkbox/Checkbox.d.ts
+++ b/packages/primevue/src/checkbox/Checkbox.d.ts
@@ -305,10 +305,4 @@ export declare type CheckboxEmits = EmitFn<CheckboxEmitsOptions>;
  */
 declare const Checkbox: DefineComponent<CheckboxProps, CheckboxSlots, CheckboxEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Checkbox: DefineComponent<CheckboxProps, CheckboxSlots, CheckboxEmits>;
-    }
-}
-
 export default Checkbox;

--- a/packages/primevue/src/checkboxgroup/CheckboxGroup.d.ts
+++ b/packages/primevue/src/checkboxgroup/CheckboxGroup.d.ts
@@ -151,10 +151,4 @@ export declare type CheckboxGroupEmits = EmitFn<CheckboxGroupEmitsOptions>;
  */
 declare const CheckboxGroup: DefineComponent<CheckboxGroupProps, CheckboxGroupSlots, CheckboxGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        CheckboxGroup: DefineComponent<CheckboxGroupProps, CheckboxGroupSlots, CheckboxGroupEmits>;
-    }
-}
-
 export default CheckboxGroup;

--- a/packages/primevue/src/chip/Chip.d.ts
+++ b/packages/primevue/src/chip/Chip.d.ts
@@ -197,10 +197,4 @@ export declare type ChipEmits = EmitFn<ChipEmitsOptions>;
  */
 declare const Chip: DefineComponent<ChipProps, ChipSlots, ChipEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Chip: DefineComponent<ChipProps, ChipSlots, ChipEmits>;
-    }
-}
-
 export default Chip;

--- a/packages/primevue/src/chips/Chips.d.ts
+++ b/packages/primevue/src/chips/Chips.d.ts
@@ -81,10 +81,4 @@ export declare type ChipsEmits = EmitFn<ChipsEmitsOptions> & InputChips.InputChi
  */
 declare const Chips: DefineComponent<ChipsProps, ChipsSlots, ChipsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Chips: DefineComponent<ChipsProps, ChipsSlots, ChipsEmits>;
-    }
-}
-
 export default Chips;

--- a/packages/primevue/src/colorpicker/ColorPicker.d.ts
+++ b/packages/primevue/src/colorpicker/ColorPicker.d.ts
@@ -276,10 +276,4 @@ export declare type ColorPickerEmits = EmitFn<ColorPickerEmitsOptions>;
  */
 declare const ColorPicker: DefineComponent<ColorPickerProps, ColorPickerSlots, ColorPickerEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ColorPicker: DefineComponent<ColorPickerProps, ColorPickerSlots, ColorPickerEmits>;
-    }
-}
-
 export default ColorPicker;

--- a/packages/primevue/src/column/Column.d.ts
+++ b/packages/primevue/src/column/Column.d.ts
@@ -1037,10 +1037,4 @@ declare const Column: DefineComponent<ColumnProps, ColumnSlots, ColumnEmits>;
 
 export type ColumnNode = { props: ColumnProps };
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Column: DefineComponent<ColumnProps, ColumnSlots, ColumnEmits>;
-    }
-}
-
 export default Column;

--- a/packages/primevue/src/columngroup/ColumnGroup.d.ts
+++ b/packages/primevue/src/columngroup/ColumnGroup.d.ts
@@ -136,10 +136,4 @@ export declare type ColumnGroupEmits = EmitFn<ColumnGroupEmitsOptions>;
  */
 declare const ColumnGroup: DefineComponent<ColumnGroupProps, ColumnGroupSlots, ColumnGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ColumnGroup: DefineComponent<ColumnGroupProps, ColumnGroupSlots, ColumnGroupEmits>;
-    }
-}
-
 export default ColumnGroup;

--- a/packages/primevue/src/confirmdialog/ConfirmDialog.d.ts
+++ b/packages/primevue/src/confirmdialog/ConfirmDialog.d.ts
@@ -286,10 +286,4 @@ export declare type ConfirmDialogEmits = EmitFn<ConfirmDialogEmitsOptions>;
  */
 declare const ConfirmDialog: DefineComponent<ConfirmDialogProps, ConfirmDialogSlots, ConfirmDialogEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ConfirmDialog: DefineComponent<ConfirmDialogProps, ConfirmDialogSlots, ConfirmDialogEmits>;
-    }
-}
-
 export default ConfirmDialog;

--- a/packages/primevue/src/confirmpopup/ConfirmPopup.d.ts
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.d.ts
@@ -232,10 +232,4 @@ export declare type ConfirmPopupEmits = EmitFn<ConfirmPopupEmitsOptions>;
  */
 declare const ConfirmPopup: DefineComponent<ConfirmPopupProps, ConfirmPopupSlots, ConfirmPopupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ConfirmPopup: DefineComponent<ConfirmPopupProps, ConfirmPopupSlots, ConfirmPopupEmits>;
-    }
-}
-
 export default ConfirmPopup;

--- a/packages/primevue/src/contextmenu/ContextMenu.d.ts
+++ b/packages/primevue/src/contextmenu/ContextMenu.d.ts
@@ -409,10 +409,4 @@ export interface ContextMenuMethods {
  */
 declare const ContextMenu: DefineComponent<ContextMenuProps, ContextMenuSlots, ContextMenuEmits, ContextMenuMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ContextMenu: DefineComponent<ContextMenuProps, ContextMenuSlots, ContextMenuEmits, ContextMenuMethods>;
-    }
-}
-
 export default ContextMenu;

--- a/packages/primevue/src/datatable/DataTable.d.ts
+++ b/packages/primevue/src/datatable/DataTable.d.ts
@@ -1697,10 +1697,4 @@ export interface DataTableMethods {
  */
 declare const DataTable: DefineComponent<DataTableProps, DataTableSlots, DataTableEmits, DataTableMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        DataTable: DefineComponent<DataTableProps, DataTableSlots, DataTableEmits, DataTableMethods>;
-    }
-}
-
 export default DataTable;

--- a/packages/primevue/src/dataview/DataView.d.ts
+++ b/packages/primevue/src/dataview/DataView.d.ts
@@ -408,10 +408,4 @@ export declare type DataViewEmits = EmitFn<DataViewEmitsOptions>;
  */
 declare const DataView: DefineComponent<DataViewProps, DataViewSlots, DataViewEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        DataView: DefineComponent<DataViewProps, DataViewSlots, DataViewEmits>;
-    }
-}
-
 export default DataView;

--- a/packages/primevue/src/datepicker/DatePicker.d.ts
+++ b/packages/primevue/src/datepicker/DatePicker.d.ts
@@ -1204,10 +1204,4 @@ export declare type DatePickerEmits = EmitFn<DatePickerEmitsOptions>;
  */
 declare const DatePicker: DefineComponent<DatePickerProps, DatePickerSlots, DatePickerEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        DatePicker: DefineComponent<DatePickerProps, DatePickerSlots, DatePickerEmits>;
-    }
-}
-
 export default DatePicker;

--- a/packages/primevue/src/deferredcontent/DeferredContent.d.ts
+++ b/packages/primevue/src/deferredcontent/DeferredContent.d.ts
@@ -139,10 +139,4 @@ export declare type DeferredContentEmits = EmitFn<DeferredContentEmitsOptions>;
  */
 declare const DeferredContent: DefineComponent<DeferredContentProps, DeferredContentSlots, DeferredContentEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        DeferredContent: DefineComponent<DeferredContentProps, DeferredContentSlots, DeferredContentEmits>;
-    }
-}
-
 export default DeferredContent;

--- a/packages/primevue/src/dialog/Dialog.d.ts
+++ b/packages/primevue/src/dialog/Dialog.d.ts
@@ -454,10 +454,4 @@ export declare type DialogEmits = EmitFn<DialogEmitsOptions>;
  */
 declare const Dialog: DefineComponent<DialogProps, DialogSlots, DialogEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Dialog: DefineComponent<DialogProps, DialogSlots, DialogEmits>;
-    }
-}
-
 export default Dialog;

--- a/packages/primevue/src/divider/Divider.d.ts
+++ b/packages/primevue/src/divider/Divider.d.ts
@@ -134,10 +134,4 @@ export declare type DividerEmits = EmitFn<DividerEmitsOptions>;
  */
 declare const Divider: DefineComponent<DividerProps, DividerSlots, DividerEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Divider: DefineComponent<DividerProps, DividerSlots, DividerEmits>;
-    }
-}
-
 export default Divider;

--- a/packages/primevue/src/dock/Dock.d.ts
+++ b/packages/primevue/src/dock/Dock.d.ts
@@ -322,10 +322,4 @@ export declare type DockEmits = EmitFn<DockEmitsOptions>;
  */
 declare const Dock: DefineComponent<DockProps, DockSlots, DockEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Dock: DefineComponent<DockProps, DockSlots, DockEmits>;
-    }
-}
-
 export default Dock;

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -304,10 +304,4 @@ export declare type DrawerEmits = EmitFn<DrawerEmitsOptions>;
  */
 declare const Drawer: DefineComponent<DrawerProps, DrawerSlots, DrawerEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Drawer: DefineComponent<DrawerProps, DrawerSlots, DrawerEmits>;
-    }
-}
-
 export default Drawer;

--- a/packages/primevue/src/dropdown/Dropdown.d.ts
+++ b/packages/primevue/src/dropdown/Dropdown.d.ts
@@ -99,10 +99,4 @@ export interface DropdownMethods {
  */
 declare const Dropdown: DefineComponent<DropdownProps, DropdownSlots, DropdownEmits, DropdownMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Dropdown: DefineComponent<DropdownProps, DropdownSlots, DropdownEmits, DropdownMethods>;
-    }
-}
-
 export default Dropdown;

--- a/packages/primevue/src/dynamicdialog/DynamicDialog.d.ts
+++ b/packages/primevue/src/dynamicdialog/DynamicDialog.d.ts
@@ -46,10 +46,4 @@ export declare type DynamicDialogEmits = EmitFn<DynamicDialogEmitsOptions>;
  */
 declare const DynamicDialog: DefineComponent<DynamicDialogProps, DynamicDialogSlots, DynamicDialogEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        DynamicDialog: DefineComponent<DynamicDialogProps, DynamicDialogSlots, DynamicDialogEmits>;
-    }
-}
-
 export default DynamicDialog;

--- a/packages/primevue/src/editor/Editor.d.ts
+++ b/packages/primevue/src/editor/Editor.d.ts
@@ -318,10 +318,4 @@ export declare type EditorEmits = EmitFn<EditorEmitsOptions>;
  */
 declare const Editor: DefineComponent<EditorProps, EditorSlots, EditorEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Editor: DefineComponent<EditorProps, EditorSlots, EditorEmits>;
-    }
-}
-
 export default Editor;

--- a/packages/primevue/src/fieldset/Fieldset.d.ts
+++ b/packages/primevue/src/fieldset/Fieldset.d.ts
@@ -248,10 +248,4 @@ export declare type FieldsetEmits = EmitFn<FieldsetEmitsOptions>;
  */
 declare const Fieldset: DefineComponent<FieldsetProps, FieldsetSlots, FieldsetEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Fieldset: DefineComponent<FieldsetProps, FieldsetSlots, FieldsetEmits>;
-    }
-}
-
 export default Fieldset;

--- a/packages/primevue/src/fileupload/FileUpload.d.ts
+++ b/packages/primevue/src/fileupload/FileUpload.d.ts
@@ -656,10 +656,4 @@ export interface FileUploadMethods {
  */
 declare const FileUpload: DefineComponent<FileUploadProps, FileUploadSlots, FileUploadEmits, FileUploadMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        FileUpload: DefineComponent<FileUploadProps, FileUploadSlots, FileUploadEmits, FileUploadMethods>;
-    }
-}
-
 export default FileUpload;

--- a/packages/primevue/src/floatlabel/FloatLabel.d.ts
+++ b/packages/primevue/src/floatlabel/FloatLabel.d.ts
@@ -126,10 +126,4 @@ export declare type FloatLabelEmits = EmitFn<FloatLabelEmitsOptions>;
  */
 declare const FloatLabel: DefineComponent<FloatLabelProps, FloatLabelSlots, FloatLabelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        FloatLabel: DefineComponent<FloatLabelProps, FloatLabelSlots, FloatLabelEmits>;
-    }
-}
-
 export default FloatLabel;

--- a/packages/primevue/src/fluid/Fluid.d.ts
+++ b/packages/primevue/src/fluid/Fluid.d.ts
@@ -121,10 +121,4 @@ export declare type FluidEmits = EmitFn<FluidEmitsOptions>;
  */
 declare const Fluid: DefineComponent<FluidProps, FluidSlots, FluidEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Fluid: DefineComponent<FluidProps, FluidSlots, FluidEmits>;
-    }
-}
-
 export default Fluid;

--- a/packages/primevue/src/galleria/Galleria.d.ts
+++ b/packages/primevue/src/galleria/Galleria.d.ts
@@ -540,10 +540,4 @@ export declare type GalleriaEmits = EmitFn<GalleriaEmitsOptions>;
  */
 declare const Galleria: DefineComponent<GalleriaProps, GalleriaSlots, GalleriaEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Galleria: DefineComponent<GalleriaProps, GalleriaSlots, GalleriaEmits>;
-    }
-}
-
 export default Galleria;

--- a/packages/primevue/src/iconfield/IconField.d.ts
+++ b/packages/primevue/src/iconfield/IconField.d.ts
@@ -119,10 +119,4 @@ export declare type IconFieldEmits = EmitFn<IconFieldEmitsOptions>;
  */
 declare const IconField: DefineComponent<IconFieldProps, IconFieldSlots, IconFieldEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        IconField: DefineComponent<IconFieldProps, IconFieldSlots, IconFieldEmits>;
-    }
-}
-
 export default IconField;

--- a/packages/primevue/src/iftalabel/IftaLabel.d.ts
+++ b/packages/primevue/src/iftalabel/IftaLabel.d.ts
@@ -121,10 +121,4 @@ export declare type IftaLabelEmits = EmitFn<IftaLabelEmitsOptions>;
  */
 declare const IftaLabel: DefineComponent<IftaLabelProps, IftaLabelSlots, IftaLabelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        IftaLabel: DefineComponent<IftaLabelProps, IftaLabelSlots, IftaLabelEmits>;
-    }
-}
-
 export default IftaLabel;

--- a/packages/primevue/src/image/Image.d.ts
+++ b/packages/primevue/src/image/Image.d.ts
@@ -357,10 +357,4 @@ export interface ImageMethods {
  */
 declare const Image: DefineComponent<ImageProps, ImageSlots, ImageEmits, ImageMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Image: DefineComponent<ImageProps, ImageSlots, ImageEmits, ImageMethods>;
-    }
-}
-
 export default Image;

--- a/packages/primevue/src/imagecompare/ImageCompare.d.ts
+++ b/packages/primevue/src/imagecompare/ImageCompare.d.ts
@@ -140,10 +140,4 @@ export declare type ImageCompareEmits = EmitFn<ImageCompareEmitsOptions>;
  */
 declare const ImageCompare: DefineComponent<ImageCompareProps, ImageCompareSlots, ImageCompareEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ImageCompare: DefineComponent<ImageCompareProps, ImageCompareSlots, ImageCompareEmits>;
-    }
-}
-
 export default ImageCompare;

--- a/packages/primevue/src/inlinemessage/InlineMessage.d.ts
+++ b/packages/primevue/src/inlinemessage/InlineMessage.d.ts
@@ -153,10 +153,4 @@ export declare type InlineMessageEmits = EmitFn<InlineMessageEmitsOptions>;
  */
 declare const InlineMessage: DefineComponent<InlineMessageProps, InlineMessageSlots, InlineMessageEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InlineMessage: DefineComponent<InlineMessageProps, InlineMessageSlots, InlineMessageEmits>;
-    }
-}
-
 export default InlineMessage;

--- a/packages/primevue/src/inplace/Inplace.d.ts
+++ b/packages/primevue/src/inplace/Inplace.d.ts
@@ -196,10 +196,4 @@ export declare type InplaceEmits = EmitFn<InplaceEmitsOptions>;
  */
 declare const Inplace: DefineComponent<InplaceProps, InplaceSlots, InplaceEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Inplace: DefineComponent<InplaceProps, InplaceSlots, InplaceEmits>;
-    }
-}
-
 export default Inplace;

--- a/packages/primevue/src/inputchips/InputChips.d.ts
+++ b/packages/primevue/src/inputchips/InputChips.d.ts
@@ -340,10 +340,4 @@ export declare type InputChipsEmits = EmitFn<InputChipsEmitsOptions>;
  */
 declare const InputChips: DefineComponent<InputChipsProps, InputChipsSlots, InputChipsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputChips: DefineComponent<InputChipsProps, InputChipsSlots, InputChipsEmits>;
-    }
-}
-
 export default InputChips;

--- a/packages/primevue/src/inputgroup/InputGroup.d.ts
+++ b/packages/primevue/src/inputgroup/InputGroup.d.ts
@@ -124,10 +124,4 @@ export declare type InputGroupEmits = EmitFn<InputGroupEmitsOptions>;
  */
 declare const InputGroup: DefineComponent<InputGroupProps, InputGroupSlots, InputGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputGroup: DefineComponent<InputGroupProps, InputGroupSlots, InputGroupEmits>;
-    }
-}
-
 export default InputGroup;

--- a/packages/primevue/src/inputgroupaddon/InputGroupAddon.d.ts
+++ b/packages/primevue/src/inputgroupaddon/InputGroupAddon.d.ts
@@ -120,10 +120,4 @@ export declare type InputGroupAddonEmits = EmitFn<InputGroupAddonEmitsOptions>;
  */
 declare const InputGroupAddon: DefineComponent<InputGroupAddonProps, InputGroupAddonSlots, InputGroupAddonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputGroupAddon: DefineComponent<InputGroupAddonProps, InputGroupAddonSlots, InputGroupAddonEmits>;
-    }
-}
-
 export default InputGroupAddon;

--- a/packages/primevue/src/inputicon/InputIcon.d.ts
+++ b/packages/primevue/src/inputicon/InputIcon.d.ts
@@ -115,10 +115,4 @@ export declare type InputIconEmits = EmitFn<InputIconEmitsOptions>;
  */
 declare const InputIcon: DefineComponent<InputIconProps, InputIconSlots, InputIconEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputIcon: DefineComponent<InputIconProps, InputIconSlots, InputIconEmits>;
-    }
-}
-
 export default InputIcon;

--- a/packages/primevue/src/inputmask/InputMask.d.ts
+++ b/packages/primevue/src/inputmask/InputMask.d.ts
@@ -257,10 +257,4 @@ export declare type InputMaskEmits = EmitFn<InputMaskEmitsOptions>;
  */
 declare const InputMask: DefineComponent<InputMaskProps, InputMaskSlots, InputMaskEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputMask: DefineComponent<InputMaskProps, InputMaskSlots, InputMaskEmits>;
-    }
-}
-
 export default InputMask;

--- a/packages/primevue/src/inputnumber/InputNumber.d.ts
+++ b/packages/primevue/src/inputnumber/InputNumber.d.ts
@@ -499,10 +499,4 @@ export interface InputNumberMethods {
  */
 declare const InputNumber: DefineComponent<InputNumberProps, InputNumberSlots, InputNumberEmits, InputNumberMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputNumber: DefineComponent<InputNumberProps, InputNumberSlots, InputNumberEmits, InputNumberMethods>;
-    }
-}
-
 export default InputNumber;

--- a/packages/primevue/src/inputotp/InputOtp.d.ts
+++ b/packages/primevue/src/inputotp/InputOtp.d.ts
@@ -308,10 +308,4 @@ export declare type InputOtpEmits = EmitFn<InputOtpEmitsOptions>;
  */
 declare const InputOtp: DefineComponent<InputOtpProps, InputOtpSlots, InputOtpEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputOtp: DefineComponent<InputOtpProps, InputOtpSlots, InputOtpEmits>;
-    }
-}
-
 export default InputOtp;

--- a/packages/primevue/src/inputswitch/InputSwitch.d.ts
+++ b/packages/primevue/src/inputswitch/InputSwitch.d.ts
@@ -60,10 +60,4 @@ export declare type InputSwitchEmits = EmitFn<InputSwitchEmitsOptions> & ToggleS
  */
 declare const InputSwitch: DefineComponent<InputSwitchProps, InputSwitchSlots, InputSwitchEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputSwitch: DefineComponent<InputSwitchProps, InputSwitchSlots, InputSwitchEmits>;
-    }
-}
-
 export default InputSwitch;

--- a/packages/primevue/src/inputtext/InputText.d.ts
+++ b/packages/primevue/src/inputtext/InputText.d.ts
@@ -176,10 +176,4 @@ export declare type InputTextEmits = EmitFn<InputTextEmitsOptions>;
  */
 declare const InputText: DefineComponent<InputTextProps, InputTextSlots, InputTextEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        InputText: DefineComponent<InputTextProps, InputTextSlots, InputTextEmits>;
-    }
-}
-
 export default InputText;

--- a/packages/primevue/src/knob/Knob.d.ts
+++ b/packages/primevue/src/knob/Knob.d.ts
@@ -272,10 +272,4 @@ export declare type KnobEmits = EmitFn<KnobEmitsOptions>;
  */
 declare const Knob: DefineComponent<KnobProps, KnobSlots, KnobEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Knob: DefineComponent<KnobProps, KnobSlots, KnobEmits>;
-    }
-}
-
 export default Knob;

--- a/packages/primevue/src/listbox/Listbox.d.ts
+++ b/packages/primevue/src/listbox/Listbox.d.ts
@@ -638,10 +638,4 @@ export declare type ListboxEmits = EmitFn<ListboxEmitsOptions>;
  */
 declare const Listbox: DefineComponent<ListboxProps, ListboxSlots, ListboxEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Listbox: DefineComponent<ListboxProps, ListboxSlots, ListboxEmits>;
-    }
-}
-
 export default Listbox;

--- a/packages/primevue/src/megamenu/MegaMenu.d.ts
+++ b/packages/primevue/src/megamenu/MegaMenu.d.ts
@@ -409,10 +409,4 @@ export declare type MegaMenuEmits = EmitFn<MegaMenuEmitsOptions>;
  */
 declare const MegaMenu: DefineComponent<MegaMenuProps, MegaMenuSlots, MegaMenuEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        MegaMenu: DefineComponent<MegaMenuProps, MegaMenuSlots, MegaMenuEmits>;
-    }
-}
-
 export default MegaMenu;

--- a/packages/primevue/src/menu/Menu.d.ts
+++ b/packages/primevue/src/menu/Menu.d.ts
@@ -373,10 +373,4 @@ export interface MenuMethods {
  */
 declare const Menu: DefineComponent<MenuProps, MenuSlots, MenuEmits, MenuMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Menu: DefineComponent<MenuProps, MenuSlots, MenuEmits, MenuMethods>;
-    }
-}
-
 export default Menu;

--- a/packages/primevue/src/menubar/Menubar.d.ts
+++ b/packages/primevue/src/menubar/Menubar.d.ts
@@ -412,10 +412,4 @@ export declare type MenubarEmits = EmitFn<MenubarEmitsOptions>;
  */
 declare const Menubar: DefineComponent<MenubarProps, MenubarSlots, MenubarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Menubar: DefineComponent<MenubarProps, MenubarSlots, MenubarEmits>;
-    }
-}
-
 export default Menubar;

--- a/packages/primevue/src/message/Message.d.ts
+++ b/packages/primevue/src/message/Message.d.ts
@@ -238,10 +238,4 @@ export declare type MessageEmits = EmitFn<MessageEmitsOptions>;
  */
 declare const Message: DefineComponent<MessageProps, MessageSlots, MessageEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Message: DefineComponent<MessageProps, MessageSlots, MessageEmits>;
-    }
-}
-
 export default Message;

--- a/packages/primevue/src/metergroup/MeterGroup.d.ts
+++ b/packages/primevue/src/metergroup/MeterGroup.d.ts
@@ -303,10 +303,4 @@ export declare type MeterGroupEmits = EmitFn<MeterGroupEmitsOptions>;
  */
 declare const MeterGroup: DefineComponent<MeterGroupProps, MeterGroupSlots, MeterGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        MeterGroup: DefineComponent<MeterGroupProps, MeterGroupSlots, MeterGroupEmits>;
-    }
-}
-
 export default MeterGroup;

--- a/packages/primevue/src/multiselect/MultiSelect.d.ts
+++ b/packages/primevue/src/multiselect/MultiSelect.d.ts
@@ -940,10 +940,4 @@ export interface MultiSelectMethods {
  */
 declare const MultiSelect: DefineComponent<MultiSelectProps, MultiSelectSlots, MultiSelectEmits, MultiSelectMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        MultiSelect: DefineComponent<MultiSelectProps, MultiSelectSlots, MultiSelectEmits, MultiSelectMethods>;
-    }
-}
-
 export default MultiSelect;

--- a/packages/primevue/src/orderlist/OrderList.d.ts
+++ b/packages/primevue/src/orderlist/OrderList.d.ts
@@ -391,10 +391,4 @@ export declare type OrderListEmits = EmitFn<OrderListEmitsOptions>;
  */
 declare const OrderList: DefineComponent<OrderListProps, OrderListSlots, OrderListEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        OrderList: DefineComponent<OrderListProps, OrderListSlots, OrderListEmits>;
-    }
-}
-
 export default OrderList;

--- a/packages/primevue/src/organizationchart/OrganizationChart.d.ts
+++ b/packages/primevue/src/organizationchart/OrganizationChart.d.ts
@@ -367,10 +367,4 @@ export declare type OrganizationChartEmits = EmitFn<OrganizationChartEmitsOption
  */
 declare const OrganizationChart: DefineComponent<OrganizationChartProps, OrganizationChartSlots, OrganizationChartEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        OrganizationChart: DefineComponent<OrganizationChartProps, OrganizationChartSlots, OrganizationChartEmits>;
-    }
-}
-
 export default OrganizationChart;

--- a/packages/primevue/src/overlaybadge/OverlayBadge.d.ts
+++ b/packages/primevue/src/overlaybadge/OverlayBadge.d.ts
@@ -143,10 +143,4 @@ export declare type OverlayBadgeEmits = EmitFn<OverlayBadgeEmitsOptions>;
  */
 declare const OverlayBadge: DefineComponent<OverlayBadgeProps, OverlayBadgeSlots, OverlayBadgeEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        OverlayBadge: DefineComponent<OverlayBadgeProps, OverlayBadgeSlots, OverlayBadgeEmits>;
-    }
-}
-
 export default OverlayBadge;

--- a/packages/primevue/src/overlaypanel/OverlayPanel.d.ts
+++ b/packages/primevue/src/overlaypanel/OverlayPanel.d.ts
@@ -101,10 +101,4 @@ export interface OverlayPanelMethods {
  */
 declare const OverlayPanel: DefineComponent<OverlayPanelProps, OverlayPanelSlots, OverlayPanelEmits, OverlayPanelMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        OverlayPanel: DefineComponent<OverlayPanelProps, OverlayPanelSlots, OverlayPanelEmits, OverlayPanelMethods>;
-    }
-}
-
 export default OverlayPanel;

--- a/packages/primevue/src/paginator/Paginator.d.ts
+++ b/packages/primevue/src/paginator/Paginator.d.ts
@@ -517,10 +517,4 @@ export declare type PaginatorEmits = EmitFn<PaginatorEmitsOptions>;
  */
 declare const Paginator: DefineComponent<PaginatorProps, PaginatorSlots, PaginatorEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Paginator: DefineComponent<PaginatorProps, PaginatorSlots, PaginatorEmits>;
-    }
-}
-
 export default Paginator;

--- a/packages/primevue/src/panel/Panel.d.ts
+++ b/packages/primevue/src/panel/Panel.d.ts
@@ -292,10 +292,4 @@ export declare type PanelEmits = EmitFn<PanelEmitsOptions>;
  */
 declare const Panel: DefineComponent<PanelProps, PanelSlots, PanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Panel: DefineComponent<PanelProps, PanelSlots, PanelEmits>;
-    }
-}
-
 export default Panel;

--- a/packages/primevue/src/panelmenu/PanelMenu.d.ts
+++ b/packages/primevue/src/panelmenu/PanelMenu.d.ts
@@ -405,10 +405,4 @@ export declare type PanelMenuEmits = EmitFn<PanelMenuEmitsOptions>;
  */
 declare const PanelMenu: DefineComponent<PanelMenuProps, PanelMenuSlots, PanelMenuEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        PanelMenu: DefineComponent<PanelMenuProps, PanelMenuSlots, PanelMenuEmits>;
-    }
-}
-
 export default PanelMenu;

--- a/packages/primevue/src/password/Password.d.ts
+++ b/packages/primevue/src/password/Password.d.ts
@@ -447,10 +447,4 @@ export declare type PasswordEmits = EmitFn<PasswordEmitsOptions>;
  */
 declare const Password: DefineComponent<PasswordProps, PasswordSlots, PasswordEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Password: DefineComponent<PasswordProps, PasswordSlots, PasswordEmits>;
-    }
-}
-
 export default Password;

--- a/packages/primevue/src/picklist/PickList.d.ts
+++ b/packages/primevue/src/picklist/PickList.d.ts
@@ -614,10 +614,4 @@ export declare type PickListEmits = EmitFn<PickListEmitsOptions>;
  */
 declare const PickList: DefineComponent<PickListProps, PickListSlots, PickListEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        PickList: DefineComponent<PickListProps, PickListSlots, PickListEmits>;
-    }
-}
-
 export default PickList;

--- a/packages/primevue/src/popover/Popover.d.ts
+++ b/packages/primevue/src/popover/Popover.d.ts
@@ -248,10 +248,4 @@ export interface PopoverMethods {
  */
 declare const Popover: DefineComponent<PopoverProps, PopoverSlots, PopoverEmits, PopoverMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Popover: DefineComponent<PopoverProps, PopoverSlots, PopoverEmits, PopoverMethods>;
-    }
-}
-
 export default Popover;

--- a/packages/primevue/src/portal/Portal.d.ts
+++ b/packages/primevue/src/portal/Portal.d.ts
@@ -30,10 +30,4 @@ export declare type PortalEmits = EmitFn<PortalEmitsOptions>;
 
 declare const Portal: DefineComponent<PortalProps, PortalSlots, PortalEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Portal: DefineComponent<PortalProps, PortalSlots, PortalEmits>;
-    }
-}
-
 export default Portal;

--- a/packages/primevue/src/progressbar/ProgressBar.d.ts
+++ b/packages/primevue/src/progressbar/ProgressBar.d.ts
@@ -137,10 +137,4 @@ export declare type ProgressBarEmits = EmitFn<ProgressBarEmitsOptions>;
  */
 declare const ProgressBar: DefineComponent<ProgressBarProps, ProgressBarSlots, ProgressBarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ProgressBar: DefineComponent<ProgressBarProps, ProgressBarSlots, ProgressBarEmits>;
-    }
-}
-
 export default ProgressBar;

--- a/packages/primevue/src/progressspinner/ProgressSpinner.d.ts
+++ b/packages/primevue/src/progressspinner/ProgressSpinner.d.ts
@@ -135,10 +135,4 @@ export declare type ProgressSpinnerEmits = EmitFn<ProgressSpinnerEmitsOptions>;
  */
 declare const ProgressSpinner: DefineComponent<ProgressSpinnerProps, ProgressSpinnerSlots, ProgressSpinnerEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ProgressSpinner: DefineComponent<ProgressSpinnerProps, ProgressSpinnerSlots, ProgressSpinnerEmits>;
-    }
-}
-
 export default ProgressSpinner;

--- a/packages/primevue/src/radiobutton/RadioButton.d.ts
+++ b/packages/primevue/src/radiobutton/RadioButton.d.ts
@@ -252,10 +252,4 @@ export declare type RadioButtonEmits = EmitFn<RadioButtonEmitsOptions>;
  */
 declare const RadioButton: DefineComponent<RadioButtonProps, RadioButtonSlots, RadioButtonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        RadioButton: DefineComponent<RadioButtonProps, RadioButtonSlots, RadioButtonEmits>;
-    }
-}
-
 export default RadioButton;

--- a/packages/primevue/src/radiobuttongroup/RadioButtonGroup.d.ts
+++ b/packages/primevue/src/radiobuttongroup/RadioButtonGroup.d.ts
@@ -151,10 +151,4 @@ export declare type RadioButtonGroupEmits = EmitFn<RadioButtonGroupEmitsOptions>
  */
 declare const RadioButtonGroup: DefineComponent<RadioButtonGroupProps, RadioButtonGroupSlots, RadioButtonGroupEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        RadioButtonGroup: DefineComponent<RadioButtonGroupProps, RadioButtonGroupSlots, RadioButtonGroupEmits>;
-    }
-}
-
 export default RadioButtonGroup;

--- a/packages/primevue/src/rating/Rating.d.ts
+++ b/packages/primevue/src/rating/Rating.d.ts
@@ -296,10 +296,4 @@ export declare type RatingEmits = EmitFn<RatingEmitsOptions>;
  */
 declare const Rating: DefineComponent<RatingProps, RatingSlots, RatingEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Rating: DefineComponent<RatingProps, RatingSlots, RatingEmits>;
-    }
-}
-
 export default Rating;

--- a/packages/primevue/src/row/Row.d.ts
+++ b/packages/primevue/src/row/Row.d.ts
@@ -117,10 +117,4 @@ export declare type RowEmits = EmitFn<RowEmitsOptions>;
  */
 declare const Row: DefineComponent<RowProps, RowSlots, RowEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Row: DefineComponent<RowProps, RowSlots, RowEmits>;
-    }
-}
-
 export default Row;

--- a/packages/primevue/src/scrollpanel/ScrollPanel.d.ts
+++ b/packages/primevue/src/scrollpanel/ScrollPanel.d.ts
@@ -166,10 +166,4 @@ export declare type ScrollPanelEmits = EmitFn<ScrollPanelEmitsOptions>;
  */
 declare const ScrollPanel: DefineComponent<ScrollPanelProps, ScrollPanelSlots, ScrollPanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ScrollPanel: DefineComponent<ScrollPanelProps, ScrollPanelSlots, ScrollPanelEmits>;
-    }
-}
-
 export default ScrollPanel;

--- a/packages/primevue/src/scrolltop/ScrollTop.d.ts
+++ b/packages/primevue/src/scrolltop/ScrollTop.d.ts
@@ -181,10 +181,4 @@ export declare type ScrollTopEmits = EmitFn<ScrollTopEmitsOptions>;
  */
 declare const ScrollTop: DefineComponent<ScrollTopProps, ScrollTopSlots, ScrollTopEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ScrollTop: DefineComponent<ScrollTopProps, ScrollTopSlots, ScrollTopEmits>;
-    }
-}
-
 export default ScrollTop;

--- a/packages/primevue/src/select/Select.d.ts
+++ b/packages/primevue/src/select/Select.d.ts
@@ -824,10 +824,4 @@ export interface SelectMethods {
  */
 declare const Select: DefineComponent<SelectProps, SelectSlots, SelectEmits, SelectMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Select: DefineComponent<SelectProps, SelectSlots, SelectEmits, SelectMethods>;
-    }
-}
-
 export default Select;

--- a/packages/primevue/src/selectbutton/SelectButton.d.ts
+++ b/packages/primevue/src/selectbutton/SelectButton.d.ts
@@ -277,10 +277,4 @@ export declare type SelectButtonEmits = EmitFn<SelectButtonEmitsOptions>;
  */
 declare const SelectButton: DefineComponent<SelectButtonProps, SelectButtonSlots, SelectButtonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        SelectButton: DefineComponent<SelectButtonProps, SelectButtonSlots, SelectButtonEmits>;
-    }
-}
-
 export default SelectButton;

--- a/packages/primevue/src/sidebar/Sidebar.d.ts
+++ b/packages/primevue/src/sidebar/Sidebar.d.ts
@@ -70,10 +70,4 @@ export declare type SidebarEmits = EmitFn<SidebarEmitsOptions> & Drawer.DrawerEm
  */
 declare const Sidebar: DefineComponent<SidebarProps, SidebarSlots, SidebarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Sidebar: DefineComponent<SidebarProps, SidebarSlots, SidebarEmits>;
-    }
-}
-
 export default Sidebar;

--- a/packages/primevue/src/skeleton/Skeleton.d.ts
+++ b/packages/primevue/src/skeleton/Skeleton.d.ts
@@ -141,10 +141,4 @@ export declare type SkeletonEmits = EmitFn<SkeletonEmitsOptions>;
  */
 declare const Skeleton: DefineComponent<SkeletonProps, SkeletonSlots, SkeletonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Skeleton: DefineComponent<SkeletonProps, SkeletonSlots, SkeletonEmits>;
-    }
-}
-
 export default Skeleton;

--- a/packages/primevue/src/slider/Slider.d.ts
+++ b/packages/primevue/src/slider/Slider.d.ts
@@ -228,10 +228,4 @@ export declare type SliderEmits = EmitFn<SliderEmitsOptions>;
  */
 declare const Slider: DefineComponent<SliderProps, SliderSlots, SliderEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Slider: DefineComponent<SliderProps, SliderSlots, SliderEmits>;
-    }
-}
-
 export default Slider;

--- a/packages/primevue/src/speeddial/SpeedDial.d.ts
+++ b/packages/primevue/src/speeddial/SpeedDial.d.ts
@@ -418,10 +418,4 @@ export declare type SpeedDialEmits = EmitFn<SpeedDialEmitsOptions>;
  */
 declare const SpeedDial: DefineComponent<SpeedDialProps, SpeedDialSlots, SpeedDialEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        SpeedDial: DefineComponent<SpeedDialProps, SpeedDialSlots, SpeedDialEmits>;
-    }
-}
-
 export default SpeedDial;

--- a/packages/primevue/src/splitbutton/SplitButton.d.ts
+++ b/packages/primevue/src/splitbutton/SplitButton.d.ts
@@ -338,10 +338,4 @@ export declare type SplitButtonEmits = EmitFn<SplitButtonEmitsOptions>;
  */
 declare const SplitButton: DefineComponent<SplitButtonProps, SplitButtonSlots, SplitButtonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        SplitButton: DefineComponent<SplitButtonProps, SplitButtonSlots, SplitButtonEmits>;
-    }
-}
-
 export default SplitButton;

--- a/packages/primevue/src/splitter/Splitter.d.ts
+++ b/packages/primevue/src/splitter/Splitter.d.ts
@@ -247,10 +247,4 @@ export interface SplitterMethods {
  */
 declare const Splitter: DefineComponent<SplitterProps, SplitterSlots, SplitterEmits, SplitterMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Splitter: DefineComponent<SplitterProps, SplitterSlots, SplitterEmits, SplitterMethods>;
-    }
-}
-
 export default Splitter;

--- a/packages/primevue/src/splitterpanel/SplitterPanel.d.ts
+++ b/packages/primevue/src/splitterpanel/SplitterPanel.d.ts
@@ -138,10 +138,4 @@ export declare type SplitterPanelEmits = EmitFn<SplitterPanelEmitsOptions>;
  */
 declare const SplitterPanel: DefineComponent<SplitterPanelProps, SplitterPanelSlots, SplitterPanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        SplitterPanel: DefineComponent<SplitterPanelProps, SplitterPanelSlots, SplitterPanelEmits>;
-    }
-}
-
 export default SplitterPanel;

--- a/packages/primevue/src/step/Step.d.ts
+++ b/packages/primevue/src/step/Step.d.ts
@@ -178,10 +178,4 @@ export declare type StepEmits = EmitFn<StepEmitsOptions>;
  */
 declare const Step: DefineComponent<StepProps, StepSlots, StepEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Step: DefineComponent<StepProps, StepSlots, StepEmits>;
-    }
-}
-
 export default Step;

--- a/packages/primevue/src/stepitem/StepItem.d.ts
+++ b/packages/primevue/src/stepitem/StepItem.d.ts
@@ -112,10 +112,4 @@ export declare type StepItemEmits = EmitFn<StepItemEmitsOptions>;
  */
 declare const StepItem: DefineComponent<StepItemProps, StepItemSlots, StepItemEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        StepItem: DefineComponent<StepItemProps, StepItemSlots, StepItemEmits>;
-    }
-}
-
 export default StepItem;

--- a/packages/primevue/src/steplist/StepList.d.ts
+++ b/packages/primevue/src/steplist/StepList.d.ts
@@ -108,10 +108,4 @@ export declare type StepListEmits = EmitFn<StepListEmitsOptions>;
  */
 declare const StepList: DefineComponent<StepListProps, StepListSlots, StepListEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        StepList: DefineComponent<StepListProps, StepListSlots, StepListEmits>;
-    }
-}
-
 export default StepList;

--- a/packages/primevue/src/steppanel/StepPanel.d.ts
+++ b/packages/primevue/src/steppanel/StepPanel.d.ts
@@ -147,10 +147,4 @@ export declare type StepPanelEmits = EmitFn<StepPanelEmitsOptions>;
  */
 declare const StepPanel: DefineComponent<StepPanelProps, StepPanelSlots, StepPanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        StepPanel: DefineComponent<StepPanelProps, StepPanelSlots, StepPanelEmits>;
-    }
-}
-
 export default StepPanel;

--- a/packages/primevue/src/steppanels/StepPanels.d.ts
+++ b/packages/primevue/src/steppanels/StepPanels.d.ts
@@ -108,10 +108,4 @@ export declare type StepPanelsEmits = EmitFn<StepPanelsEmitsOptions>;
  */
 declare const StepPanels: DefineComponent<StepPanelsProps, StepPanelsSlots, StepPanelsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        StepPanels: DefineComponent<StepPanelsProps, StepPanelsSlots, StepPanelsEmits>;
-    }
-}
-
 export default StepPanels;

--- a/packages/primevue/src/stepper/Stepper.d.ts
+++ b/packages/primevue/src/stepper/Stepper.d.ts
@@ -165,10 +165,4 @@ export declare type StepperEmits = EmitFn<StepperEmitsOptions>;
  */
 declare const Stepper: DefineComponent<StepperProps, StepperSlots, StepperEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Stepper: DefineComponent<StepperProps, StepperSlots, StepperEmits>;
-    }
-}
-
 export default Stepper;

--- a/packages/primevue/src/steps/Steps.d.ts
+++ b/packages/primevue/src/steps/Steps.d.ts
@@ -226,10 +226,4 @@ export declare type StepsEmits = EmitFn<StepsEmitsOptions>;
  */
 declare const Steps: DefineComponent<StepsProps, StepsSlots, StepsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Steps: DefineComponent<StepsProps, StepsSlots, StepsEmits>;
-    }
-}
-
 export default Steps;

--- a/packages/primevue/src/tab/Tab.d.ts
+++ b/packages/primevue/src/tab/Tab.d.ts
@@ -141,10 +141,4 @@ export declare type TabEmits = EmitFn<TabEmitsOptions>;
  */
 declare const Tab: DefineComponent<TabProps, TabSlots, TabEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Tab: DefineComponent<TabProps, TabSlots, TabEmits>;
-    }
-}
-
 export default Tab;

--- a/packages/primevue/src/tablist/TabList.d.ts
+++ b/packages/primevue/src/tablist/TabList.d.ts
@@ -139,10 +139,4 @@ export declare type TabListEmits = EmitFn<TabListEmitsOptions>;
  */
 declare const TabList: DefineComponent<TabListProps, TabListSlots, TabListEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TabList: DefineComponent<TabListProps, TabListSlots, TabListEmits>;
-    }
-}
-
 export default TabList;

--- a/packages/primevue/src/tabmenu/TabMenu.d.ts
+++ b/packages/primevue/src/tabmenu/TabMenu.d.ts
@@ -269,10 +269,4 @@ export declare type TabMenuEmits = EmitFn<TabMenuEmitsOptions>;
  */
 declare const TabMenu: DefineComponent<TabMenuProps, TabMenuSlots, TabMenuEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TabMenu: DefineComponent<TabMenuProps, TabMenuSlots, TabMenuEmits>;
-    }
-}
-
 export default TabMenu;

--- a/packages/primevue/src/tabpanel/TabPanel.d.ts
+++ b/packages/primevue/src/tabpanel/TabPanel.d.ts
@@ -227,10 +227,4 @@ export declare type TabPanelEmits = EmitFn<TabPanelEmitsOptions>;
  */
 declare const TabPanel: DefineComponent<TabPanelProps, TabPanelSlots, TabPanelEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TabPanel: DefineComponent<TabPanelProps, TabPanelSlots, TabPanelEmits>;
-    }
-}
-
 export default TabPanel;

--- a/packages/primevue/src/tabpanels/TabPanels.d.ts
+++ b/packages/primevue/src/tabpanels/TabPanels.d.ts
@@ -119,10 +119,4 @@ export declare type TabPanelsEmits = EmitFn<TabPanelsEmitsOptions>;
  */
 declare const TabPanels: DefineComponent<TabPanelsProps, TabPanelsSlots, TabPanelsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TabPanels: DefineComponent<TabPanelsProps, TabPanelsSlots, TabPanelsEmits>;
-    }
-}
-
 export default TabPanels;

--- a/packages/primevue/src/tabs/Tabs.d.ts
+++ b/packages/primevue/src/tabs/Tabs.d.ts
@@ -180,10 +180,4 @@ export declare type TabsEmits = EmitFn<TabsEmitsOptions>;
  */
 declare const Tabs: DefineComponent<TabsProps, TabsSlots, TabsEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Tabs: DefineComponent<TabsProps, TabsSlots, TabsEmits>;
-    }
-}
-
 export default Tabs;

--- a/packages/primevue/src/tabview/TabView.d.ts
+++ b/packages/primevue/src/tabview/TabView.d.ts
@@ -278,10 +278,4 @@ export declare type TabViewEmits = EmitFn<TabViewEmitsOptions>;
  */
 declare const TabView: DefineComponent<TabViewProps, TabViewSlots, TabViewEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TabView: DefineComponent<TabViewProps, TabViewSlots, TabViewEmits>;
-    }
-}
-
 export default TabView;

--- a/packages/primevue/src/tag/Tag.d.ts
+++ b/packages/primevue/src/tag/Tag.d.ts
@@ -148,10 +148,4 @@ export declare type TagEmits = EmitFn<TagEmitsOptions>;
  */
 declare const Tag: DefineComponent<TagProps, TagSlots, TagEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Tag: DefineComponent<TagProps, TagSlots, TagEmits>;
-    }
-}
-
 export default Tag;

--- a/packages/primevue/src/terminal/Terminal.d.ts
+++ b/packages/primevue/src/terminal/Terminal.d.ts
@@ -171,10 +171,4 @@ export declare type TerminalEmits = EmitFn<TerminalEmitsOptions>;
  */
 declare const Terminal: DefineComponent<TerminalProps, TerminalSlots, TerminalEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Terminal: DefineComponent<TerminalProps, TerminalSlots, TerminalEmits>;
-    }
-}
-
 export default Terminal;

--- a/packages/primevue/src/textarea/Textarea.d.ts
+++ b/packages/primevue/src/textarea/Textarea.d.ts
@@ -185,10 +185,4 @@ export declare type TextareaEmits = EmitFn<TextareaEmitsOptions>;
  */
 declare const Textarea: DefineComponent<TextareaProps, TextareaSlots, TextareaEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Textarea: DefineComponent<TextareaProps, TextareaSlots, TextareaEmits>;
-    }
-}
-
 export default Textarea;

--- a/packages/primevue/src/tieredmenu/TieredMenu.d.ts
+++ b/packages/primevue/src/tieredmenu/TieredMenu.d.ts
@@ -415,10 +415,4 @@ export interface TieredMenuMethods {
  */
 declare const TieredMenu: DefineComponent<TieredMenuProps, TieredMenuSlots, TieredMenuEmits, TieredMenuMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TieredMenu: DefineComponent<TieredMenuProps, TieredMenuSlots, TieredMenuEmits, TieredMenuMethods>;
-    }
-}
-
 export default TieredMenu;

--- a/packages/primevue/src/timeline/Timeline.d.ts
+++ b/packages/primevue/src/timeline/Timeline.d.ts
@@ -230,10 +230,4 @@ export declare type TimelineEmits = EmitFn<TimelineEmitsOptions>;
  */
 declare const Timeline: DefineComponent<TimelineProps, TimelineSlots, TimelineEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Timeline: DefineComponent<TimelineProps, TimelineSlots, TimelineEmits>;
-    }
-}
-
 export default Timeline;

--- a/packages/primevue/src/toast/Toast.d.ts
+++ b/packages/primevue/src/toast/Toast.d.ts
@@ -369,10 +369,4 @@ export declare type ToastEmits = EmitFn<ToastEmitsOptions>;
  */
 declare const Toast: DefineComponent<ToastProps, ToastSlots, ToastEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Toast: DefineComponent<ToastProps, ToastSlots, ToastEmits>;
-    }
-}
-
 export default Toast;

--- a/packages/primevue/src/togglebutton/ToggleButton.d.ts
+++ b/packages/primevue/src/togglebutton/ToggleButton.d.ts
@@ -263,10 +263,4 @@ export declare type ToggleButtonEmits = EmitFn<ToggleButtonEmitsOptions>;
  */
 declare const ToggleButton: DefineComponent<ToggleButtonProps, ToggleButtonSlots, ToggleButtonEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ToggleButton: DefineComponent<ToggleButtonProps, ToggleButtonSlots, ToggleButtonEmits>;
-    }
-}
-
 export default ToggleButton;

--- a/packages/primevue/src/toggleswitch/ToggleSwitch.d.ts
+++ b/packages/primevue/src/toggleswitch/ToggleSwitch.d.ts
@@ -246,10 +246,4 @@ export declare type ToggleSwitchEmits = EmitFn<ToggleSwitchEmitsOptions>;
  */
 declare const ToggleSwitch: DefineComponent<ToggleSwitchProps, ToggleSwitchSlots, ToggleSwitchEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        ToggleSwitch: DefineComponent<ToggleSwitchProps, ToggleSwitchSlots, ToggleSwitchEmits>;
-    }
-}
-
 export default ToggleSwitch;

--- a/packages/primevue/src/toolbar/Toolbar.d.ts
+++ b/packages/primevue/src/toolbar/Toolbar.d.ts
@@ -144,10 +144,4 @@ export declare type ToolbarEmits = EmitFn<ToolbarEmitsOptions>;
  */
 declare const Toolbar: DefineComponent<ToolbarProps, ToolbarSlots, ToolbarEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Toolbar: DefineComponent<ToolbarProps, ToolbarSlots, ToolbarEmits>;
-    }
-}
-
 export default Toolbar;

--- a/packages/primevue/src/tree/Tree.d.ts
+++ b/packages/primevue/src/tree/Tree.d.ts
@@ -565,10 +565,4 @@ export declare type TreeEmits = EmitFn<TreeEmitsOptions>;
  */
 declare const Tree: DefineComponent<TreeProps, TreeSlots, TreeEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        Tree: DefineComponent<TreeProps, TreeSlots, TreeEmits>;
-    }
-}
-
 export default Tree;

--- a/packages/primevue/src/treeselect/TreeSelect.d.ts
+++ b/packages/primevue/src/treeselect/TreeSelect.d.ts
@@ -601,10 +601,4 @@ export interface TreeSelectMethods {
  */
 declare const TreeSelect: DefineComponent<TreeSelectProps, TreeSelectSlots, TreeSelectEmits, TreeSelectMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TreeSelect: DefineComponent<TreeSelectProps, TreeSelectSlots, TreeSelectEmits, TreeSelectMethods>;
-    }
-}
-
 export default TreeSelect;

--- a/packages/primevue/src/treetable/TreeTable.d.ts
+++ b/packages/primevue/src/treetable/TreeTable.d.ts
@@ -880,10 +880,4 @@ export declare type TreeTableEmits = EmitFn<TreeTableEmitsOptions>;
  */
 declare const TreeTable: DefineComponent<TreeTableProps, TreeTableSlots, TreeTableEmits>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        TreeTable: DefineComponent<TreeTableProps, TreeTableSlots, TreeTableEmits>;
-    }
-}
-
 export default TreeTable;

--- a/packages/primevue/src/virtualscroller/VirtualScroller.d.ts
+++ b/packages/primevue/src/virtualscroller/VirtualScroller.d.ts
@@ -528,10 +528,4 @@ export interface VirtualScrollerMethods {
  */
 declare const VirtualScroller: DefineComponent<VirtualScrollerProps, VirtualScrollerSlots, VirtualScrollerEmits, VirtualScrollerMethods>;
 
-declare module 'vue' {
-    export interface GlobalComponents {
-        VirtualScroller: DefineComponent<VirtualScrollerProps, VirtualScrollerSlots, VirtualScrollerEmits, VirtualScrollerMethods>;
-    }
-}
-
 export default VirtualScroller;


### PR DESCRIPTION
## Remove `GlobalComponents` Type Definitions

The [Vue language tool](https://github.com/vuejs/language-tools) picks up every `GlobalComponents` definition in the entire project directory, including those in `node_modules`. This causes type pollution for all users, even if they are not globally importing components or are using a global name prefix for their global imports.

### Implications for users that don't use global component imports
The Vue Language Tool explicitly states:
> After registering your global components you can register them in the GlobalComponents interface.
-See: https://github.com/vuejs/language-tools/wiki/Global-Component-Types

Component auto import is optional when using PrimeVue. So it's a bad idea to register these types globally for every user.

These definitions confuse autocomplete and import automation in code editors. Also type safety is greatly hindered, because type checker and linter cannot distinguish whether the component is actually imported globally or not.  Degrading the developer experience.

### Implications for users that do use global component imports
These type definitions are also of little use for users who use global component imports.
When using auto-imports with [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components), the plugin automatically generates the necessary global types, making these manual definitions redundant. See: [Link](https://github.com/unplugin/unplugin-vue-components?tab=readme-ov-file#typescript)

### Ecosystem
- No other major vue component library exposes global component types in this way.
- This behaviour is discouraged, as seen in the Vue Language Tool documentation above.
- Because PrimeVue components share some names with native HTML Tags, These global type definition impacting intellisense on native `<button>` and `<select>` components.

### Related Issues
- https://github.com/primefaces/primevue/issues/3952#issuecomment-2571392554
- https://github.com/primefaces/primevue/issues/6007
- https://github.com/primefaces/primevue/issues/6060


Removing these definitions will reduce confusion, prevent type pollution, and align the project with best practices in the Vue ecosystem.
