### PR TITLE
Fix #7521 – use composedPath in MultiSelect to detect target in shadow root events

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.vue
+++ b/packages/primevue/src/multiselect/MultiSelect.vue
@@ -777,7 +777,8 @@ export default {
         bindOutsideClickListener() {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = (event) => {
-                    if (this.overlayVisible && this.isOutsideClicked(event)) {
+                    const composedPath = event.composedPath();
+                    if (this.overlayVisible && this.overlay && !composedPath.includes(this.$el) && !composedPath.includes(this.overlay)) {
                         this.hide();
                     }
                 };
@@ -823,9 +824,6 @@ export default {
                 window.removeEventListener('resize', this.resizeListener);
                 this.resizeListener = null;
             }
-        },
-        isOutsideClicked(event) {
-            return !(this.$el.isSameNode(event.target) || this.$el.contains(event.target) || (this.overlay && this.overlay.contains(event.target)));
         },
         getLabelByValue(value) {
             const options = this.optionGroupLabel ? this.flatOptions(this.options) : this.options || [];


### PR DESCRIPTION
### Defect Fixes

Fixes https://github.com/primefaces/primevue/issues/7521

When `MultiSelect` is used inside a shadow root, clicks inside the overlay are not detected correctly. The existing `isOutsideClicked` method relies on `event.target` and `contains()`, which don’t behave as expected across shadow DOM boundaries. As a result, interactions inside the overlay (e.g., clicking the filter input or selecting an option) are treated as outside clicks, causing the overlay to close unexpectedly.

In contrast, the `Select` component already handles this properly by using `event.composedPath()` to determine whether the click originated from inside the component or its overlay.

### Suggested fix

Unify the behavior between `MultiSelect` and `Select` by replacing the `isOutsideClicked` check with logic based on `event.composedPath()`. This ensures correct event target detection both in the light DOM and shadow DOM contexts.