### PR TITLE
fix(image): consolidate emits options and methods

### DIFF
--- a/packages/primevue/src/image/Image.d.ts
+++ b/packages/primevue/src/image/Image.d.ts
@@ -318,30 +318,24 @@ export interface ImageSlots {
     }): VNode[];
 }
 
-export interface ImageEmitsOptions {}
-
-export declare type ImageEmits = EmitFn<ImageEmitsOptions>;
-
-export interface ImageMethods {
+export interface ImageEmitsOptions {
     /**
      * Triggered when the preview overlay is shown.
-     *
-     * @memberof Image
      */
     show(): void;
     /**
      * Triggered when the preview overlay is hidden.
-     *
-     * @memberof Image
      */
     hide(): void;
     /**
      * Triggered when an error occurs while loading an image file.
-     *
-     * @memberof Image
      */
     error(): void;
 }
+
+export declare type ImageEmits = EmitFn<ImageEmitsOptions>;
+
+export interface ImageMethods {}
 
 /**
  * **PrimeVue - Image**


### PR DESCRIPTION
### Defect Fixes

#8140 

### Feature Requests

The Image component docs incorrectly listed `show`, `hide`, and `error` under **Methods**.  
They are actually **emits**. Updated the docs accordingly.
