### PR TITLE
Ensure canvas exists when initializing Chart.js

### DIFF
--- a/packages/primevue/src/chart/Chart.vue
+++ b/packages/primevue/src/chart/Chart.vue
@@ -48,7 +48,7 @@ export default {
                     this.chart = null;
                 }
 
-                if (module && module.default) {
+                if (module && module.default && this.$refs.canvas) {
                     this.chart = new module.default(this.$refs.canvas, {
                         type: this.type,
                         data: this.data,


### PR DESCRIPTION
When initializing the chart, the import for chart.js is dynamic which means its possible for the canvas to be removed before we call chart.js's initialization function.  This can cause sporadic failures during tests if components are being loaded for short periods of times. During general use it's unlikely to happen as the import is likely to be resolved quickly.

<details>
<summary>Our tests involving components with Charts will sometimes fail with:</summary>

```
TypeError: can't access property "id", existingChart.canvas is null
 ❯ existingChart node_modules/chart.js/src/core/core.controller.js:130:56
 ❯ initChart/< node_modules/.cache/storybook/8daef92945d3cde78e35af65d1a26653ec49eb015c1bba2e1ded8d936ac3fdb0/sb-vitest/deps/primevue_chart.js:674:24
 ❯ promise callback*initChart node_modules/.cache/storybook/8daef92945d3cde78e35af65d1a26653ec49eb015c1bba2e1ded8d936ac3fdb0/sb-vitest/deps/primevue_chart.js:668:57
 ❯ mounted2 node_modules/.cache/storybook/8daef92945d3cde78e35af65d1a26653ec49eb015c1bba2e1ded8d936ac3fdb0/sb-vitest/deps/primevue_chart.js:657:9
 ❯ renderToCanvas node_modules/@storybook/vue3/dist/chunk-DYBVISFM.mjs:6:6552
 ❯ async*renderToCanvas node_modules/@storybook/vue3/dist/index.mjs:8:430
 ❯ Ro3/h2</f3.renderToCanvas node_modules/storybook/dist/preview-api/index.js:3398:22
 ❯ mount/< node_modules/@storybook/vue3/dist/chunk-DYBVISFM.mjs:6:8392
 ❯ ei3 node_modules/storybook/dist/preview-api/index.js:3519:19
 ❯ ei node_modules/storybook/dist/preview-api/index.js:3428:32
 ❯ testStory/< node_modules/.cache/storybook/8daef92945d3cde78e35af65d1a26653ec49eb015c1bba2e1ded8d936ac3fdb0/sb-vitest/deps/@storybook_addon-vitest_internal_test-utils.js:95:129
```
</details>

Fixes #8228 