### PR TITLE
Feat: Popover - conditionally bind scroll listener based on hideOnScroll prop

### DIFF
--- a/packages/primevue/src/popover/Popover.vue
+++ b/packages/primevue/src/popover/Popover.vue
@@ -31,7 +31,8 @@ export default {
     emits: ['show', 'hide'],
     data() {
         return {
-            visible: false
+            visible: false,
+            hideOnScroll: true
         };
     },
     watch: {
@@ -110,7 +111,10 @@ export default {
                 this.bindOutsideClickListener();
             }
 
-            this.bindScrollListener();
+            if (this.hideOnScroll) {
+                this.bindScrollListener();
+            }
+
             this.bindResizeListener();
 
             if (this.autoZIndex) {


### PR DESCRIPTION
When using a Popover inside a parent with an overflow scroll, the Popover will hide when the parent is scrolled.
This behavior has also been reported here: https://github.com/primefaces/primeng/issues/11470

This fixes https://github.com/primefaces/primevue/issues/8129