### PR TITLE
Fix typo in chart documentation

### DIFF
--- a/apps/showcase/doc/chart/BasicDoc.vue
+++ b/apps/showcase/doc/chart/BasicDoc.vue
@@ -1,7 +1,7 @@
 <template>
     <DocSectionText v-bind="$attrs">
         <p>
-            A chart is configured with 3 properties; <i>type</i>, <i>data</i> and <i>options</i>. Chart type is defined using the <i>type</i> property that accepts <i>pie</i>, <i>doughtnut</i>, <i>line</i>, <i>bar</i>, <i>radar</i> and
+            A chart is configured with 3 properties; <i>type</i>, <i>data</i> and <i>options</i>. Chart type is defined using the <i>type</i> property that accepts <i>pie</i>, <i>doughnut</i>, <i>line</i>, <i>bar</i>, <i>radar</i> and
             <i>polarArea</i> as a value. The <i>data</i> defines datasets represented with the chart and the <i>options</i> provide numerous customization options to customize the presentation.
         </p>
     </DocSectionText>


### PR DESCRIPTION
### Defect Fixes

I found a typo in the `chart` documentation - thought it'd be handy to open a PR whilst I was at it 👍 
