### PR TITLE
Fix DatePicker aria attributes

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -191,7 +191,7 @@
                                 </div>
                                 <table v-if="currentView === 'date'" :class="cx('dayView')" role="grid" v-bind="ptm('dayView')">
                                     <thead v-bind="ptm('tableHeader')">
-                                        <tr row="row" role="row"  v-bind="ptm('tableHeaderRow')">
+                                        <tr role="row"  v-bind="ptm('tableHeaderRow')">
                                             <th v-if="showWeek" scope="col" :class="cx('weekHeader')" role="gridcell" v-bind="ptm('weekHeader', { context: { disabled: showWeek } })" :data-p-disabled="showWeek" data-pc-group-section="tableheadercell">
                                                 <slot name="weekheaderlabel">
                                                     <span v-bind="ptm('weekHeaderLabel', { context: { disabled: showWeek } })" data-pc-group-section="tableheadercelllabel">


### PR DESCRIPTION
Storybook’s [accessibility addon](https://storybook.js.org/docs/writing-tests/accessibility-testing) identifies problems with the PrimeVue Password component. When used inline, the component does not assign a role to its panel section, even though the section defines an aria-label. Because aria-label must always be associated with an explicit role, this omission results in an accessibility violation. Role application seems most applicable?

Another issue arises with the day elements, which set the aria-selected attribute without specifying a corresponding role. While assigning an option role initially seemed appropriate, that approach requires the parent element to have either a group or listbox role, both of which introduce further violations. The effective solution is to assign role="gridcell" to the daycell section. This aligns with the existing hierarchy, as the parent elements already use role="grid". Note that I also added role="row" to be more correct. The final step is to move the aria-selected attribute from the day section to the daycell section, ensuring it resides on an element that correctly defines a role.

Relevant issue: https://github.com/primefaces/primevue/issues/8181