### PR TITLE
fix style of checkbox icon when disabled (volt)

### DIFF
--- a/apps/volt/volt/Checkbox.vue
+++ b/apps/volt/volt/Checkbox.vue
@@ -40,7 +40,7 @@ const theme = ref<CheckboxPassThroughOptions>({
         peer-focus-visible:outline-1 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary peer-focus-visible:outline 
         p-invalid:border-red-400 dark:p-invalid:border-red-300
         p-filled:bg-surface-50 dark:p-filled:bg-surface-800
-        p-disabled:bg-surface-200 dark:p-disabled:bg-surface-400 p-disabled:border-surface-300 dark:p-disabled:border-surface-700 p-disabled:text-surface-700 dark:p-disabled:text-surface-400
+        p-disabled:bg-surface-200 dark:p-disabled:bg-surface-400 p-disabled:border-surface-300 dark:p-disabled:border-surface-500 p-disabled:text-surface-400 dark:p-disabled:text-surface-600
         shadow-[0_1px_2px_0_rgba(18,18,23,0.05)] transition-colors duration-200
         p-small:w-4 p-small:h-4
         p-large:w-6 p-large:h-6`,


### PR DESCRIPTION
Fix the Style of the Checkbox in Dark Mode

The check icon was not visible in darkmode when checkbox was disabled.

> dark:p-disabled:bg-surface-400
> dark:p-disabled:text-surface-400

Also tried to add matching style for light/dark mode for disabled checkboxes.

(same problem as in [https://github.com/primefaces/primevue-tailwind/pull/371](https://github.com/primefaces/primevue-tailwind/pull/371) but hopefullly fixed correctly this time)

BEFORE:
<img width="42" height="80" alt="image" src="https://github.com/user-attachments/assets/3824dcc3-47eb-44ad-bd14-2fcc33b8e1d1" />
<img width="42" height="75" alt="image" src="https://github.com/user-attachments/assets/5643ef5c-8e95-4a18-b567-7997c842e3e5" />


AFTER:
<img width="44" height="80" alt="image" src="https://github.com/user-attachments/assets/696e7b76-5bb4-469c-8804-b1792b6bea4f" />
<img width="41" height="74" alt="image" src="https://github.com/user-attachments/assets/d3b5697d-768a-4f54-b831-b181f36fb7c9" />

https://volt.primevue.org/checkbox/#disabled
