### PR TITLE
Update Select.vue to fix issue 7909

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -497,7 +497,7 @@ export default {
             focus(focusableEl);
         },
         onOptionSelect(event, option, isHide = true) {
-            const value = this.getOptionValue(option) !== '' ? this.getOptionValue(option) : this.getOptionLabel(option);
+            const value = this.getOptionValue(option);
             this.updateModel(event, value);
             isHide && this.hide(true);
         },
@@ -863,7 +863,7 @@ export default {
             return this.isValidOption(option) && this.isSelected(option);
         },
         isSelected(option) {
-            return equals(this.d_value, this.getOptionValue(option) !== '' ? this.getOptionValue(option) : this.getOptionLabel(option), this.equalityKey);
+            return equals(this.d_value, this.getOptionValue(option), this.equalityKey);
         },
         findFirstOptionIndex() {
             return this.visibleOptions.findIndex((option) => this.isValidOption(option));
@@ -882,7 +882,7 @@ export default {
             return matchedOptionIndex > -1 ? matchedOptionIndex : index;
         },
         findSelectedOptionIndex() {
-            return this.$filled ? this.visibleOptions.findIndex((option) => this.isValidSelectedOption(option)) : -1;
+            return this.visibleOptions.findIndex((option) => this.isValidSelectedOption(option));
         },
         findFirstFocusedOptionIndex() {
             const selectedIndex = this.findSelectedOptionIndex();


### PR DESCRIPTION
Use the value of this.visibleOptions.findIndex((option) => this.isValidSelectedOption(option)) directly.
Because it can already correctly represent the actual index (-1 (not selected) or x (empty value)).
Revert Commit 3d192cf

### Defect Fixes

fix #7909 
