### PR TITLE
fix(DataTable): added missing data-p attributes

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -2155,7 +2155,10 @@ export default {
         dataP() {
             return cn({
                 scrollable: this.scrollable,
-                'flex-scrollable': this.scrollable && this.scrollHeight === 'flex'
+                'flex-scrollable': this.scrollable && this.scrollHeight === 'flex',
+                [this.size]: this.size,
+                loading: this.loading,
+                empty: this.empty
             });
         }
     },


### PR DESCRIPTION
I noticed that some `data-p` attributes aren't present for the DataTable. As [tailwindcss-primeui](https://github.com/primefaces/tailwindcss-primeui) exposes these data-p classes to tailwind custom variants, these values are quite useful when creating custom Tailwind based styling, e.g. for Volt.

fixes: #8062 