### PR TITLE
feat(drawer): add closeOnEscape prop to control closing on Escape Key

### DIFF
--- a/apps/showcase/doc/common/apidoc/index.json
+++ b/apps/showcase/doc/common/apidoc/index.json
@@ -28092,6 +28092,14 @@
                             "description": "Used to pass the custom value to read for the button inside the component."
                         },
                         {
+                            "name": "closeOnEscape",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "true",
+                            "description": "Specifies if pressing escape key should hide the drawer."
+                        },
+                        {
                             "name": "closeIcon",
                             "optional": true,
                             "readonly": false,

--- a/packages/primevue/src/drawer/BaseDrawer.vue
+++ b/packages/primevue/src/drawer/BaseDrawer.vue
@@ -51,6 +51,10 @@ export default {
         blockScroll: {
             type: Boolean,
             default: false
+        },
+        closeOnEscape: {
+            type: Boolean,
+            default: true
         }
     },
     style: DrawerStyle,

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -200,6 +200,11 @@ export interface DrawerProps {
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * Specifies if pressing escape key should hide the drawer.
+     * @defaultValue true
+     */
+    closeOnEscape?: boolean | undefined;
 }
 
 /**

--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -175,7 +175,7 @@ export default {
             }
         },
         onKeydown(event) {
-            if (event.code === 'Escape') {
+            if (event.code === 'Escape' && this.closeOnEscape) {
                 this.hide();
             }
         },


### PR DESCRIPTION
This PR adds a new closeOnEscape prop to the Drawer component. 
By default it is true (current behavior), but setting it to false prevents the Drawer from closing when pressing Escape.