### PR TITLE
fix/refactor: rewrite event.code --> event.key

### DIFF
--- a/apps/showcase/components/layout/designer/editor/DesignEditor.vue
+++ b/apps/showcase/components/layout/designer/editor/DesignEditor.vue
@@ -95,7 +95,7 @@ export default {
     },
     methods: {
         onKeyDown(event) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === 'Enter') {
                 this.designerService.applyTheme(this.$appState.designer.theme);
                 event.preventDefault();
             }

--- a/packages/primevue/src/accordionheader/AccordionHeader.vue
+++ b/packages/primevue/src/accordionheader/AccordionHeader.vue
@@ -43,12 +43,14 @@ export default {
             !this.$pcAccordion.selectOnFocus && this.changeActiveValue();
         },
         onKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
@@ -61,8 +63,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onEnterKey(event);
                     break;
 

--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -375,20 +375,24 @@ export default {
                 return;
             }
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -409,15 +413,16 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -425,8 +430,7 @@ export default {
                     this.onTabKey(event);
                     break;
 
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     this.onShiftKey(event);
                     break;
 
@@ -514,12 +518,14 @@ export default {
                 return;
             }
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKeyOnMultiple(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKeyOnMultiple(event);
                     break;
 
@@ -604,8 +610,9 @@ export default {
             });
         },
         onOverlayKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 

--- a/packages/primevue/src/carousel/Carousel.vue
+++ b/packages/primevue/src/carousel/Carousel.vue
@@ -450,12 +450,14 @@ export default {
             }
         },
         onIndicatorKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowRight':
+                case 'Right':
                     this.onRightKey();
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onLeftKey();
                     break;
 
@@ -470,7 +472,9 @@ export default {
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowDown':
+                case 'Down':
                 case 'PageUp':
                 case 'PageDown':
                     event.preventDefault();

--- a/packages/primevue/src/cascadeselect/CascadeSelect.vue
+++ b/packages/primevue/src/cascadeselect/CascadeSelect.vue
@@ -241,20 +241,24 @@ export default {
 
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -266,16 +270,17 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -286,8 +291,7 @@ export default {
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 
@@ -406,8 +410,9 @@ export default {
             });
         },
         onOverlayKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 

--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -135,7 +135,7 @@ export default {
                     break;
 
                 default:
-                    //NoOp
+                    //NOOP
                     break;
             }
 
@@ -391,19 +391,21 @@ export default {
             this.overlayVisible = !this.overlayVisible;
         },
         onInputKeydown(event) {
-            switch (event.code) {
-                case 'Space':
+            switch (event.key) {
+                case ' ':
+                case 'Spacebar':
                     this.overlayVisible = !this.overlayVisible;
                     event.preventDefault();
                     break;
 
                 case 'Escape':
+                case 'Esc':
                 case 'Tab':
                     this.overlayVisible = false;
                     break;
 
                 default:
-                    //NoOp
+                    //NOOP
                     break;
             }
         },

--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -159,14 +159,14 @@ export default {
             this.visible = false;
         },
         onAcceptKeydown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
                 this.accept();
                 focus(this.target);
                 event.preventDefault();
             }
         },
         onRejectKeydown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
                 this.reject();
                 focus(this.target);
                 event.preventDefault();
