### PR TITLE
feat: add `regleResolver` for `Regle` library

### DIFF
--- a/apps/showcase/doc/forms/ResolversDoc.vue
+++ b/apps/showcase/doc/forms/ResolversDoc.vue
@@ -3,8 +3,8 @@
         <p>
             Validations are implemented with the <i>resolver</i> property. A custom resolver is responsible for handling the validation and returning an <i>errors</i> object with key-value pairs where key is the form field name and value is an array
             of error object data. For productivity, we recommend using a schema validation library instead of building your own custom validation logic. The forms library provide built-in resolvers for popular options including
-            <a href="https://zod.dev/">Zod</a>, <a href="https://github.com/jquense/yup">Yup</a>, <a href="https://joi.dev/">Joi</a>, <a href="https://valibot.dev/">Valibot</a>, and <a href="https://docs.superstructjs.org/">Superstruct</a> that can
-            be imported from <i>@primevue/forms/resolvers</i> path.
+            <a href="https://zod.dev/">Zod</a>, <a href="https://github.com/jquense/yup">Yup</a>, <a href="https://joi.dev/">Joi</a>, <a href="https://valibot.dev/">Valibot</a>, <a href="https://docs.superstructjs.org/">Superstruct</a>, and
+            <a href="https://reglejs.dev/">Regle</a> that can be imported from <i>@primevue/forms/resolvers</i> path.
         </p>
     </DocSectionText>
     <div class="card flex flex-col items-center gap-5">
@@ -27,6 +27,10 @@
                     <label for="superStruct">SuperStruct</label>
                 </div>
                 <div class="flex items-center gap-2">
+                    <RadioButton inputId="regle" value="Regle" />
+                    <label for="regle">Regle</label>
+                </div>
+                <div class="flex items-center gap-2">
                     <RadioButton inputId="custom" value="Custom" />
                     <label for="custom">Custom</label>
                 </div>
@@ -45,10 +49,13 @@
 </template>
 
 <script>
+import { regleResolver } from '@primevue/forms/resolvers/regle';
 import { superStructResolver } from '@primevue/forms/resolvers/superstruct';
 import { valibotResolver } from '@primevue/forms/resolvers/valibot';
 import { yupResolver } from '@primevue/forms/resolvers/yup';
 import { zodResolver } from '@primevue/forms/resolvers/zod';
+import { useRegle } from '@regle/core';
+import { required, withMessage } from '@regle/rules';
 import * as s from 'superstruct';
 import * as v from 'valibot';
 import * as yup from 'yup';
@@ -166,6 +173,9 @@ export default {
                         username: s.nonempty(s.string())
                     })
                 );
+            } else if (schema === 'Regle') {
+                const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
+                this.resolver = regleResolver(r$);
             } else if (schema === 'Custom') {
                 this.resolver = ({ values }) => {
                     const errors = {};
@@ -214,6 +224,10 @@ export default {
                     <label for="superStruct">SuperStruct</label>
                 </div>
                 <div class="flex items-center gap-2">
+                    <RadioButton inputId="regle" value="Regle" />
+                    <label for="regle">Regle</label>
+                </div>
+                <div class="flex items-center gap-2">
                     <RadioButton inputId="custom" value="Custom" />
                     <label for="custom">Custom</label>
                 </div>
@@ -236,6 +250,9 @@ import { superStructResolver } from '@primevue/forms/resolvers/superstruct';
 import { valibotResolver } from '@primevue/forms/resolvers/valibot';
 import { yupResolver } from '@primevue/forms/resolvers/yup';
 import { zodResolver } from '@primevue/forms/resolvers/zod';
+import { regleResolver } from '@primevue/forms/resolvers/regle';
+import { useRegle } from '@regle/core';
+import { required, withMessage } from '@regle/rules';
 import * as s from 'superstruct';
 import * as v from 'valibot';
 import * as yup from 'yup';
@@ -284,6 +301,9 @@ const changeResolver = (schema) => {
                 username: s.nonempty(s.string())
             })
         );
+    } else if (schema === 'Regle') {
+        const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
+        resolver.value = regleResolver(r$);
     } else if (schema === 'Custom') {
         resolver.value = ({ values }) => {
             const errors = {};
@@ -336,6 +356,9 @@ const onFormSubmit = ({ valid }) => {
                         username: s.nonempty(s.string())
                     })
                 );
