### PR TITLE
fix(VirtualScroller): Initialize properly when parent transitions from display:none to visible

### DIFF
--- a/packages/primevue/src/virtualscroller/VirtualScroller.vue
+++ b/packages/primevue/src/virtualscroller/VirtualScroller.vue
@@ -593,8 +593,12 @@ export default {
                 window.addEventListener('resize', this.resizeListener);
                 window.addEventListener('orientationchange', this.resizeListener);
 
-                this.resizeObserver = new ResizeObserver(() => {
-                    this.onResize();
+                this.resizeObserver = new ResizeObserver((entries) => {
+                    if (!this.initialized && isVisible(this.element)) {
+                        this.viewInit();
+                    } else {
+                        this.onResize();
+                    }
                 });
                 this.resizeObserver.observe(this.element);
             }


### PR DESCRIPTION
## Description

Fixes an initialization bug where VirtualScroller fails to render when its parent element starts with `display: none` and is later made visible.