### PR TITLE
feat: custom elements support

### DIFF
--- a/packages/core/src/basecomponent/BaseComponent.vue
+++ b/packages/core/src/basecomponent/BaseComponent.vue
@@ -351,7 +351,7 @@ export default {
             return { classes: undefined, inlineStyles: undefined, load: () => {}, loadCSS: () => {}, loadStyle: () => {}, ...(this._getHostInstance(this) || {}).$style, ...this.$options.style };
         },
         $styleOptions() {
-            return { nonce: this.$primevueConfig?.csp?.nonce };
+            return { nonce: this.$primevueConfig?.csp?.nonce, styleContainer: this.$primevueConfig?.styleContainer };
         },
         $primevueConfig() {
             return this.$primevue?.config;

--- a/packages/core/src/basedirective/BaseDirective.js
+++ b/packages/core/src/basedirective/BaseDirective.js
@@ -71,14 +71,15 @@ const BaseDirective = {
     _loadStyles: (instance = {}, binding, vnode) => {
         const config = BaseDirective._getConfig(binding, vnode);
         const useStyleOptions = { nonce: config?.csp?.nonce };
+        const styleContainer = config?.styleContainer;
 
-        BaseDirective._loadCoreStyles(instance, useStyleOptions);
-        BaseDirective._loadThemeStyles(instance, useStyleOptions);
-        BaseDirective._loadScopedThemeStyles(instance, useStyleOptions);
+        BaseDirective._loadCoreStyles(instance, { ...useStyleOptions, styleContainer });
+        BaseDirective._loadThemeStyles(instance, { ...useStyleOptions, styleContainer });
+        BaseDirective._loadScopedThemeStyles(instance, { ...useStyleOptions, styleContainer });
 
         BaseDirective._removeThemeListeners(instance);
 
-        instance.$loadStyles = () => BaseDirective._loadThemeStyles(instance, useStyleOptions);
+        instance.$loadStyles = () => BaseDirective._loadThemeStyles(instance, { ...useStyleOptions, styleContainer });
 
         BaseDirective._themeChangeListener(instance.$loadStyles);
     },

--- a/packages/core/src/config/PrimeVue.d.ts
+++ b/packages/core/src/config/PrimeVue.d.ts
@@ -7,6 +7,7 @@ export interface PrimeVueConfiguration {
      */
     inputStyle?: 'filled' | 'outlined' | undefined;
     inputVariant?: 'filled' | 'outlined' | undefined;
+    styleContainer?: HTMLElement | ShadowRoot;
     locale?: PrimeVueLocaleOptions;
     filterMatchModeOptions?: any;
     zIndex?: PrimeVueZIndexOptions;

--- a/packages/core/src/config/PrimeVue.js
+++ b/packages/core/src/config/PrimeVue.js
@@ -9,6 +9,7 @@ export const defaultOptions = {
     ripple: false,
     inputStyle: null,
     inputVariant: null,
+    styleContainer: undefined,
     locale: {
         startsWith: 'Starts with',
         contains: 'Contains',
@@ -198,7 +199,7 @@ export function setupConfig(app, PrimeVue) {
         // common
         if (!Theme.isStyleNameLoaded('common')) {
             const { primitive, semantic, global, style } = BaseStyle.getCommonTheme?.() || {};
-            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce };
+            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce, styleContainer: PrimeVue.config?.styleContainer };
 
             BaseStyle.load(primitive?.css, { name: 'primitive-variables', ...styleOptions });
             BaseStyle.load(semantic?.css, { name: 'semantic-variables', ...styleOptions });

--- a/packages/core/src/usestyle/UseStyle.d.ts
+++ b/packages/core/src/usestyle/UseStyle.d.ts
@@ -7,6 +7,7 @@ export interface StyleOptions {
     media?: string;
     nonce?: string;
     props?: any;
+    styleContainer?: HTMLElement | ShadowRoot;
 }
 
 export interface Style {


### PR DESCRIPTION
Create a new `styleContainer` option in primevue config to be able to pass via configuration where the style tags need to be injected, allowing to pass the shadowRoot in the defineCustomElement setup function and keeping the existing functionality without breaking changes.

Example use:

```typescript
import { defineCustomElement, getCurrentInstance, h, useShadowRoot } from 'vue'
import App from './App.vue';
import PrimeVue from 'primevue/config';
import Aura from '@primeuix/themes/aura';


// Define the custom element with all the
const MyWebComponent = defineCustomElement({
  setup() {
    const instance = getCurrentInstance()
    const app = instance?.appContext.app
    app?.use(PrimeVue, {
      styleContainer: useShadowRoot() ?? undefined,
      theme: {
        preset: Aura,
      },
    })

    return () => h(App)
  },
})

// Auto-register the custom element
customElements.define('my-web-component', MyWebComponent);
``` 

This is a much simpler proposal than #7351 that will also help with #4001 that will add support for custom elements to the library without breaking changes.

Components that use the Portal like the dialog will be rendered by default in the body and the styles will be added to the shadowRoot, consumers will have to handle this situation in their custom elements, by either coping the styles to the document head or by passing a template ref as anchorEl to render this components inside the shadowRoot.

Example
```vue
<script setup lang="ts">
import { ref, useTemplateRef } from 'vue'
import { Button, Dialog } from 'primevue'

const visible = ref(false)
const portal = useTemplateRef('portal')

const openDialog = () => {
  visible.value = true
}

const closeDialog = () => {
  visible.value = false
}
</script>
<template>
  <div class="fixed right-8 bottom-8">
    <Button label="Open Dialog" @click="openDialog" raised size="large" />
    <Dialog
      :visible="visible"
      :appendTo="portal"
      header="I'm a dialog"
      @update:visible="closeDialog"
      class="w-full max-w-md"
    >
      <p class="f-body-md text-surface-700">This is the dialog body</p>
      <template #footer>
        <Button label="Close" @click="closeDialog" outlined />
      </template>
    </Dialog>
  </div>
  <div ref="portal"></div>
</template>
```

This fix was tested locally, and the styles are correctly copied to the shadowRoot, when building a "regular" vue app or a custom element without a shadow dom, the styles are injected to the document head and everything works as usual

<img width="2052" height="1565" alt="Screenshot 2025-11-05 at 17 51 11" src="https://github.com/user-attachments/assets/1dac4608-ff30-46ef-ac85-393ef9d4ea32" />

<img width="2052" height="1565" alt="Screenshot 2025-11-05 at 17 52 32" src="https://github.com/user-attachments/assets/22fe5ab2-36f6-49d5-bc17-94fa1aa471ff" />