### PR TITLE
Fix: Ensure d_value updates render correctly for quill editor for unc…

### DIFF
--- a/packages/primevue/src/editor/Editor.vue
+++ b/packages/primevue/src/editor/Editor.vue
@@ -71,6 +71,11 @@ export default {
                 this.renderValue(newValue);
             }
         },
+        d_value(newValue, oldValue) {
+            if (newValue !== oldValue && this.quill && !this.quill.hasFocus()) {
+                this.renderValue(newValue);
+            }
+        },
         readonly() {
             this.handleReadOnlyChange();
         }
@@ -86,7 +91,6 @@ export default {
             formats: this.formats,
             placeholder: this.placeholder
         };
-
         if (QuillJS) {
             // Loaded by script only
             this.quill = new QuillJS(this.$refs.editorElement, configuration);


### PR DESCRIPTION
…ontroll form.

This PR addresses an issue where calling form.reset() does not properly reset the visible content of the Editor component (Quill-based). Although the bound model value (d_value) is being updated behind the scenes, the UI remains unchanged, which can be misleading to users.

This behavior has been reported in the following issue: [primefaces/primevue#8080](https://github.com/primefaces/primevue/issues/8080)

**Root Cause**

This issue occurs particularly with uncontrolled forms. While the internal state (d_value) is updated correctly, the Quill editor does not automatically reflect this change. Unlike other input components, the Quill editor requires an explicit call to update its content when the value is changed programmatically.

**Fix**

To resolve this, I’ve added logic to manually update the Quill editor’s content inside the modelValue watcher, similar to how it's handled in controlled scenarios. This ensures that both the internal state and the visible content in the editor stay in sync.