### PR TITLE
Indicate indeterminate state with prop iso aria-checked attr

### DIFF
--- a/packages/primevue/src/checkbox/Checkbox.vue
+++ b/packages/primevue/src/checkbox/Checkbox.vue
@@ -1,6 +1,7 @@
 <template>
     <div :class="cx('root')" v-bind="getPTOptions('root')" :data-p-checked="checked" :data-p-indeterminate="d_indeterminate || undefined" :data-p-disabled="disabled" :data-p="dataP">
         <input
+            ref="input"
             :id="inputId"
             type="checkbox"
             :class="[cx('input'), inputClass]"
@@ -15,7 +16,6 @@
             :aria-labelledby="ariaLabelledby"
             :aria-label="ariaLabel"
             :aria-invalid="invalid || undefined"
-            :aria-checked="d_indeterminate ? 'mixed' : undefined"
             @focus="onFocus"
             @blur="onBlur"
             @change="onChange"
@@ -55,7 +55,15 @@ export default {
     watch: {
         indeterminate(newValue) {
             this.d_indeterminate = newValue;
-        }
+
+            this.updateIndeterminate();
+        },
+    },
+    mounted() {
+        this.updateIndeterminate();
+    },
+    updated() {
+        this.updateIndeterminate();
     },
     methods: {
         getPTOptions(key) {
@@ -96,6 +104,11 @@ export default {
         onBlur(event) {
             this.$emit('blur', event);
             this.formField.onBlur?.(event);
+        },
+        updateIndeterminate() {
+            if (this.$refs.input) {
+                this.$refs.input.indeterminate = this.d_indeterminate;
+            }
         }
     },
     computed: {


### PR DESCRIPTION
Storybook’s [accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) identifies problems with the way the PrimeVue Checkbox component manages its indeterminate state. The implementation currently applies **aria-checked="mixed"** to the internal input element. This is problematic because native input **type="checkbox"** elements do not support **aria-checked**, that attribute is reserved for custom controls that mimic checkboxes. For native checkboxes, the correct method is to set the indeterminate state via the element’s indeterminate property.

Relevant issue: https://github.com/primefaces/primevue/issues/8142