### PR TITLE
Fix #7995 - unformatted date being displayed when clicking on the same date

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1253,7 +1253,7 @@ export default {
             let modelVal = null;
 
             if (this.isSingleSelection()) {
-                modelVal = date;
+                modelVal = (this.d_value?.getTime() !== date.getTime()) ? date : null;
             } else if (this.isMultipleSelection()) {
                 modelVal = this.d_value ? [...this.d_value, date] : [date];
             } else if (this.isRangeSelection()) {


### PR DESCRIPTION
### Defect Fixes

Fixes #7995 -- unformatted dates are being displayed if the user clicks on the same date as the one that's already selected. This issue manifests itself only when DatePicker is used with forms.

This happens because the value displayed on the input is a computed value (in `primevue/src/datepicker/DatePicker.vue`):

```
inputFieldValue() {
    return this.formatValue(this.d_value);
},
```

But `useForm`'s `defineField` has an event listener that modifies the field's value directly (in `forms/src/useform/index.js`):

```
onChange: (event) => {
    _states[field].value = event && Object.hasOwn(event, 'value') ? event.value : event.target.type === 'checkbox' || event.target.type === 'radio' ? event.target.checked : event.target.value;
},
```

If the same date is selected, a change event is still fired, which sets the field value to the same `Date` -- only it's now unformatted. But the computed display value is never recalculated since `d_value` remains unchanged, so it fails to display the formatted date.

### Solution

In `selectDate`, if we set `modelVal` to a non-null value only when the date actually changes, we can prevent `this.updateModel()` from being called. This stops the change event from being fired and then unnecessarily handled by the forms code.

Ideally, the value of a form input should only be controlled by one component, to prevent confusion and bugs like this. Perhaps the redesigned forms can take this into consideration.