### PR TITLE
Feature Requests: Add the prop 'preventArrowKeys'

### DIFF
--- a/packages/primevue/src/inputnumber/BaseInputNumber.vue
+++ b/packages/primevue/src/inputnumber/BaseInputNumber.vue
@@ -140,6 +140,10 @@ export default {
         required: {
             type: Boolean,
             default: false
+        },
+        preventArrowKeys: {
+            type: Boolean,
+            default: false
         }
     },
     style: InputNumberStyle,

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -410,11 +410,13 @@ export default {
 
             switch (code) {
                 case 'ArrowUp':
+                    if (this.preventArrowKeys) break;
                     this.spin(event, 1);
                     event.preventDefault();
                     break;
 
                 case 'ArrowDown':
+                    if (this.preventArrowKeys) break;
                     this.spin(event, -1);
                     event.preventDefault();
                     break;


### PR DESCRIPTION
Some cases, `InputNumber` needs prevention for Arrow keys with still remaining number formatting features.

So I added the prop `preventArrowKeys` that work as described above.

Please check.