+            } else if (schema === 'Regle') {
+                const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
+                this.resolver = regleResolver(r$);
             } else if (schema === 'Custom') {
                 this.resolver = ({ values }) => {
                     const errors = {};

--- a/apps/showcase/doc/forms/ResolversDoc.vue
+++ b/apps/showcase/doc/forms/ResolversDoc.vue
@@ -54,7 +54,7 @@ import { superStructResolver } from '@primevue/forms/resolvers/superstruct';
 import { valibotResolver } from '@primevue/forms/resolvers/valibot';
 import { yupResolver } from '@primevue/forms/resolvers/yup';
 import { zodResolver } from '@primevue/forms/resolvers/zod';
-import { useRegle } from '@regle/core';
+import { useRules } from '@regle/core';
 import { required, withMessage } from '@regle/rules';
 import * as s from 'superstruct';
 import * as v from 'valibot';
@@ -107,6 +107,10 @@ export default {
                     <label for="superStruct">SuperStruct</label>
                 </div>
                 <div class="flex items-center gap-2">
+                    <RadioButton inputId="regle" value="Regle" />
+                    <label for="regle">Regle</label>
+                </div>
+                <div class="flex items-center gap-2">
                     <RadioButton inputId="custom" value="Custom" />
                     <label for="custom">Custom</label>
                 </div>
@@ -128,10 +132,13 @@ import { superStructResolver } from '@primevue/forms/resolvers/superstruct';
 import { valibotResolver } from '@primevue/forms/resolvers/valibot';
 import { yupResolver } from '@primevue/forms/resolvers/yup';
 import { zodResolver } from '@primevue/forms/resolvers/zod';
+import { regleResolver } from '@primevue/forms/resolvers/regle';
 import * as s from 'superstruct';
 import * as v from 'valibot';
 import * as yup from 'yup';
 import { z } from 'zod';
+import { useRules } from '@regle/core';
+import { required, withMessage } from '@regle/rules';
 
 export default {
     data() {
@@ -174,8 +181,11 @@ export default {
                     })
                 );
             } else if (schema === 'Regle') {
-                const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
-                this.resolver = regleResolver(r$);
+                this.resolver = regleResolver(
+                    useRules({
+                        username: { required: withMessage(required, 'Username is required via Regle.') }
+                    })
+                );
             } else if (schema === 'Custom') {
                 this.resolver = ({ values }) => {
                     const errors = {};
@@ -251,7 +261,7 @@ import { valibotResolver } from '@primevue/forms/resolvers/valibot';
 import { yupResolver } from '@primevue/forms/resolvers/yup';
 import { zodResolver } from '@primevue/forms/resolvers/zod';
 import { regleResolver } from '@primevue/forms/resolvers/regle';
-import { useRegle } from '@regle/core';
+import { useRules } from '@regle/core';
 import { required, withMessage } from '@regle/rules';
 import * as s from 'superstruct';
 import * as v from 'valibot';
@@ -302,8 +312,11 @@ const changeResolver = (schema) => {
             })
         );
     } else if (schema === 'Regle') {
-        const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
-        resolver.value = regleResolver(r$);
+        resolver.value = regleResolver(
+            useRules({
+                username: { required: withMessage(required, 'Username is required via Regle.') }
+            })
+        );
     } else if (schema === 'Custom') {
         resolver.value = ({ values }) => {
             const errors = {};
@@ -357,8 +370,11 @@ const onFormSubmit = ({ valid }) => {
                     })
                 );
             } else if (schema === 'Regle') {
-                const { r$ } = useRegle({ username: '' }, { username: { required: withMessage(required, 'Username is required via Regle.') } });
-                this.resolver = regleResolver(r$);
+                this.resolver = regleResolver(
+                    useRules({
+                        username: { required: withMessage(required, 'Username is required via Regle.') }
+                    })
+                );
             } else if (schema === 'Custom') {
                 this.resolver = ({ values }) => {
                     const errors = {};

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -52,8 +52,8 @@
         "valibot": "^0.42.1",
         "yup": "1.4.0",
         "zod": "3.23.8",
-        "@regle/core": "1.8.5",
-        "@regle/rules": "1.8.5"
+        "@regle/core": "1.9.1",
+        "@regle/rules": "1.9.1"
     },
     "devDependencies": {
         "@stackblitz/sdk": "^1.8.2",

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -51,7 +51,9 @@
         "superstruct": "^2.0.2",
         "valibot": "^0.42.1",
         "yup": "1.4.0",
-        "zod": "3.23.8"
+        "zod": "3.23.8",
+        "@regle/core": "1.8.5",
+        "@regle/rules": "1.8.5"
     },
     "devDependencies": {
         "@stackblitz/sdk": "^1.8.2",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -54,7 +54,8 @@
     "dependencies": {
         "@primeuix/utils": "catalog:",
         "@primeuix/forms": "catalog:",
-        "@primevue/core": "workspace:*"
+        "@primevue/core": "workspace:*",
+        "@regle/core": "1.8.4"
     },
     "engines": {
         "node": ">=12.11.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -55,7 +55,7 @@
         "@primeuix/utils": "catalog:",
         "@primeuix/forms": "catalog:",
         "@primevue/core": "workspace:*",
-        "@regle/core": "1.8.4"
+        "@regle/core": "1.9.1"
     },
     "engines": {
         "node": ">=12.11.0"

--- a/packages/forms/src/resolvers/regle/index.d.ts
+++ b/packages/forms/src/resolvers/regle/index.d.ts
@@ -1,0 +1,6 @@
+import type { R as ResolverOptions, a as ResolverResult } from '@primeuix/forms/dist/index.d-BMK_1xX7.d.mts';
+import type { RegleRoot } from '@regle/core';
+
+declare const regleResolver: <T extends Record<string, unknown>>(r$: RegleRoot<T>, resolverOptions?: ResolverOptions) => ({ values, name }: any) => Promise<ResolverResult<T>>;
+
+export { regleResolver };

--- a/packages/forms/src/resolvers/regle/index.js
+++ b/packages/forms/src/resolvers/regle/index.js
@@ -5,7 +5,7 @@ export const regleResolver = (r$, resolverOptions) => {
     return async ({ values, name }) => {
         const { raw = false } = resolverOptions || {};
 
-        r$.$values = values;
+        r$.$value = values;
         const { valid, data: result } = await r$.$validate();
 
         if (valid) {

--- a/packages/forms/src/resolvers/regle/index.js
+++ b/packages/forms/src/resolvers/regle/index.js
@@ -15,10 +15,12 @@ export const regleResolver = (r$, resolverOptions) => {
             };
         }
 
-        const errors = flatErrors(r$.$errors, { includePath: true }).reduce((acc, { error, path }) => {
+        const errors = flatErrors(r$.$errors, { includePath: true }).reduce((acc, { message, path }) => {
             if (path) {
-                acc[path] ||= [];
-                acc[path].push({ message: error });
+                const joinedPath = path.join('.');
+
+                acc[joinedPath] ||= [];
+                acc[joinedPath].push({ message });
             }
 
             return acc;

--- a/packages/forms/src/resolvers/regle/index.js
+++ b/packages/forms/src/resolvers/regle/index.js
@@ -1,0 +1,32 @@
+import { toValues } from '@primeuix/forms/utils';
+import { flatErrors } from '@regle/core';
+
+export const regleResolver = (r$, resolverOptions) => {
+    return async ({ values, name }) => {
+        const { raw = false } = resolverOptions || {};
+
+        r$.$values = values;
+        const { valid, data: result } = await r$.$validate();
+
+        if (valid) {
+            return {
+                values: toValues(raw ? values : undefined, name),
+                errors: {}
+            };
+        }
+
+        const errors = flatErrors(r$.$errors, { includePath: true }).reduce((acc, { error, path }) => {
+            if (path) {
+                acc[path] ||= [];
+                acc[path].push({ message: error });
+            }
+
+            return acc;
+        }, {});
+
+        return {
+            values: toValues(raw ? values : result, name),
+            errors
+        };
+    };
+};

--- a/packages/forms/src/resolvers/regle/package.json
+++ b/packages/forms/src/resolvers/regle/package.json
@@ -1,0 +1,5 @@
+{
+    "main": "./index.js",
+    "module": "./index.js",
+    "types": "./index.d.ts"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,11 +118,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/nuxt-module
       '@regle/core':
-        specifier: 1.8.5
-        version: 1.8.5(vue@3.5.21(typescript@5.7.3))
+        specifier: 1.9.1
+        version: 1.9.1(vue@3.5.21(typescript@5.7.3))
       '@regle/rules':
-        specifier: 1.8.5
-        version: 1.8.5(vue@3.5.21(typescript@5.7.3))
+        specifier: 1.9.1
+        version: 1.9.1(vue@3.5.21(typescript@5.7.3))
       chart.js:
         specifier: catalog:app
         version: 3.3.2
@@ -254,7 +254,7 @@ importers:
         version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(typescript@5.7.3)(yaml@2.8.1)
       unplugin-vue-components:
         specifier: ^0.27.0
-        version: 0.27.5(@babel/parser@7.28.4)(@nuxt/kit@3.19.2)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))
+        version: 0.27.5(@babel/parser@7.28.4)(@nuxt/kit@3.19.2(magicast@0.3.5))(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3))
     publishDirectory: dist
 
   packages/core:
@@ -282,8 +282,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@regle/core':
-        specifier: 1.8.4
-        version: 1.8.4(vue@3.5.21(typescript@5.7.3))
+        specifier: 1.9.1
+        version: 1.9.1(vue@3.5.21(typescript@5.7.3))
     publishDirectory: dist
 
   packages/icons:
@@ -2024,8 +2024,8 @@ packages:
     resolution: {integrity: sha512-tQL/ZOPgCdD+NTimlUmhyD0ey8J1XmpZE4hDHM+/fnuBicVVmlKOd5HpS748LcOVRUKbWjmEPdHX4hi5XZoC1Q==}
     engines: {node: '>=12.11.0'}
 
-  '@regle/core@1.8.4':
-    resolution: {integrity: sha512-wcGvkQdShARDDtfRsTd4JMrUkdfM2E60xHvvdL0EA5kvmS5gYYz+n64O7VRFR0BsQtNtRD/7n9VYkTgIsrOq7g==}
+  '@regle/core@1.9.1':
+    resolution: {integrity: sha512-fnoePh4YkPFL5XtSHvWdwSfyuICr2ptyT7gGRamcDPuxoXfvT/rueHDfSmIOhU/TET5+9kUZmeYmJzjQReIatw==}
     peerDependencies:
       pinia: '>=2.2.5'
       vue: '>=3.3.0'
@@ -2033,17 +2033,8 @@ packages:
       pinia:
         optional: true
 
-  '@regle/core@1.8.5':
-    resolution: {integrity: sha512-srJD6JrbovmxQQE0fpO/ju6zc95aggVhEKVoNiryOlzGIOQgBqSeKVkz+k1GcwPMOSwHax7k9zQVevj4gU0Rnw==}
-    peerDependencies:
-      pinia: '>=2.2.5'
-      vue: '>=3.3.0'
-    peerDependenciesMeta:
-      pinia:
-        optional: true
-
-  '@regle/rules@1.8.5':
-    resolution: {integrity: sha512-WfDt/Z+35wDV228Ef2FOcPsx0xbg1w/rWm4jfhEndJVjhssQ1tCGwttQXeuHf4SWUxUdl1g2doffot2Nzsi3+w==}
+  '@regle/rules@1.9.1':
+    resolution: {integrity: sha512-DD4tt7nIfJmQ0R69sQf1zUVBcNgftO5MgooAKvMIw5PgvjQnYBu1EPoRTLlULCQEqYoxQx/Cms+Fedd81Z+DYA==}
 
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
@@ -2287,6 +2278,9 @@ packages:
 
   '@stackblitz/sdk@1.11.0':
     resolution: {integrity: sha512-DFQGANNkEZRzFk1/rDP6TcFdM82ycHE+zfl9C/M/jXlH68jiqHWHFMQURLELoD8koxvu/eW5uhg94NSAZlYrUQ==}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@stylistic/eslint-plugin@5.3.1':
     resolution: {integrity: sha512-Ykums1VYonM0TgkD0VteVq9mrlO2FhF48MDJnPyv3MktIB2ydtuhlO0AfWm7xnW1kyf5bjOqA6xc7JjviuVTxg==}
@@ -9184,17 +9178,14 @@ snapshots:
 
   '@primeuix/utils@0.6.1': {}
 
-  '@regle/core@1.8.4(vue@3.5.21(typescript@5.7.3))':
+  '@regle/core@1.9.1(vue@3.5.21(typescript@5.7.3))':
     dependencies:
+      '@standard-schema/spec': 1.0.0
       vue: 3.5.21(typescript@5.7.3)
 
-  '@regle/core@1.8.5(vue@3.5.21(typescript@5.7.3))':
+  '@regle/rules@1.9.1(vue@3.5.21(typescript@5.7.3))':
     dependencies:
-      vue: 3.5.21(typescript@5.7.3)
-
-  '@regle/rules@1.8.5(vue@3.5.21(typescript@5.7.3))':
-    dependencies:
-      '@regle/core': 1.8.5(vue@3.5.21(typescript@5.7.3))
+      '@regle/core': 1.9.1(vue@3.5.21(typescript@5.7.3))
     transitivePeerDependencies:
       - pinia
       - vue
@@ -9419,6 +9410,8 @@ snapshots:
   '@speed-highlight/core@1.2.7': {}
 
   '@stackblitz/sdk@1.11.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@stylistic/eslint-plugin@5.3.1(eslint@9.35.0(jiti@2.5.1))':
     dependencies:
@@ -14415,7 +14408,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
-  unplugin-vue-components@0.27.5(@babel/parser@7.28.4)(@nuxt/kit@3.19.2)(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3)):
+  unplugin-vue-components@0.27.5(@babel/parser@7.28.4)(@nuxt/kit@3.19.2(magicast@0.3.5))(rollup@4.50.2)(vue@3.5.21(typescript@5.7.3)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.50.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,12 @@ importers:
       '@primevue/nuxt-module':
         specifier: workspace:*
         version: link:../../packages/nuxt-module
+      '@regle/core':
+        specifier: 1.8.5
+        version: 1.8.5(vue@3.5.21(typescript@5.7.3))
+      '@regle/rules':
+        specifier: 1.8.5
+        version: 1.8.5(vue@3.5.21(typescript@5.7.3))
       chart.js:
         specifier: catalog:app
         version: 3.3.2
@@ -2026,6 +2032,18 @@ packages:
     peerDependenciesMeta:
       pinia:
         optional: true
+
+  '@regle/core@1.8.5':
+    resolution: {integrity: sha512-srJD6JrbovmxQQE0fpO/ju6zc95aggVhEKVoNiryOlzGIOQgBqSeKVkz+k1GcwPMOSwHax7k9zQVevj4gU0Rnw==}
+    peerDependencies:
+      pinia: '>=2.2.5'
+      vue: '>=3.3.0'
+    peerDependenciesMeta:
+      pinia:
+        optional: true
+
+  '@regle/rules@1.8.5':
+    resolution: {integrity: sha512-WfDt/Z+35wDV228Ef2FOcPsx0xbg1w/rWm4jfhEndJVjhssQ1tCGwttQXeuHf4SWUxUdl1g2doffot2Nzsi3+w==}
 
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
@@ -9169,6 +9187,17 @@ snapshots:
   '@regle/core@1.8.4(vue@3.5.21(typescript@5.7.3))':
     dependencies:
       vue: 3.5.21(typescript@5.7.3)
+
+  '@regle/core@1.8.5(vue@3.5.21(typescript@5.7.3))':
+    dependencies:
+      vue: 3.5.21(typescript@5.7.3)
+
+  '@regle/rules@1.8.5(vue@3.5.21(typescript@5.7.3))':
+    dependencies:
+      '@regle/core': 1.8.5(vue@3.5.21(typescript@5.7.3))
+    transitivePeerDependencies:
+      - pinia
+      - vue
 
   '@rolldown/pluginutils@1.0.0-beta.38': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 10.1.8(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-prettier:
         specifier: ^5.2.3
-        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2)
+        version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2)
       eslint-plugin-vue:
         specifier: ^9.32.0
         version: 9.33.0(eslint@9.35.0(jiti@2.5.1))
@@ -153,7 +153,7 @@ importers:
         version: 19.0.0
       nuxt:
         specifier: catalog:app
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.1)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))(yaml@2.8.1)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.2)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))(yaml@2.8.1)
       postcss:
         specifier: ^8.4.31
         version: 8.5.6
