### PR TITLE
fix: prevent dialog from closing on IME composition

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -238,7 +238,7 @@ export default {
             }
         },
         onKeyDown(event) {
-            if (event.code === 'Escape' && this.closeOnEscape) {
+            if (event.code === 'Escape' && this.closeOnEscape && !event.isComposing) {
                 this.close();
             }
         },


### PR DESCRIPTION
### Defect Fixes

Fix: Dialog closes incorrectly when pressing Escape during IME composition  
  
In `Dialog.vue`, updated the `onKeyDown` handler to ignore `Escape` key during composition.  
Previously, pressing `Escape` always closed the dialog even during IME input.  
Now, it checks `event.isComposing` before closing.
