### PR TITLE
Drop buggy listbox filter blur event handler

### DIFF
--- a/packages/primevue/src/listbox/Listbox.vue
+++ b/packages/primevue/src/listbox/Listbox.vue
@@ -29,7 +29,6 @@
                     :aria-activedescendant="focusedOptionId"
                     :tabindex="!disabled && !focused ? tabindex : -1"
                     @input="onFilterChange"
-                    @blur="onFilterBlur"
                     @keydown="onFilterKeyDown"
                     :pt="ptm('pcFilter')"
                 />
@@ -410,9 +409,6 @@ export default {
         },
         onFilterChange(event) {
             this.$emit('filter', { originalEvent: event, value: event.target.value, filterValue: this.visibleOptions });
-            this.focusedOptionIndex = this.startRangeIndex = -1;
-        },
-        onFilterBlur() {
             this.focusedOptionIndex = this.startRangeIndex = -1;
         },
         onFilterKeyDown(event) {


### PR DESCRIPTION
Resolves #7862

In some contexts that issue is worse than described (e.g. when nested inside of a DataTable filter), as the listbox will outright drop the user's input. It seems like the component is relying on a race condition to correctly register the value change, as the "blur" event handler for the listbox filter clears the selected value.

@tugcekucukoglu As far as I can see there's no reason for this event handler to exist. The "change" event handler already clears the selected value when the user updates the filter, so we don't need to do it again when the input is blurred.