@@ -174,7 +174,7 @@ importers:
         version: 0.23.23(typescript@5.7.3)
       vite:
         specifier: catalog:app
-        version: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+        version: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
 
   apps/volt:
     dependencies:
@@ -199,7 +199,7 @@ importers:
         version: 1.11.0
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.1.13(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
+        version: 4.1.13(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10
         version: 10.4.21(postcss@8.5.6)
@@ -208,7 +208,7 @@ importers:
         version: 19.0.0
       nuxt:
         specifier: catalog:app
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.1)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))(yaml@2.8.1)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.2)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))(yaml@2.8.1)
       postcss:
         specifier: ^8.4.31
         version: 8.5.6
@@ -232,7 +232,7 @@ importers:
         version: 0.27.9(typescript@5.7.3)
       vite:
         specifier: catalog:app
-        version: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+        version: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.12(typescript@5.7.3)
@@ -275,6 +275,9 @@ importers:
       '@primevue/core':
         specifier: workspace:*
         version: link:../core
+      '@regle/core':
+        specifier: 1.8.4
+        version: 1.8.4(vue@3.5.21(typescript@5.7.3))
     publishDirectory: dist
 
   packages/icons:
@@ -2015,6 +2018,15 @@ packages:
     resolution: {integrity: sha512-tQL/ZOPgCdD+NTimlUmhyD0ey8J1XmpZE4hDHM+/fnuBicVVmlKOd5HpS748LcOVRUKbWjmEPdHX4hi5XZoC1Q==}
     engines: {node: '>=12.11.0'}
 
