### PR TITLE
Can always show overlay

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -458,7 +458,7 @@ export default {
 
                 if (query.length === 0) {
                     this.searching = false;
-                    this.hide();
+                    !this.keepOverlayOnClear && this.hide();
                     this.$emit('clear');
                 } else {
                     if (query.length >= this.minLength) {

--- a/packages/primevue/src/autocomplete/BaseAutoComplete.vue
+++ b/packages/primevue/src/autocomplete/BaseAutoComplete.vue
@@ -58,6 +58,10 @@ export default {
             type: Boolean,
             default: false
         },
+        keepOverlayOnClear: {
+            type: Boolean,
+            default: true
+        },
         completeOnFocus: {
             type: Boolean,
             default: false


### PR DESCRIPTION
# Add option to keep overlay open when search is cleared

## What
Added new functionality to keep the autocomplete overlay open even when the input field is cleared.

## Why
Enables command palette functionality where users can browse available options without requiring search input.

## Changes
- Added `keepOverlayOnClear` prop
- Modified overlay close logic to respect this setting
- Maintains existing behavior when option is disabled (default)

## Use Case
Perfect for implementing command palettes, quick action menus, or browsable option lists that don't require search filtering.

dicussion : [4357](https://github.com/orgs/primefaces/discussions/4357)