### PR TITLE
fix: use ordered list for Timeline component to improve accessibility

### DIFF
--- a/packages/primevue/src/timeline/Timeline.spec.js
+++ b/packages/primevue/src/timeline/Timeline.spec.js
@@ -31,6 +31,11 @@ describe('Timeline.vue', () => {
         expect(wrapper.findAll('.p-timeline-event-separator').length).toBe(4);
     });
 
+    it('should use ordered list structure for accessibility', () => {
+        expect(wrapper.find('ol.p-timeline').exists()).toBe(true);
+        expect(wrapper.findAll('li.p-timeline-event').length).toBe(4);
+    });
+
     it('should align right', async () => {
         await wrapper.setProps({ align: 'right' });
 

--- a/packages/primevue/src/timeline/Timeline.vue
+++ b/packages/primevue/src/timeline/Timeline.vue
@@ -1,6 +1,6 @@
 <template>
-    <div :class="cx('root')" v-bind="ptmi('root')" :data-p="dataP">
-        <div v-for="(item, index) of value" :key="getKey(item, index)" :class="cx('event')" v-bind="getPTOptions('event', index)" :data-p="dataP">
+    <ol :class="cx('root')" v-bind="ptmi('root')" :data-p="dataP">
+        <li v-for="(item, index) of value" :key="getKey(item, index)" :class="cx('event')" v-bind="getPTOptions('event', index)" :data-p="dataP">
             <div :class="cx('eventOpposite', { index })" v-bind="getPTOptions('eventOpposite', index)" :data-p="dataP">
                 <slot name="opposite" :item="item" :index="index"></slot>
             </div>
@@ -15,8 +15,8 @@
             <div :class="cx('eventContent')" v-bind="getPTOptions('eventContent', index)" :data-p="dataP">
                 <slot name="content" :item="item" :index="index"></slot>
             </div>
-        </div>
-    </div>
+        </li>
+    </ol>
 </template>
 
 <script>


### PR DESCRIPTION
### Defect Fixes

According to the Timeline documentation: "Timeline uses a semantic ordered list element to list the events.", but that's not the case, Timeline is using div tags without any semantic meaning.

This PR is adding ol and li tags to the Timeline component to be accessible and consistent with documentation. Related PR that needs to be merged along with this one: https://github.com/primefaces/primeuix/pull/159.