### PR TITLE
Fix parseDateTime when format has spaces

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1858,17 +1858,17 @@ export default {
         },
         parseDateTime(text) {
             let date;
-            let parts = text.split(' ');
+            let parts = text.match(/(?:(.+?) )?(\d{2}:\d{2})(?: (am|pm))?/);
 
             if (this.timeOnly) {
                 date = new Date();
-                this.populateTime(date, parts[0], parts[1]);
+                this.populateTime(date, parts[2], parts[3]);
             } else {
                 const dateFormat = this.datePattern;
 
                 if (this.showTime) {
-                    date = this.parseDate(parts[0], dateFormat);
-                    this.populateTime(date, parts[1], parts[2]);
+                    date = this.parseDate(parts[1], dateFormat);
+                    this.populateTime(date, parts[2], parts[3]);
                 } else {
                     date = this.parseDate(text, dateFormat);
                 }


### PR DESCRIPTION
### Defect Fixes

Fixes #8075

The `parseDate` method misbehaves when the date format contains spaces. The issue lies in this line:

```
let parts = text.split(' ');

// then, later:
date = this.parseDate(parts[0], dateFormat);
```

Let's compare two different formats, and the problem becomes apparent:

| Format    | `text` | `parts[0]` |
| -------- | ------- | ------- |
| `dd-mm-yy` | `'13-09-2025 14:54'`    | `'13-09-2025'`
| `dd mm yy` | `'13 09 2025 14:54'`     | `'13'`

If you use `dd mm yy`, `parts[0]` is now just `'13'`, which makes the parseDate() method think it's an invalid date.

### Solution

The solution is to replace splitting on spaces with a RegExp matcher:

```
let parts = text.match(/(?:(.+?) )?(\d{2}:\d{2})(?: (am|pm))?/);

// breaking down the regex:
/
  (?:(.+?) )?   // optionally match anything followed by a space (this backreference will contain the date)
  (\d{2}:\d{2}) // match hh:mm
  (?: (am|pm))? // optionally match am/pm
/
```

Note that when there is no time component, the entire `text` string is passed to parseDate. This code change only affects parsing of date+time and time only strings.