### PR TITLE
Fix - remove duplicate class with misleading name and property from api docs

### DIFF
--- a/apps/volt/doc/animations/ApiDoc.vue
+++ b/apps/volt/doc/animations/ApiDoc.vue
@@ -19,10 +19,6 @@
                         <td>animation-name: leave; <br />--p-leave-opacity: initial; <br />--p-leave-scale: initial; <br />--p-leave-rotate: initial; <br />--p-leave-translate-x: initial; <br />--p-leave-translate-y: initial;</td>
                     </tr>
                     <tr>
-                        <td>animate-leave</td>
-                        <td>fadein 0.15s linear</td>
-                    </tr>
-                    <tr>
                         <td>animate-fadein</td>
                         <td>fadein 0.15s linear</td>
                     </tr>


### PR DESCRIPTION
<img width="1355" height="521" alt="image" src="https://github.com/user-attachments/assets/78ef11ca-036d-40eb-8547-eb69eb33722d" />

'animate-leave' has a duplicated

I think 'animate-leave' shouldn't equal to 'fadein 0.15s linear'
because 'animate-leave' already has it's own description on previous row
and 'fadein 0.15s linear' is already assign to 'animate-fadein'

url: https://volt.primevue.org/animations/