+  '@regle/core@1.8.4':
+    resolution: {integrity: sha512-wcGvkQdShARDDtfRsTd4JMrUkdfM2E60xHvvdL0EA5kvmS5gYYz+n64O7VRFR0BsQtNtRD/7n9VYkTgIsrOq7g==}
+    peerDependencies:
+      pinia: '>=2.2.5'
+      vue: '>=3.3.0'
+    peerDependenciesMeta:
+      pinia:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.38':
     resolution: {integrity: sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==}
 
@@ -2396,6 +2408,9 @@ packages:
 
   '@types/node@24.5.1':
     resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
+
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -8502,12 +8517,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))':
+  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       execa: 7.2.0
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -8517,7 +8532,7 @@ snapshots:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       execa: 7.2.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -8526,7 +8541,7 @@ snapshots:
     dependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       execa: 8.0.1
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
 
@@ -8589,7 +8604,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@3.29.5)
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@3.29.5)(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
       vite-plugin-vue-inspector: 5.3.2(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
       which: 3.0.1
@@ -8601,13 +8616,13 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
+  '@nuxt/devtools@1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
       '@nuxt/devtools-wizard': 1.7.0
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
-      '@vue/devtools-core': 7.6.8(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@vue/devtools-core': 7.6.8(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       '@vue/devtools-kit': 7.6.8
       birpc: 0.2.19
       consola: 3.4.2
@@ -8636,9 +8651,9 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@4.50.2)
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
-      vite-plugin-vue-inspector: 5.3.2(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
+      vite-plugin-vue-inspector: 5.3.2(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
       which: 3.0.1
       ws: 8.18.3
     transitivePeerDependencies:
@@ -8678,7 +8693,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-inspect: 11.3.3(@nuxt/kit@3.19.2(magicast@0.3.5))(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
       vite-plugin-vue-tracer: 1.0.0(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       which: 5.0.0
@@ -8899,8 +8914,8 @@ snapshots:
       ufo: 1.6.1
       unenv: 1.10.0
       unplugin: 2.3.10
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-checker: 0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))
       vue: 3.5.21(typescript@5.7.3)
       vue-bundle-renderer: 2.1.2
@@ -8929,12 +8944,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@3.15.4(@types/node@24.5.1)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.1.10(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@3.15.4(@types/node@24.5.2)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.1.10(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.1(postcss@8.5.6)
@@ -8958,9 +8973,9 @@ snapshots:
       ufo: 1.6.1
       unenv: 1.10.0
       unplugin: 2.3.10
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-checker: 0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite-plugin-checker: 0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))
       vue: 3.5.21(typescript@5.7.3)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
@@ -8988,12 +9003,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@3.15.4(@types/node@24.5.1)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.2.12(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
+  '@nuxt/vite-builder@3.15.4(@types/node@24.5.2)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.2.12(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.50.2)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       autoprefixer: 10.4.21(postcss@8.5.6)
       consola: 3.4.2
       cssnano: 7.1.1(postcss@8.5.6)
@@ -9017,9 +9032,9 @@ snapshots:
       ufo: 1.6.1
       unenv: 1.10.0
       unplugin: 2.3.10
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-plugin-checker: 0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite-plugin-checker: 0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))
       vue: 3.5.21(typescript@5.7.3)
       vue-bundle-renderer: 2.1.2
     transitivePeerDependencies:
@@ -9150,6 +9165,10 @@ snapshots:
       '@primeuix/styled': 0.7.2
 
   '@primeuix/utils@0.6.1': {}
+
+  '@regle/core@1.8.4(vue@3.5.21(typescript@5.7.3))':
+    dependencies:
+      vue: 3.5.21(typescript@5.7.3)
 
   '@rolldown/pluginutils@1.0.0-beta.38': {}
 
@@ -9446,12 +9465,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.13(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -9493,6 +9512,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/node@24.5.1':
+    dependencies:
+      undici-types: 7.12.0
+
+  '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
 
@@ -9709,14 +9732,30 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
       '@rolldown/pluginutils': 1.0.0-beta.38
       '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vue: 3.5.21(typescript@5.7.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.38
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.28.4)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
 
   '@vitejs/plugin-vue@5.2.4(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
     dependencies:
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vue: 3.5.21(typescript@5.7.3)
+
+  '@vitejs/plugin-vue@5.2.4(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
+    dependencies:
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.7.3)
 
   '@vitest/expect@0.29.8':
@@ -9739,7 +9778,7 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -9885,14 +9924,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.6.8(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
+  '@vue/devtools-core@7.6.8(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))':
     dependencies:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 1.1.2
-      vite-hot-client: 0.2.4(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
+      vite-hot-client: 0.2.4(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))
       vue: 3.5.21(typescript@5.7.3)
     transitivePeerDependencies:
       - vite
@@ -11126,13 +11165,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.35.0(jiti@2.5.1)))(eslint@9.35.0(jiti@2.5.1))(prettier@3.6.2):
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.11
     optionalDependencies:
+      '@types/eslint': 9.6.1
       eslint-config-prettier: 10.1.8(eslint@9.35.0(jiti@2.5.1))
 
   eslint-plugin-regexp@2.10.0(eslint@9.35.0(jiti@2.5.1)):
@@ -11821,7 +11861,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -12528,15 +12568,15 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.1)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))(yaml@2.8.1):
+  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.2)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@nuxt/devtools': 1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.15.4(@types/node@24.5.1)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.1.10(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
+      '@nuxt/vite-builder': 3.15.4(@types/node@24.5.2)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.1.10(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
       '@unhead/dom': 1.11.20
       '@unhead/shared': 1.11.20
       '@unhead/ssr': 1.11.20
@@ -12596,7 +12636,7 @@ snapshots:
       vue-router: 4.5.1(vue@3.5.21(typescript@5.7.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12652,15 +12692,15 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.1)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))(yaml@2.8.1):
