### PR TITLE
Change role of Drawer depending if its modal or not

### DIFF
--- a/packages/primevue/src/drawer/Drawer.vue
+++ b/packages/primevue/src/drawer/Drawer.vue
@@ -2,7 +2,7 @@
     <Portal>
         <div v-if="containerVisible" :ref="maskRef" @mousedown="onMaskClick" :class="cx('mask')" :style="sx('mask', true, { position, modal })" :data-p="dataP" v-bind="ptm('mask')">
             <transition name="p-drawer" @enter="onEnter" @after-enter="onAfterEnter" @before-leave="onBeforeLeave" @leave="onLeave" @after-leave="onAfterLeave" appear v-bind="ptm('transition')">
-                <div v-if="visible" :ref="containerRef" v-focustrap :class="cx('root')" :style="sx('root')" role="complementary" :aria-modal="modal" :data-p="dataP" v-bind="ptmi('root')">
+                <div v-if="visible" :ref="containerRef" v-focustrap :class="cx('root')" :style="sx('root')" :role="modal ? 'dialog' : 'complementary'" :aria-modal="modal ? true : undefined" :data-p="dataP" v-bind="ptmi('root')">
                     <slot v-if="$slots.container" name="container" :closeCallback="hide"></slot>
                     <template v-else>
                         <div :ref="headerContainerRef" :class="cx('header')" v-bind="ptm('header')">


### PR DESCRIPTION
### Defect Fixes
Storybook’s [accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) identifies problems with the PrimeVue Drawer use of both role="complementary" and aria-modal attributes.

I understand that role="complementary" is a landmark role for persistent, supporting content like sidebars, while aria-modal="true" is reserved for temporary overlays that block background interaction and trap focus. These meanings conflict: complementary implies ongoing accessibility, whereas modal implies temporary exclusivity. WAI-ARIA therefore restricts aria-modal to dialog, alertdialog, and window.

If the Drawer is modal, then use role="dialog" and aria-modal="true".
If not modal, then use role="complementary" and don't set aria-modal at all.

Relevant issue: https://github.com/primefaces/primevue/issues/7943