### PR TITLE
Add collapsed to panel header slot

### DIFF
--- a/packages/primevue/src/panel/Panel.d.ts
+++ b/packages/primevue/src/panel/Panel.d.ts
@@ -208,6 +208,10 @@ export interface PanelSlots {
          * Style class of the icon
          */
         class: string;
+        /**
+         * Collapsed state as a boolean
+         */
+        collapsed: boolean,
     }): VNode[];
     /**
      * Custom icons template.

--- a/packages/primevue/src/panel/Panel.vue
+++ b/packages/primevue/src/panel/Panel.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="cx('root')" :data-p="dataP" v-bind="ptmi('root')">
         <div :class="cx('header')" :data-p="dataP" v-bind="ptm('header')">
-            <slot :id="$id + '_header'" name="header" :class="cx('title')">
+            <slot :id="$id + '_header'" name="header" :class="cx('title')" :collapsed="d_collapsed" >
                 <span v-if="header" :id="$id + '_header'" :class="cx('title')" v-bind="ptm('title')">{{ header }}</span>
             </slot>
             <div :class="cx('headerActions')" v-bind="ptm('headerActions')">


### PR DESCRIPTION
Panel component has a number of slots.
The header slot is missing the collapsed state.
