### PR TITLE
Select: label length check

### DIFF
--- a/packages/primevue/src/select/style/SelectStyle.js
+++ b/packages/primevue/src/select/style/SelectStyle.js
@@ -21,7 +21,7 @@ const classes = {
         'p-select-label',
         {
             'p-placeholder': !props.editable && instance.label === props.placeholder,
-            'p-select-label-empty': !props.editable && !instance.$slots['value'] && (instance.label === 'p-emptylabel' || instance.label.length === 0)
+            'p-select-label-empty': !props.editable && !instance.$slots['value'] && (instance.label === 'p-emptylabel' || instance.label?.length === 0)
         }
     ],
     clearIcon: 'p-select-clear-icon',


### PR DESCRIPTION
fix(select): style error when option label is empty or wrong

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')
    at label (SelectStyle.js:24:138)