@@ -295,7 +295,7 @@ export default {
             });
         },
         onOverlayKeydown(event) {
-            if (event.code === 'Escape') {
+            if (event.key === 'Escape' || event.key === 'Esc') {
                 ConfirmationEventBus.emit('close', this.closeListener);
                 focus(this.target);
             }

--- a/packages/primevue/src/contextmenu/ContextMenu.vue
+++ b/packages/primevue/src/contextmenu/ContextMenu.vue
@@ -159,20 +159,24 @@ export default {
         onKeyDown(event) {
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -184,16 +188,17 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -204,8 +209,7 @@ export default {
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 

--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -381,13 +381,13 @@ export default {
         },
         onKeyDown(event) {
             if (this.editMode === 'cell') {
-                switch (event.code) {
+                switch (event.key) {
                     case 'Enter':
-                    case 'NumpadEnter':
                         this.completeEdit(event, 'enter');
                         break;
 
                     case 'Escape':
+                    case 'Esc':
                         this.switchCellToViewMode();
                         this.$emit('cell-edit-cancel', { originalEvent: event, data: this.rowData, field: this.field, index: this.rowIndex });
                         break;

--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -394,15 +394,16 @@ export default {
             event.preventDefault();
         },
         onToggleButtonKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.toggleMenu(event);
 
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.overlayVisible = false;
                     break;
             }
@@ -419,8 +420,9 @@ export default {
         onRowMatchModeKeyDown(event) {
             let item = event.target;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     var nextItem = this.findNextItem(item);
 
                     if (nextItem) {
@@ -433,6 +435,7 @@ export default {
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     var prevItem = this.findPrevItem(item);
 
                     if (prevItem) {

--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -889,12 +889,14 @@ export default {
             if (this.selectionMode) {
                 const row = event.target;
 
-                switch (event.code) {
+                switch (event.key) {
                     case 'ArrowDown':
+                    case 'Down':
                         this.onArrowDownKey(event, row, rowIndex, slotProps);
                         break;
 
                     case 'ArrowUp':
+                    case 'Up':
                         this.onArrowUpKey(event, row, rowIndex, slotProps);
                         break;
 
@@ -907,11 +909,11 @@ export default {
                         break;
 
                     case 'Enter':
-                    case 'NumpadEnter':
                         this.onEnterKey(event, rowData, rowIndex);
                         break;
 
-                    case 'Space':
+                    case ' ':
+                    case 'Spacebar':
                         this.onSpaceKey(event, rowData, rowIndex, slotProps);
                         break;
 
@@ -920,13 +922,13 @@ export default {
                         break;
 
                     default:
-                        if (event.code === 'KeyA' && metaKey && this.isMultipleSelectionMode()) {
+                        if ((event.key === 'a' || event.key === 'A') && metaKey && this.isMultipleSelectionMode()) {
                             const data = this.dataToRender(slotProps.rows);
 
                             this.$emit('update:selection', data);
                         }
 
-                        const isCopyShortcut = event.code === 'KeyC' && metaKey;
+                        const isCopyShortcut = (event.key === 'c' || event.key === 'C') && metaKey;
 
                         if (!isCopyShortcut) event.preventDefault();
 
@@ -1019,7 +1021,7 @@ export default {
             const body = this.$refs.bodyRef && this.$refs.bodyRef.$el;
             const rows = find(body, 'tr[data-p-selectable-row="true"]');
 
-            if (event.code === 'Tab' && rows && rows.length > 0) {
+            if (event.key === 'Tab' && rows && rows.length > 0) {
                 const firstSelectedRow = findSingle(body, 'tr[data-p-selected="true"]');
                 const focusedItem = findSingle(body, 'tr[data-p-selectable-row="true"][tabindex="0"]');
 

--- a/packages/primevue/src/datatable/HeaderCell.vue
+++ b/packages/primevue/src/datatable/HeaderCell.vue
@@ -237,7 +237,7 @@ export default {
             this.$emit('column-click', { originalEvent: event, column: this.column });
         },
         onKeyDown(event) {
-            if ((event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
+            if ((event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
                 this.$emit('column-click', { originalEvent: event, column: this.column });
                 event.preventDefault();
             }

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1519,10 +1519,10 @@ export default {
             this.clearTimePickerTimer();
         },
         onTimePickerElementKeyDown(event, type, direction) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     if (this.isEnabled()) {
                         this.repeat(event, null, type, direction);
                         event.preventDefault();
@@ -1531,10 +1531,10 @@ export default {
             }
         },
         onTimePickerElementKeyUp(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     if (this.isEnabled()) {
                         this.clearTimePickerTimer();
                         this.updateModelTime();
@@ -2115,8 +2115,9 @@ export default {
 
             const cellIndex = getIndex(cell);
 
-            switch (event.code) {
-                case 'ArrowDown': {
+            switch (event.key) {
+                case 'ArrowDown':
+                case 'Down': {
                     cellContent.tabIndex = '-1';
 
                     let nextRow = cell.parentElement.nextElementSibling;
@@ -2150,7 +2151,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowUp': {
+                case 'ArrowUp':
+                case 'Up': {
                     cellContent.tabIndex = '-1';
 
                     if (event.altKey) {
@@ -2189,7 +2191,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     cellContent.tabIndex = '-1';
                     let prevCell = cell.previousElementSibling;
 
@@ -2219,7 +2222,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowRight': {
+                case 'ArrowRight':
+                case 'Right': {
                     cellContent.tabIndex = '-1';
                     let nextCell = cell.nextElementSibling;
 
@@ -2249,15 +2253,15 @@ export default {
                 }
 
                 case 'Enter':
-                case 'NumpadEnter':
-
-                case 'Space': {
+                case ' ':
+                case 'Spacebar': {
                     this.onDateSelect(event, date);
                     event.preventDefault();
                     break;
                 }
 
-                case 'Escape': {
+                case 'Escape':
+                case 'Esc': {
                     this.overlayVisible = false;
                     event.preventDefault();
                     break;
@@ -2326,7 +2330,7 @@ export default {
                 }
 
                 default:
-                    //no op
+                    //NOOP
                     break;
             }
         },
@@ -2359,14 +2363,15 @@ export default {
         onMonthCellKeydown(event, index) {
             const cell = event.currentTarget;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowUp':
-
-                case 'ArrowDown': {
+                case 'Up':
+                case 'ArrowDown':
+                case 'Down': {
                     cell.tabIndex = '-1';
                     var cells = cell.parentElement.children;
                     var cellIndex = getIndex(cell);
-                    let nextCell = cells[event.code === 'ArrowDown' ? cellIndex + 3 : cellIndex - 3];
+                    let nextCell = cells[(event.key === 'ArrowDown' || event.key == 'Down') ? cellIndex + 3 : cellIndex - 3];
 
                     if (nextCell) {
                         nextCell.tabIndex = '0';
@@ -2377,7 +2382,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     cell.tabIndex = '-1';
                     let prevCell = cell.previousElementSibling;
 
@@ -2393,7 +2399,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowRight': {
+                case 'ArrowRight':
+                case 'Right': {
                     cell.tabIndex = '-1';
                     let nextCell = cell.nextElementSibling;
 
@@ -2426,15 +2433,15 @@ export default {
                 }
 
                 case 'Enter':
-                case 'NumpadEnter':
-
-                case 'Space': {
+                case ' ':
+                case 'Spacebar': {
                     this.onMonthSelect(event, index);
                     event.preventDefault();
                     break;
                 }
 
-                case 'Escape': {
+                case 'Escape':
+                case 'Esc': {
                     this.overlayVisible = false;
                     event.preventDefault();
                     break;
@@ -2446,21 +2453,22 @@ export default {
                 }
 
                 default:
-                    //no op
+                    //NOOP
                     break;
             }
         },
         onYearCellKeydown(event, index) {
             const cell = event.currentTarget;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowUp':
-
-                case 'ArrowDown': {
+                case 'Up':
+                case 'ArrowDown':
+                case 'Down': {
                     cell.tabIndex = '-1';
                     var cells = cell.parentElement.children;
                     var cellIndex = getIndex(cell);
-                    let nextCell = cells[event.code === 'ArrowDown' ? cellIndex + 2 : cellIndex - 2];
+                    let nextCell = cells[(event.key === 'ArrowDown' || event.key == 'Down') ? cellIndex + 2 : cellIndex - 2];
 
                     if (nextCell) {
                         nextCell.tabIndex = '0';
@@ -2471,7 +2479,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     cell.tabIndex = '-1';
                     let prevCell = cell.previousElementSibling;
 
@@ -2487,7 +2496,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowRight': {
+                case 'ArrowRight':
+                case 'Right': {
                     cell.tabIndex = '-1';
                     let nextCell = cell.nextElementSibling;
 
@@ -2520,15 +2530,15 @@ export default {
                 }
 
                 case 'Enter':
-                case 'NumpadEnter':
-
-                case 'Space': {
+                case ' ':
+                case 'Spacebar': {
                     this.onYearSelect(event, index);
                     event.preventDefault();
                     break;
                 }
 
-                case 'Escape': {
+                case 'Escape':
+                case 'Esc': {
                     this.overlayVisible = false;
                     event.preventDefault();
                     break;
@@ -2540,7 +2550,7 @@ export default {
                 }
 
                 default:
-                    //no op
+                    //NOOP
                     break;
             }
         },
@@ -2664,18 +2674,19 @@ export default {
             }
         },
         onContainerButtonKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Tab':
                     this.trapFocus(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.overlayVisible = false;
                     event.preventDefault();
                     break;
 
                 default:
-                    //Noop
+                    //NOOP
                     break;
             }
 
@@ -2720,17 +2731,17 @@ export default {
             event.target.value = this.formatValue(this.d_value);
         },
         onKeyDown(event) {
-            if (event.code === 'ArrowDown' && this.overlay) {
+            if ((event.key === 'ArrowDown' || event.key == 'Down') && this.overlay) {
                 this.trapFocus(event);
-            } else if (event.code === 'ArrowDown' && !this.overlay) {
+            } else if (event.key === 'ArrowDown' || event.key == 'Down') {
                 this.overlayVisible = true;
-            } else if (event.code === 'Escape') {
+            } else if (event.key === 'Escape' || event.key === 'Esc') {
                 if (this.overlayVisible) {
                     this.overlayVisible = false;
                     event.preventDefault();
                     event.stopPropagation();
                 }
-            } else if (event.code === 'Tab') {
+            } else if (event.key === 'Tab') {
                 if (this.overlay) {
                     getFocusableElements(this.overlay).forEach((el) => (el.tabIndex = '-1'));
                 }
@@ -2738,7 +2749,7 @@ export default {
                 if (this.overlayVisible) {
                     this.overlayVisible = false;
                 }
-            } else if (event.code === 'Enter') {
+            } else if (event.key === 'Enter') {
                 if (this.manualInput && event.target.value !== null && event.target.value?.trim() !== '') {
                     try {
                         let value = this.parseValue(event.target.value);
@@ -2783,8 +2794,9 @@ export default {
             }
         },
         onOverlayKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     if (!this.inline) {
                         this.input.focus();
                         this.overlayVisible = false;

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -238,7 +238,7 @@ export default {
             }
         },
         onKeyDown(event) {
-            if (event.code === 'Escape' && this.closeOnEscape) {
+            if ((event.key === 'Escape' || event.key === 'Esc') && this.closeOnEscape) {
                 this.close();
             }
         },

--- a/packages/primevue/src/dock/DockSub.vue
+++ b/packages/primevue/src/dock/DockSub.vue
@@ -151,26 +151,30 @@ export default {
             this.$emit('blur', event);
         },
         onListKeyDown(event) {
-            switch (event.code) {
-                case 'ArrowDown': {
+            switch (event.key) {
+                case 'ArrowDown':
+                case 'Down': {
                     if (this.position === 'left' || this.position === 'right') this.onArrowDownKey();
                     event.preventDefault();
                     break;
                 }
 
-                case 'ArrowUp': {
+                case 'ArrowUp':
+                case 'Up': {
                     if (this.position === 'left' || this.position === 'right') this.onArrowUpKey();
                     event.preventDefault();
                     break;
                 }
 
-                case 'ArrowRight': {
+                case 'ArrowRight':
+                case 'Right': {
                     if (this.position === 'top' || this.position === 'bottom') this.onArrowDownKey();
                     event.preventDefault();
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     if (this.position === 'top' || this.position === 'bottom') this.onArrowUpKey();
                     event.preventDefault();
                     break;
@@ -189,9 +193,8 @@ export default {
                 }
 
                 case 'Enter':
-                case 'NumpadEnter':
-
-                case 'Space': {
+                case ' ':
+                case 'Spacebar': {
                     this.onSpaceKey(event);
                     event.preventDefault();
                     break;

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -175,7 +175,7 @@ export default {
             }
         },
         onKeydown(event) {
-            if (event.code === 'Escape') {
+            if (event.key === 'Escape' || event.key === 'Esc') {
                 this.hide();
             }
         },

--- a/packages/primevue/src/fieldset/Fieldset.vue
+++ b/packages/primevue/src/fieldset/Fieldset.vue
@@ -66,7 +66,7 @@ export default {
             });
         },
         onKeyDown(event) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') {
+            if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
                 this.toggle(event);
                 event.preventDefault();
             }

--- a/packages/primevue/src/galleria/Galleria.vue
+++ b/packages/primevue/src/galleria/Galleria.vue
@@ -88,7 +88,7 @@ export default {
             this.mask = el;
         },
         onKeyDown(event) {
-            if (event.code === 'Escape') {
+            if (event.key === 'Escape' || event.key === 'Esc') {
                 this.maskHide();
             }
         },

--- a/packages/primevue/src/galleria/GalleriaItem.vue
+++ b/packages/primevue/src/galleria/GalleriaItem.vue
@@ -147,10 +147,10 @@ export default {
             }
         },
         onIndicatorKeyDown(event, index) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.stopSlideShow();
 
                     this.$emit('update:activeIndex', index);
@@ -158,10 +158,12 @@ export default {
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onRightKey();
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onLeftKey();
                     break;
 
@@ -180,7 +182,9 @@ export default {
                     break;
 
                 case 'ArrowDown':
+                case 'Down':
                 case 'ArrowUp':
+                case 'Up':
                 case 'PageUp':
                 case 'PageDown':
                     event.preventDefault();

--- a/packages/primevue/src/galleria/GalleriaThumbnails.vue
+++ b/packages/primevue/src/galleria/GalleriaThumbnails.vue
@@ -308,17 +308,19 @@ export default {
             }
         },
         onThumbnailKeydown(event, index) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') {
+            if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
                 this.onItemClick(index);
                 event.preventDefault();
             }
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowRight':
+                case 'Right':
                     this.onRightKey();
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onLeftKey();
                     break;
 
@@ -333,7 +335,9 @@ export default {
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowDown':
+                case 'Down':
                     event.preventDefault();
                     break;
 

--- a/packages/primevue/src/image/Image.vue
+++ b/packages/primevue/src/image/Image.vue
@@ -119,8 +119,9 @@ export default {
             this.previewClick = false;
         },
         onMaskKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     this.hidePreview();
                     setTimeout(() => {
                         focus(this.$refs.previewButton);

--- a/packages/primevue/src/inputchips/InputChips.vue
+++ b/packages/primevue/src/inputchips/InputChips.vue
@@ -104,7 +104,7 @@ export default {
         onKeyDown(event) {
             const inputValue = event.target.value;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'Backspace':
                     if (inputValue.length === 0 && this.modelValue && this.modelValue.length > 0) {
                         if (this.focusedIndex !== null) {
@@ -115,7 +115,6 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     if (inputValue && inputValue.trim().length && !this.maxedOut) {
                         this.addItem(event, inputValue, true);
                     }
@@ -123,6 +122,7 @@ export default {
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     if (inputValue.length === 0 && this.modelValue && this.modelValue.length > 0) {
                         this.$refs.container.focus();
                     }
@@ -130,6 +130,7 @@ export default {
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     event.stopPropagation();
                     break;
 
@@ -166,12 +167,14 @@ export default {
             this.focused = false;
         },
         onContainerKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKeyOn(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKeyOn(event);
                     break;
 

--- a/packages/primevue/src/inputmask/InputMask.vue
+++ b/packages/primevue/src/inputmask/InputMask.vue
@@ -127,7 +127,7 @@ export default {
                 return;
             }
 
-            let k = event.code,
+            let k = event.key,
                 pos,
                 begin,
                 end;
@@ -136,14 +136,14 @@ export default {
             this.oldVal = this.$el.value;
 
             //backspace, delete, and escape get special treatment
-            if (k === 'Backspace' || k === 'Delete' || (iPhone && k === 'Escape')) {
+            if (k === 'Backspace' || k === 'Delete' || k === 'Del' || (iPhone && k === 'Escape')) {
                 pos = this.caret();
                 begin = pos.begin;
                 end = pos.end;
 
                 if (end - begin === 0) {
-                    begin = k !== 'Delete' ? this.seekPrev(begin) : (end = this.seekNext(begin - 1));
-                    end = k === 'Delete' ? this.seekNext(end) : end;
+                    begin = (k !== 'Delete' && k !== 'Del') ? this.seekPrev(begin) : (end = this.seekNext(begin - 1));
+                    end = (k === 'Delete' || k === 'Del') ? this.seekNext(end) : end;
                 }
 
                 this.clearBuffer(begin, end);
@@ -155,7 +155,7 @@ export default {
                 // enter
                 this.$el.blur();
                 this.updateModelValue(event.target.value);
-            } else if (k === 'Escape') {
+            } else if (k === 'Escape' || k === 'Esc') {
                 // escape
                 this.$el.value = this.focusText;
                 this.caret(0, this.checkVal());
@@ -170,14 +170,14 @@ export default {
                 return;
             }
 
-            var k = event.code,
+            var k = event.key,
                 pos = this.caret(),
                 p,
                 c,
                 next,
                 completed;
 
-            if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey || event.key === 'CapsLock' || event.key === 'Escape' || event.key === 'Tab') {
+            if (event.ctrlKey || event.altKey || event.metaKey || event.shiftKey || event.key === 'CapsLock' || event.key === 'Escape' || event.key === 'Esc' || event.key === 'Tab') {
                 //Ignore
                 return;
             } else if (k && k !== 'Enter') {

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -358,7 +358,7 @@ export default {
             }
         },
         onUpButtonKeyDown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
                 this.repeat(event, null, 1);
             }
         },
@@ -385,7 +385,7 @@ export default {
             }
         },
         onDownButtonKeyDown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
                 this.repeat(event, null, -1);
             }
         },
@@ -420,20 +420,22 @@ export default {
             let selectionRange = selectionEnd - selectionStart;
             let inputValue = event.target.value;
             let newValueStr = null;
-            const code = event.code || event.key;
 
-            switch (code) {
+            switch (event.key) {
                 case 'ArrowUp':
+                case 'Up':
                     this.spin(event, 1);
                     event.preventDefault();
                     break;
 
                 case 'ArrowDown':
+                case 'Down':
                     this.spin(event, -1);
                     event.preventDefault();
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     if (selectionRange > 1) {
                         const cursorPosition = this.isNumeralChar(inputValue.charAt(selectionStart)) ? selectionStart + 1 : selectionStart + 2;
 
@@ -445,6 +447,7 @@ export default {
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     if (selectionRange > 1) {
                         const cursorPosition = selectionEnd - 1;
 
@@ -457,7 +460,6 @@ export default {
 
                 case 'Tab':
                 case 'Enter':
-                case 'NumpadEnter':
                     newValueStr = this.validateValue(this.parseValue(inputValue));
                     this.$refs.input.$el.value = this.formatValue(newValueStr);
                     this.$refs.input.$el.setAttribute('aria-valuenow', newValueStr);
@@ -512,6 +514,7 @@ export default {
                 }
 
                 case 'Delete':
+                case 'Del':
                     event.preventDefault();
 
                     if (selectionStart === selectionEnd) {
@@ -583,7 +586,7 @@ export default {
             let isDecimalSign = this.isDecimalSign(char);
             const isMinusSign = this.isMinusSign(char);
 
-            if (event.code !== 'Enter') {
+            if (event.key !== 'Enter') {
                 event.preventDefault();
             }
 

--- a/packages/primevue/src/inputotp/InputOtp.vue
+++ b/packages/primevue/src/inputotp/InputOtp.vue
@@ -130,15 +130,18 @@ export default {
                 return;
             }
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowLeft':
+                case 'Left':
                     this.moveToPrev(event);
                     event.preventDefault();
 
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowDown':
+                case 'Down':
                     event.preventDefault();
 
                     break;
@@ -152,18 +155,18 @@ export default {
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.moveToNext(event);
                     event.preventDefault();
 
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                 case 'Tab':
                     break;
 
                 default:
-                    if ((this.integerOnly && !(event.code !== 'Space' && Number(event.key) >= 0 && Number(event.key) <= 9)) || (this.tokens.join('').length >= this.length && event.code !== 'Delete')) {
+                    if ((this.integerOnly && !(event.key !== 'Spacebar' && event.key !== ' ' && Number(event.key) >= 0 && Number(event.key) <= 9)) || (this.tokens.join('').length >= this.length && event.key !== 'Delete' && event.key !== 'Del')) {
                         event.preventDefault();
                     }
 

--- a/packages/primevue/src/knob/Knob.vue
+++ b/packages/primevue/src/knob/Knob.vue
@@ -130,18 +130,20 @@ export default {
         },
         onKeyDown(event) {
             if (!this.disabled && !this.readonly) {
-                switch (event.code) {
+                switch (event.key) {
                     case 'ArrowRight':
-
-                    case 'ArrowUp': {
+                    case 'Right':
+                    case 'ArrowUp':
+                    case 'Up': {
                         event.preventDefault();
                         this.updateModelValue(this.d_value + this.step);
                         break;
                     }
 
                     case 'ArrowLeft':
-
-                    case 'ArrowDown': {
+                    case 'Left':
+                    case 'ArrowDown':
+                    case 'Down': {
                         event.preventDefault();
                         this.updateModelValue(this.d_value - this.step);
                         break;

--- a/packages/primevue/src/listbox/Listbox.vue
+++ b/packages/primevue/src/listbox/Listbox.vue
@@ -251,12 +251,14 @@ export default {
         onListKeyDown(event) {
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
@@ -277,8 +279,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
@@ -286,13 +288,12 @@ export default {
                     //NOOP
                     break;
 
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     this.onShiftKey(event);
                     break;
 
                 default:
-                    if (this.multiple && event.code === 'KeyA' && metaKey) {
+                    if (this.multiple && (event.key === 'A' || event.key === 'a') && metaKey) {
                         const value = this.visibleOptions.filter((option) => this.isValidOption(option)).map((option) => this.getOptionValue(option));
 
                         this.updateModel(event, value);
@@ -410,17 +411,21 @@ export default {
             this.focusedOptionIndex = this.startRangeIndex = -1;
         },
         onFilterKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowLeftKey(event, true);
                     break;
 
@@ -433,12 +438,10 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     this.onShiftKey(event);
                     break;
 

--- a/packages/primevue/src/megamenu/MegaMenu.vue
+++ b/packages/primevue/src/megamenu/MegaMenu.vue
@@ -197,20 +197,24 @@ export default {
 
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -222,16 +226,17 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -242,8 +247,7 @@ export default {
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 
@@ -303,7 +307,7 @@ export default {
             this.toggle(event);
         },
         menuButtonKeydown(event) {
-            (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') && this.menuButtonClick(event);
+            (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') && this.menuButtonClick(event);
         },
         onArrowDownKey(event) {
             if (this.horizontal) {

--- a/packages/primevue/src/menu/Menu.vue
+++ b/packages/primevue/src/menu/Menu.vue
@@ -151,12 +151,14 @@ export default {
             this.$emit('blur', event);
         },
         onListKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
@@ -169,15 +171,16 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     if (this.popup) {
                         focus(this.target);
                         this.hide();

--- a/packages/primevue/src/menubar/Menubar.vue
+++ b/packages/primevue/src/menubar/Menubar.vue
@@ -184,20 +184,24 @@ export default {
         onKeyDown(event) {
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -209,16 +213,17 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -229,8 +234,7 @@ export default {
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 
@@ -306,7 +310,7 @@ export default {
             this.toggle(event);
         },
         menuButtonKeydown(event) {
-            (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') && this.menuButtonClick(event);
+            (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') && this.menuButtonClick(event);
         },
         onArrowDownKey(event) {
             const processedItem = this.visibleItems[this.focusedItemInfo.index];

--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -397,12 +397,14 @@ export default {
 
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
@@ -423,12 +425,13 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -436,13 +439,12 @@ export default {
                     this.onTabKey(event);
                     break;
 
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     this.onShiftKey(event);
                     break;
 
                 default:
-                    if (event.code === 'KeyA' && metaKey) {
+                    if ((event.key === 'A' || event.key === 'a') && metaKey) {
                         const value = this.visibleOptions.filter((option) => this.isValidOption(option)).map((option) => this.getOptionValue(option));
 
                         this.updateModel(event, value);
@@ -534,17 +536,21 @@ export default {
             !this.virtualScrollerDisabled && this.virtualScroller.scrollToIndex(0);
         },
         onFilterKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event, true);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowLeftKey(event, true);
                     break;
 
@@ -557,11 +563,11 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -588,8 +594,9 @@ export default {
             });
         },
         onOverlayKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 

--- a/packages/primevue/src/organizationchart/OrganizationChartNode.vue
+++ b/packages/primevue/src/organizationchart/OrganizationChartNode.vue
@@ -126,7 +126,7 @@ export default {
             this.$emit('node-toggle', node);
         },
         onKeydown(event) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') {
+            if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
                 this.toggleNode();
                 event.preventDefault();
             }

--- a/packages/primevue/src/panel/Panel.vue
+++ b/packages/primevue/src/panel/Panel.vue
@@ -75,7 +75,7 @@ export default {
             });
         },
         onKeyDown(event) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') {
+            if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
                 this.toggle(event);
                 event.preventDefault();
             }

--- a/packages/primevue/src/panelmenu/PanelMenu.vue
+++ b/packages/primevue/src/panelmenu/PanelMenu.vue
@@ -131,12 +131,14 @@ export default {
             focus(event.currentTarget);
         },
         onHeaderKeyDown(event, item) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onHeaderArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onHeaderArrowUpKey(event);
                     break;
 
@@ -149,8 +151,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onHeaderEnterKey(event, item);
                     break;
 

--- a/packages/primevue/src/panelmenu/PanelMenuList.vue
+++ b/packages/primevue/src/panelmenu/PanelMenuList.vue
@@ -98,20 +98,24 @@ export default {
         onKeyDown(event) {
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -123,22 +127,22 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                 case 'Tab':
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 

--- a/packages/primevue/src/password/Password.vue
+++ b/packages/primevue/src/password/Password.vue
@@ -190,7 +190,7 @@ export default {
                 this.meter = meter;
                 this.infoText = label;
 
-                if (event.code === 'Escape') {
+                if (event.key === 'Escape' || event.key === 'Esc') {
                     this.overlayVisible && (this.overlayVisible = false);
 
                     return;

--- a/packages/primevue/src/popover/Popover.vue
+++ b/packages/primevue/src/popover/Popover.vue
@@ -164,17 +164,21 @@ export default {
             }
         },
         onContentKeydown(event) {
-            if (event.code === 'Escape' && this.closeOnEscape) {
+            if ((event.key === 'Escape' || event.key === 'Esc') && this.closeOnEscape) {
                 this.hide();
                 focus(this.target);
             }
         },
         onButtonKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowLeft':
+                case 'Left':
                 case 'ArrowRight':
+                case 'Right':
                     event.preventDefault();
 
                 default:
@@ -189,7 +193,7 @@ export default {
             }
         },
         onKeyDown(event) {
-            if (event.code === 'Escape' && this.closeOnEscape) {
+            if ((event.key === 'Escape' || event.key === 'Esc') && this.closeOnEscape) {
                 this.visible = false;
             }
         },

--- a/packages/primevue/src/scrollpanel/ScrollPanel.vue
+++ b/packages/primevue/src/scrollpanel/ScrollPanel.vue
@@ -187,53 +187,59 @@ export default {
         },
         onKeyDown(event) {
             if (this.orientation === 'vertical') {
-                switch (event.code) {
-                    case 'ArrowDown': {
+                switch (event.key) {
+                    case 'ArrowDown':
+                    case 'Down': {
                         this.setTimer('scrollTop', this.step);
                         event.preventDefault();
                         break;
                     }
 
-                    case 'ArrowUp': {
+                    case 'ArrowUp':
+                    case 'Up': {
                         this.setTimer('scrollTop', this.step * -1);
                         event.preventDefault();
                         break;
                     }
 
                     case 'ArrowLeft':
-
-                    case 'ArrowRight': {
+                    case 'Left':
+                    case 'ArrowRight':
+                    case 'Right': {
                         event.preventDefault();
                         break;
                     }
 
                     default:
-                        //no op
+                        //NOOP
                         break;
                 }
             } else if (this.orientation === 'horizontal') {
-                switch (event.code) {
-                    case 'ArrowRight': {
+                switch (event.key) {
+                    case 'ArrowRight':
+                    case 'Right': {
                         this.setTimer('scrollLeft', this.step);
                         event.preventDefault();
                         break;
                     }
 
-                    case 'ArrowLeft': {
+                    case 'ArrowLeft':
+                    case 'Left': {
                         this.setTimer('scrollLeft', this.step * -1);
                         event.preventDefault();
                         break;
                     }
 
                     case 'ArrowDown':
-
-                    case 'ArrowUp': {
+                    case 'Down':
+                    case 'ArrowUp':
+                    case 'Up': {
                         event.preventDefault();
                         break;
                     }
 
                     default:
-                        //no op
+                        //NOOP
                         break;
                 }
             }

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -374,12 +374,13 @@ export default {
             }
 
             if (isAndroid()) {
-                switch (event.code) {
+                switch (event.key) {
                     case 'Backspace':
                         this.onBackspaceKey(event, this.editable);
                         break;
                     case 'Enter':
-                    case 'NumpadDecimal':
+                    case '.':
+                    case ',':
                         this.onEnterKey(event);
                         break;
                     default:
@@ -390,17 +391,21 @@ export default {
 
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event, this.editable);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowLeftKey(event, this.editable);
                     break;
 
@@ -420,16 +425,17 @@ export default {
                     this.onPageUpKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event, this.editable);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -441,8 +447,7 @@ export default {
                     this.onBackspaceKey(event, this.editable);
                     break;
 
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 
@@ -520,17 +525,21 @@ export default {
             // If event.isComposing is true, it means the user is still composing text and the input is not finalized.
             if (event.isComposing) return;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event, true);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowLeftKey(event, true);
                     break;
 
@@ -543,11 +552,11 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -574,8 +583,9 @@ export default {
             });
         },
         onOverlayKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 

--- a/packages/primevue/src/slider/Slider.vue
+++ b/packages/primevue/src/slider/Slider.vue
@@ -201,15 +201,19 @@ export default {
         onKeyDown(event, index) {
             this.handleIndex = index;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                 case 'ArrowLeft':
+                case 'Left':
                     this.decrementValue(event, index);
                     event.preventDefault();
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowRight':
+                case 'Right':
                     this.incrementValue(event, index);
                     event.preventDefault();
                     break;

--- a/packages/primevue/src/speeddial/SpeedDial.vue
+++ b/packages/primevue/src/speeddial/SpeedDial.vue
@@ -164,20 +164,25 @@ export default {
             return (visible ? index : length - index - 1) * this.transitionDelay;
         },
         onTogglerKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                 case 'ArrowLeft':
+                case 'Left':
                     this.onTogglerArrowDown(event);
 
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                 case 'ArrowRight':
+                case 'Right':
                     this.onTogglerArrowUp(event);
 
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey();
 
                     break;
@@ -187,30 +192,35 @@ export default {
             }
         },
         onKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDown(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUp(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeft(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRight(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 

--- a/packages/primevue/src/splitbutton/SplitButton.vue
+++ b/packages/primevue/src/splitbutton/SplitButton.vue
@@ -97,7 +97,7 @@ export default {
             this.isExpanded = this.$refs.menu.visible;
         },
         onDropdownKeydown(event) {
-            if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
+            if (event.key === 'ArrowDown' || event.key === 'Down' || event.key === 'ArrowUp' || event.key === 'Up') {
                 this.onDropdownButtonClick();
                 event.preventDefault();
             }

--- a/packages/primevue/src/splitter/Splitter.vue
+++ b/packages/primevue/src/splitter/Splitter.vue
@@ -186,8 +186,9 @@ export default {
             this.onResizeEnd();
         },
         onGutterKeyDown(event, index) {
-            switch (event.code) {
-                case 'ArrowLeft': {
+            switch (event.key) {
+                case 'ArrowLeft':
+                case 'Left': {
                     if (this.layout === 'horizontal') {
                         this.setTimer(event, index, this.step * -1);
                     }
@@ -196,7 +197,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowRight': {
+                case 'ArrowRight':
+                case 'Right': {
                     if (this.layout === 'horizontal') {
                         this.setTimer(event, index, this.step);
                     }
@@ -205,7 +207,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowDown': {
+                case 'ArrowDown':
+                case 'Down': {
                     if (this.layout === 'vertical') {
                         this.setTimer(event, index, this.step * -1);
                     }
@@ -214,7 +217,8 @@ export default {
                     break;
                 }
 
-                case 'ArrowUp': {
+                case 'ArrowUp':
+                case 'Up': {
                     if (this.layout === 'vertical') {
                         this.setTimer(event, index, this.step);
                     }
@@ -224,7 +228,7 @@ export default {
                 }
 
                 default:
-                    //no op
+                    //NOOP
                     break;
             }
         },

--- a/packages/primevue/src/steps/Steps.vue
+++ b/packages/primevue/src/steps/Steps.vue
@@ -87,14 +87,16 @@ export default {
             });
         },
         onItemKeydown(event, item) {
-            switch (event.code) {
-                case 'ArrowRight': {
+            switch (event.key) {
+                case 'ArrowRight':
+                case 'Right': {
                     this.navigateToNextItem(event.target);
                     event.preventDefault();
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     this.navigateToPrevItem(event.target);
                     event.preventDefault();
                     break;
@@ -113,13 +115,12 @@ export default {
                 }
 
                 case 'Tab':
-                    //no op
+                    //NOOP
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-
-                case 'Space': {
+                case ' ':
+                case 'Spacebar': {
                     this.onItemClick(event, item);
                     event.preventDefault();
                     break;

--- a/packages/primevue/src/tab/Tab.vue
+++ b/packages/primevue/src/tab/Tab.vue
@@ -26,12 +26,14 @@ export default {
             this.changeActiveValue();
         },
         onKeydown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
@@ -52,8 +54,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onEnterKey(event);
                     break;
 

--- a/packages/primevue/src/tabmenu/TabMenu.vue
+++ b/packages/primevue/src/tabmenu/TabMenu.vue
@@ -99,14 +99,16 @@ export default {
             });
         },
         onKeydownItem(event, item, index) {
-            switch (event.code) {
-                case 'ArrowRight': {
+            switch (event.key) {
+                case 'ArrowRight':
+                case 'Right': {
                     this.navigateToNextItem(event.target);
                     event.preventDefault();
                     break;
                 }
 
-                case 'ArrowLeft': {
+                case 'ArrowLeft':
+                case 'Left': {
                     this.navigateToPrevItem(event.target);
                     event.preventDefault();
                     break;
@@ -124,9 +126,8 @@ export default {
                     break;
                 }
 
-                case 'Space':
-                case 'NumpadEnter':
-
+                case ' ':
+                case 'Spacebar':
                 case 'Enter': {
                     this.onItemClick(event, item, index);
                     event.preventDefault();

--- a/packages/primevue/src/tabview/TabView.vue
+++ b/packages/primevue/src/tabview/TabView.vue
@@ -191,12 +191,14 @@ export default {
             this.$emit('tab-click', { originalEvent: event, index });
         },
         onTabKeyDown(event, tab, index) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowLeft':
+                case 'Left':
                     this.onTabArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onTabArrowRightKey(event);
                     break;
 
@@ -217,8 +219,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onTabEnterKey(event, tab, index);
                     break;
 

--- a/packages/primevue/src/tieredmenu/TieredMenu.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenu.vue
@@ -185,20 +185,24 @@ export default {
 
             const metaKey = event.metaKey || event.ctrlKey;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -210,16 +214,17 @@ export default {
                     this.onEndKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onSpaceKey(event);
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -230,8 +235,7 @@ export default {
                 case 'PageDown':
                 case 'PageUp':
                 case 'Backspace':
-                case 'ShiftLeft':
-                case 'ShiftRight':
+                case 'Shift':
                     //NOOP
                     break;
 

--- a/packages/primevue/src/tooltip/Tooltip.js
+++ b/packages/primevue/src/tooltip/Tooltip.js
@@ -210,7 +210,7 @@ const Tooltip = BaseTooltip.extend('tooltip', {
             const el = event.currentTarget;
             const hideDelay = el.$_ptooltipHideDelay;
 
-            event.code === 'Escape' && this.hide(event.currentTarget, hideDelay);
+            (event.key === 'Escape' || event.key === 'Esc') && this.hide(event.currentTarget, hideDelay);
         },
         onWindowResize(el) {
             if (!isTouchDevice()) {

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -174,7 +174,7 @@ export default {
             return node.leaf === false ? false : !(node.children && node.children.length);
         },
         onFilterKeyup(event) {
-            if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === 'Enter') {
                 event.preventDefault();
             }
 

--- a/packages/primevue/src/tree/TreeNode.vue
+++ b/packages/primevue/src/tree/TreeNode.vue
@@ -178,35 +178,39 @@ export default {
         onKeyDown(event) {
             if (!this.isSameNode(event)) return;
 
-            switch (event.code) {
+            switch (event.key) {
                 case 'Tab':
                     this.onTabKey(event);
 
                     break;
 
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDown(event);
 
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUp(event);
 
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRight(event);
 
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeft(event);
 
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     this.onEnterKey(event);
 
                     break;

--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -275,18 +275,20 @@ export default {
             focus(focusableEl);
         },
         onKeyDown(event) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                 case 'Enter':
-                case 'NumpadEnter':
                     this.onEnterKey(event);
                     break;
 
                 case 'Escape':
+                case 'Esc':
                     this.onEscapeKey(event);
                     break;
 
@@ -448,7 +450,7 @@ export default {
             this.selfClick = true;
         },
         onOverlayKeydown(event) {
-            if (event.code === 'Escape') this.hide();
+            if (event.key === 'Escape' || event.key === 'Esc') this.hide();
         },
         fillNodeMap(node, nodeMap) {
             nodeMap[node.key] = node;

--- a/packages/primevue/src/treetable/HeaderCell.vue
+++ b/packages/primevue/src/treetable/HeaderCell.vue
@@ -151,7 +151,7 @@ export default {
             this.$emit('column-click', { originalEvent: event, column: this.column });
         },
         onKeyDown(event) {
-            if ((event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
+            if ((event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
                 this.$emit('column-click', { originalEvent: event, column: this.column });
 
                 event.preventDefault();

--- a/packages/primevue/src/treetable/TreeTable.vue
+++ b/packages/primevue/src/treetable/TreeTable.vue
@@ -779,7 +779,7 @@ export default {
             }
         },
         onColumnKeyDown(event, col) {
-            if ((event.code === 'Enter' || event.code === 'NumpadEnter') && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
+            if (event.key === 'Enter' && event.currentTarget.nodeName === 'TH' && getAttribute(event.currentTarget, 'data-p-sortable-column')) {
                 this.onColumnHeaderClick(event, col);
             }
         },

--- a/packages/primevue/src/treetable/TreeTableRow.vue
+++ b/packages/primevue/src/treetable/TreeTableRow.vue
@@ -182,20 +182,24 @@ export default {
             return resolveFieldData(node, this.dataKey);
         },
         onKeyDown(event, item) {
-            switch (event.code) {
+            switch (event.key) {
                 case 'ArrowDown':
+                case 'Down':
                     this.onArrowDownKey(event);
                     break;
 
                 case 'ArrowUp':
+                case 'Up':
                     this.onArrowUpKey(event);
                     break;
 
                 case 'ArrowLeft':
+                case 'Left':
                     this.onArrowLeftKey(event);
                     break;
 
                 case 'ArrowRight':
+                case 'Right':
                     this.onArrowRightKey(event);
                     break;
 
@@ -208,8 +212,8 @@ export default {
                     break;
 
                 case 'Enter':
-                case 'NumpadEnter':
-                case 'Space':
+                case ' ':
+                case 'Spacebar':
                     if (!isClickable(event.target)) {
                         this.onEnterKey(event, item);
                     }


### PR DESCRIPTION
Fully cross-browser compatible

As we know, there may be issues with tracking event.code on mobile devices. In my experience, it is considered better practice to track key keyboard events rather than codes.
in this connection, I noticed **a real bug in the InputOtp component on Chrome for Android: event.code is not even recognized by the browser.**

**As a result, on Android it is impossible to delete entered characters in InputOtp — the component listens for 'Backspace' via event.code, but the browser never provides it.**

I initially started with just fixing the InputOtp bug, but then decided to migrate from event.code to event.key across the entire library for consistency.
All known quirks of event.key in older browsers have been taken into account.

There are many changes, but all of them are logically straightforward — it’s mostly a matter of verifying the **event.code ↔ event.key** mapping.

P.S. If this PR gets rejected, I’ll of course submit a small bugfix for InputOtp (just a few lines). However, it would be better to apply the event.code → event.key migration across the entire codebase for consistency.
