### PR TITLE
fix: DataTable TabIndex intialization

### DIFF
--- a/apps/showcase/components/landing/UsersSection.vue
+++ b/apps/showcase/components/landing/UsersSection.vue
@@ -2,7 +2,7 @@
     <section class="landing-users py-20 px-4 lg:px-20">
         <div class="section-header">Who Uses</div>
         <p class="section-detail">
-            PrimeTek libraries have reached over <span class="font-semibold animated-text relative whitespace-nowrap"> <span>250 Million Downloads </span> </span> on npm! Join the PrimeLand community and experience the difference yourself.
+            PrimeTek libraries have reached over <span class="font-semibold animated-text relative whitespace-nowrap"> <span>400 Million Downloads </span> </span> on npm! Join the PrimeLand community and experience the difference yourself.
         </p>
         <div class="flex justify-center items-center mt-6">
             <span class="ml-2"> </span>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
     '@primeuix/styled': ^0.7.4
-    '@primeuix/utils': ^0.6.1
+    '@primeuix/utils': ^0.6.2
     '@primeuix/forms': ^0.1.0
     '@primeuix/styles': ^1.2.5
     '@primeuix/themes': ^1.2.5


### PR DESCRIPTION
Fixing TabIndex initialization when DataTable is initialized with an empty array on selection model

Resolves #8218 