### PR TITLE
Fixed #8094 - Listbox: Add support for number array options

### DIFF
--- a/packages/primevue/src/listbox/Listbox.spec.js
+++ b/packages/primevue/src/listbox/Listbox.spec.js
@@ -36,6 +36,37 @@ describe('Listbox.vue', () => {
         expect(wrapper.findAll('li.p-listbox-option')[0].classes()).toContain('p-listbox-option-selected');
     });
 
+    it('should handle number array options correctly', async () => {
+        // Test with pure number array
+        await wrapper.setProps({
+            modelValue: null,
+            options: [1, 2, 3, 4, 5],
+            optionLabel: null // Clear optionLabel to test primitive values
+        });
+
+        // Check that number options are rendered correctly
+        const options = wrapper.findAll('li.p-listbox-option');
+
+        expect(options.length).toBe(5);
+        expect(options[0].text()).toBe('1');
+        expect(options[1].text()).toBe('2');
+        expect(options[4].text()).toBe('5');
+
+        // Check aria-label for number options
+        expect(options[0].attributes()['aria-label']).toBe('1');
+        expect(options[2].attributes()['aria-label']).toBe('3');
+
+        // Test selection with number values
+        await wrapper.vm.onOptionSelect({}, 3);
+        expect(wrapper.emitted()['update:modelValue'][0]).toEqual([3]);
+
+        // Test that selected number option gets correct styling
+        await wrapper.setProps({ modelValue: 3 });
+        const selectedOption = wrapper.findAll('li.p-listbox-option')[2]; // Index 2 for value 3
+
+        expect(selectedOption.classes()).toContain('p-listbox-option-selected');
+    });
+
     describe('filter', () => {
         it('should have correct custom icon', async () => {
             await wrapper.setProps({

--- a/packages/primevue/src/listbox/Listbox.vue
+++ b/packages/primevue/src/listbox/Listbox.vue
@@ -176,7 +176,11 @@ export default {
             return this.virtualScrollerDisabled ? index : fn && fn(index)['index'];
         },
         getOptionLabel(option) {
-            return this.optionLabel ? resolveFieldData(option, this.optionLabel) : typeof option === 'string' ? option : null;
+            if (this.optionLabel) {
+                const resolved = resolveFieldData(option, this.optionLabel);
+                return resolved !== null ? resolved : this.isOptionPrimitive(option) ? String(option) : null;
+            }
+            return this.isOptionPrimitive(option) ? String(option) : null;
         },
         getOptionValue(option) {
             return this.optionValue ? resolveFieldData(option, this.optionValue) : option;
@@ -543,6 +547,9 @@ export default {
         },
         isValidOption(option) {
             return isNotEmpty(option) && !(this.isOptionDisabled(option) || this.isOptionGroup(option));
+        },
+        isOptionPrimitive(option) {
+            return typeof option === 'string' || typeof option === 'number' || typeof option === 'boolean';
         },
         isValidSelectedOption(option) {
             return this.isValidOption(option) && this.isSelected(option);


### PR DESCRIPTION
### Defect Fixes

[#8094](https://github.com/primefaces/primevue/issues/8094)

### Feature Requests

When `optionLabel` is set (e.g., `"name"`) and `options` contains primitive values (e.g., `[1, 2, 3]`):
1. `resolveFieldData(1, "name")` returns `null` (since `1["name"]` is undefined)
2. The ternary operator short-circuits and returns `null`
3. Options render as blank

```javascript
// Before (problematic)
getOptionLabel(option) {
    return this.optionLabel ? resolveFieldData(option, this.optionLabel) : this.isOptionPrimitive(option) ? String(option) : null;
}
```

### Solution

1. When `resolveFieldData()` returns `null`, check if the option is a primitive type
2. Object arrays continue to work exactly as before
3. Aligns implementation with documented behavior

```javascript
// After (fixed)
getOptionLabel(option) {
    if (this.optionLabel) {
        const resolved = resolveFieldData(option, this.optionLabel);
        return resolved !== null ? resolved : this.isOptionPrimitive(option) ? String(option) : null;
    }
    return this.isOptionPrimitive(option) ? String(option) : null;
}
```