### PR TITLE
Do not unblock body scroll when the dismissable value changes to false

### DIFF
--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -76,7 +76,7 @@ export default {
             if (newValue) {
                 this.enableDocumentSettings();
             } else {
-                this.disableDocumentSettings();
+                this.unbindOutsideClickListener();
             }
         }
     },


### PR DESCRIPTION
### Defect Fixes

This PR addresses an issue with the Vue Drawer component’s dismissable prop.

Currently, the component is watching dismissable and toggles the body scroll lock based on its value:

When dismissable = true, the body scroll is blocked.

When dismissable changes to false, the body scroll is unblocked.

This behavior is incorrect because the scroll lock should not be tied directly to the dismissable state. A drawer that is open should continue to block body scroll regardless of whether it is dismissable or not.

### Fix

Updated the drawer logic to ensure body scroll remains blocked while the drawer is open, independent of changes to the dismissable value.

This fix ensures a consistent user experience where background scrolling is prevented whenever the drawer is active.
