### PR TITLE
Volt: DataTable: Add virtualScrollerSpacer flex

### DIFF
--- a/apps/volt/volt/DataTable.vue
+++ b/apps/volt/volt/DataTable.vue
@@ -175,6 +175,7 @@ const theme = ref<DataTablePassThroughOptions>({
         root: `flex items-center justify-center flex-wrap py-2 px-4 rounded-md gap-1
             bg-surface-0 dark:bg-surface-900 text-surface-700 dark:text-surface-0`
     },
+    virtualScrollerSpacer: `flex`,
     columnResizeIndicator: `w-px absolute z-10 hidden bg-primary`,
     rowReorderIndicatorUp: `absolute hidden`,
     rowReorderIndicatorDown: `absolute hidden`


### PR DESCRIPTION
Volt DataTable did not work correctly in Firefox. Unlike the styled primevue counterpart the virtualScrollerSpacer did not have the 'flex' property. Adding the property fixes the DataTable for Firefox.