### PR TITLE
Only set aria-haspop when feedback enabled

### DIFF
--- a/packages/primevue/src/password/Password.vue
+++ b/packages/primevue/src/password/Password.vue
@@ -12,7 +12,7 @@
             :aria-label="ariaLabel"
             :aria-expanded="overlayVisible"
             :aria-controls="overlayVisible ? ((overlayProps && overlayProps.id) || overlayId || (panelProps && panelProps.id) || panelId || overlayUniqueId) : undefined"
-            :aria-haspopup="true"
+            :aria-haspopup="feedback || undefined"
             :placeholder="placeholder"
             :required="required"
             :fluid="fluid"


### PR DESCRIPTION
Storybook’s [accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) identifies problems with the PrimeVue Password component. Currently, the component always sets the aria-haspopup attribute to true, regardless of the feedback property’s value. For correct accessibility implementation, both the aria-controls and aria-haspopup attributes should only be applied when the feedback property is set to true.

Relevant issue: https://github.com/primefaces/primevue/issues/8178