### PR TITLE
fix(datatable#5633): preserve keyless columns during reorder

### DIFF
--- a/packages/primevue/src/datatable/DataTable.vue
+++ b/packages/primevue/src/datatable/DataTable.vue
@@ -1552,9 +1552,15 @@ export default {
         findColumnByKey(columns, key) {
             if (columns && columns.length) {
                 for (let i = 0; i < columns.length; i++) {
-                    let column = columns[i];
+                    const column = columns[i];
+                    const columnKey = this.columnProp(column, 'columnKey');
+                    const field = this.columnProp(column, 'field');
 
-                    if (this.columnProp(column, 'columnKey') === key || this.columnProp(column, 'field') === key) {
+                    if (columnKey !== null && columnKey !== undefined && columnKey === key) {
+                        return column;
+                    }
+
+                    if (field !== null && field !== undefined && field === key) {
                         return column;
                     }
                 }
@@ -2043,11 +2049,30 @@ export default {
 
             if (cols && this.reorderableColumns && this.d_columnOrder) {
                 let orderedColumns = [];
+                const keylessColumnsQueue = cols.filter((column) => {
+                    const columnKeyProp = this.columnProp(column, 'columnKey');
+                    const fieldProp = this.columnProp(column, 'field');
+
+                    return (columnKeyProp === null || columnKeyProp === undefined) && (fieldProp === null || fieldProp === undefined) && !this.columnProp(column, 'hidden');
+                });
 
                 for (let columnKey of this.d_columnOrder) {
+                    if (columnKey === null || columnKey === undefined) {
+                        while (keylessColumnsQueue.length) {
+                            const column = keylessColumnsQueue.shift();
+
+                            if (orderedColumns.indexOf(column) < 0) {
+                                orderedColumns.push(column);
+                                break;
+                            }
+                        }
+
+                        continue;
+                    }
+
                     let column = this.findColumnByKey(cols, columnKey);
 
-                    if (column && !this.columnProp(column, 'hidden')) {
+                    if (column && !this.columnProp(column, 'hidden') && orderedColumns.indexOf(column) < 0) {
                         orderedColumns.push(column);
                     }
                 }


### PR DESCRIPTION
- fix(datatable): preserve keyless columns during reorder

- Resolves [#6764](https://github.com/primefaces/primevue/issues/6764) and [#5633](https://github.com/primefaces/primevue/issues/5633):

  - Root cause: columns() rebuilt the ordered list purely from d_columnOrder. findColumnByKey treated null order entries as a match for the first column with a falsy key, so selector/frozen columns were duplicated when d_columnOrder contained null placeholders. The final spread (...cols.filter) then re-appended the original keyed column, causing copies to appear after each drag. The same logic also forced keyless columns (selection/frozen) to the tail of the array when null was used to reserve their position.
  - Fix: tighten findColumnByKey so it ignores null/undefined props, and walk d_columnOrder with a queue of keyless columns—each null entry now consumes exactly one keyless column in its original sequence. We skip hidden columns and guard against re-adding the same vnode twice, so the remainder filter can safely merge untouched columns.
  - Verification: manually tested with selector + multi reorder, frozen action column, and multiple null placeholders at the start/end of d_columnOrder; column count stays stable, selector/frozen columns remain anchored, and no hidden columns leak back in.