### PR TITLE
Fix #8109 - selecting multiple items in AutoComplete

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -592,9 +592,10 @@ export default {
                 const value = this.visibleOptions
                     .slice(rangeStart, rangeEnd + 1)
                     .filter((option) => this.isValidOption(option))
+                    .filter((option) => !this.isSelected(option))                    
                     .map((option) => this.getOptionValue(option));
 
-                this.updateModel(event, value);
+                this.updateModel(event, [...(this.d_value || []), ...value]);
             }
         },
         onOverlayClick(event) {


### PR DESCRIPTION
### Defect Fixes

Fixes #8109

AutoComplete `onOptionSelectRange` did not include previous values in `this.updateModel`, causing the previous selection to be "forgotten"