### PR TITLE
Added a warning for cases where row selection listeners are used without a selection model.

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -344,6 +344,7 @@ import {
 } from '@primeuix/utils/dom';
 import { equals, findIndexInList, isEmpty, isNotEmpty, localeComparator, reorderArray, resolveFieldData, sort } from '@primeuix/utils/object';
 import { FilterMatchMode, FilterOperator, FilterService } from '@primevue/core/api';
+import { getCurrentInstance } from 'vue'
 import { HelperSet, getVNodeProp } from '@primevue/core/utils';
 import ArrowDownIcon from '@primevue/icons/arrowdown';
 import ArrowUpIcon from '@primevue/icons/arrowup';
@@ -492,6 +493,15 @@ export default {
 
         if (this.editMode === 'row' && this.dataKey && !this.d_editingRowKeys) {
             this.updateEditingRowKeys(this.editingRows);
+        }
+
+        // Warn the user if they are using row selection events without a selection model.
+        const componentProps = getCurrentInstance()?.vnode?.props;
+        if ((componentProps?.onRowSelect || componentProps?.onRowUnselect) && !componentProps.selection) {
+            console.warn(
+                '[PrimeVue DataTable] You are using row selection events without providing a selection model.' +
+                ' This may lead to unexpected behavior. Please provide a selection model using v-model:selection.'
+            );
         }
     },
     beforeUnmount() {


### PR DESCRIPTION
Attempts to improve DX by providing feedback whenever row selection event listeners are added to `DataTable`, but the selection model is missing. See #8125.
