### PR TITLE
fix: Fix reactivity when base editiable model value is an array

### DIFF
--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -49,8 +49,11 @@ export default {
         };
     },
     watch: {
-        modelValue(newValue) {
-            this.d_value = newValue;
+        modelValue: {
+            deep: true,
+            handler(newValue) {
+                this.d_value = newValue;
+            }
         },
         defaultValue(newValue) {
             this.d_value = newValue;


### PR DESCRIPTION
This change fixes the issue that I've described here:
- #8153

If I'm not mistaken, this should also fix the following issue, because it looks very similar:
- #8024

### Why is this necessary?
> When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.
> -- https://v3-migration.vuejs.org/breaking-changes/watch