+  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@24.5.2)(db0@0.3.2)(eslint@9.35.0(jiti@2.5.1))(ioredis@5.7.0)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3))(yaml@2.8.1):
     dependencies:
       '@nuxt/cli': 3.28.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
+      '@nuxt/devtools': 1.7.0(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.7.3))
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.15.4(@types/node@24.5.1)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.2.12(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
+      '@nuxt/vite-builder': 3.15.4(@types/node@24.5.2)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.50.2)(sass@1.45.0)(terser@5.44.0)(typescript@5.7.3)(vue-tsc@2.2.12(typescript@5.7.3))(vue@3.5.21(typescript@5.7.3))(yaml@2.8.1)
       '@unhead/dom': 1.11.20
       '@unhead/shared': 1.11.20
       '@unhead/ssr': 1.11.20
@@ -12720,7 +12760,7 @@ snapshots:
       vue-router: 4.5.1(vue@3.5.21(typescript@5.7.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
-      '@types/node': 24.5.1
+      '@types/node': 24.5.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14544,20 +14584,20 @@ snapshots:
   vite-dev-rpc@1.1.0(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       birpc: 2.5.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vite-hot-client: 2.1.0(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
 
-  vite-hot-client@0.2.4(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
+  vite-hot-client@0.2.4(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
 
   vite-hot-client@0.2.4(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
 
   vite-hot-client@2.1.0(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
 
   vite-node@0.29.8(@types/node@24.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0):
     dependencies:
@@ -14577,13 +14617,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -14598,28 +14638,26 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3)):
+  vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
-      '@babel/code-frame': 7.27.1
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      commander: 8.3.0
-      fast-glob: 3.3.3
-      fs-extra: 11.3.2
-      npm-run-path: 4.0.1
-      strip-ansi: 6.0.1
-      tiny-invariant: 1.3.3
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vscode-languageclient: 7.0.0
-      vscode-languageserver: 7.0.0
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      eslint: 9.35.0(jiti@2.5.1)
-      optionator: 0.9.4
-      typescript: 5.7.3
-      vue-tsc: 2.2.12(typescript@5.7.3)
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-plugin-checker@0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3)):
     dependencies:
@@ -14633,7 +14671,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.12
@@ -14643,6 +14681,52 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.7.3
       vue-tsc: 2.1.10(typescript@5.7.3)
+
+  vite-plugin-checker@0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.1.10(typescript@5.7.3)):
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      commander: 8.3.0
+      fast-glob: 3.3.3
+      fs-extra: 11.3.2
+      npm-run-path: 4.0.1
+      strip-ansi: 6.0.1
+      tiny-invariant: 1.3.3
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vscode-languageclient: 7.0.0
+      vscode-languageserver: 7.0.0
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      eslint: 9.35.0(jiti@2.5.1)
+      optionator: 0.9.4
+      typescript: 5.7.3
+      vue-tsc: 2.1.10(typescript@5.7.3)
+
+  vite-plugin-checker@0.8.0(eslint@9.35.0(jiti@2.5.1))(optionator@0.9.4)(typescript@5.7.3)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@2.2.12(typescript@5.7.3)):
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      commander: 8.3.0
+      fast-glob: 3.3.3
+      fs-extra: 11.3.2
+      npm-run-path: 4.0.1
+      strip-ansi: 6.0.1
+      tiny-invariant: 1.3.3
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vscode-languageclient: 7.0.0
+      vscode-languageserver: 7.0.0
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      eslint: 9.35.0(jiti@2.5.1)
+      optionator: 0.9.4
+      typescript: 5.7.3
+      vue-tsc: 2.2.12(typescript@5.7.3)
 
   vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@3.29.5)(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
@@ -14655,14 +14739,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.50.2)(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.50.2)
@@ -14673,7 +14757,7 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.2
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
     transitivePeerDependencies:
@@ -14690,14 +14774,14 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vite-dev-rpc: 1.1.0(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
     optionalDependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.3.2(vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
+  vite-plugin-vue-inspector@5.3.2(vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.4)
@@ -14708,7 +14792,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.21
       kolorist: 1.8.0
       magic-string: 0.30.19
-      vite: 6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14723,7 +14807,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.21
       kolorist: 1.8.0
       magic-string: 0.30.19
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14734,7 +14818,7 @@ snapshots:
       magic-string: 0.30.19
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.7.3)
 
   vite@4.5.14(@types/node@24.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0):
@@ -14749,7 +14833,7 @@ snapshots:
       sass: 1.45.0
       terser: 5.44.0
 
-  vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
+  vite@6.0.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.6
@@ -14759,11 +14843,24 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1
+      terser: 5.44.0
+      yaml: 2.8.1
+
+  vite@6.0.11(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.24.2
+      postcss: 8.5.6
+      rollup: 4.50.2
+    optionalDependencies:
+      '@types/node': 24.5.2
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
       sass: 1.45.0
       terser: 5.44.0
       yaml: 2.8.1
 
-  vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
+  vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14773,6 +14870,22 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.5.1
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      terser: 5.44.0
+      yaml: 2.8.1
+
+  vite@7.1.5(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.50.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.5.2
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1
@@ -14856,8 +14969,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.45.0)(terser@5.44.0)(yaml@2.8.1)
+      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.5.1


### PR DESCRIPTION
## Description

Hi!

I'm the maintainer of [Regle](https://github.com/victorgarciaesgi/regle), a Vue headless validation library and "successor" of Vuelidate.

Vuelidate is not maintained anymore, and [Regle is listed as the primary alternative](https://github.com/vuelidate/vuelidate?tab=readme-ov-file#possible-alternatives) as API is greatly similar.

This PR adds a `regleResolver` helper so you can use it as any other schema.


## Tests

I didn't find any place to add unit tests in the resolver sections, do you have one?

Thanks!
