### PR TITLE
fix: tab list next button visibility

### DIFF
--- a/packages/primevue/src/tablist/TabList.vue
+++ b/packages/primevue/src/tablist/TabList.vue
@@ -147,7 +147,7 @@ export default {
                 this.isNextButtonEnabled = list.offsetHeight >= offsetHeight && parseInt(scrollTop) !== scrollHeight - height;
             } else {
                 this.isPrevButtonEnabled = scrollLeft !== 0;
-                this.isNextButtonEnabled = list.offsetWidth >= offsetWidth && parseInt(scrollLeft) !== scrollWidth - width;
+                this.isNextButtonEnabled = list.offsetWidth >= offsetWidth && Math.abs(parseInt(scrollLeft) - scrollWidth + width) > 1;
             }
         },
         getVisibleButtonWidths() {


### PR DESCRIPTION
This changes fixes an issue where the tab list next button stays visible under certain widths. Precision is increased in order to match logic in [primeng repo](https://github.com/primefaces/primeng/blob/master/packages/primeng/src/tabs/tablist.ts#L208)

### Defect Fixes
https://github.com/primefaces/primevue/issues/8250
