### PR TITLE
fix: conditional check on empty-array option prop

### DIFF
--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -464,7 +464,7 @@ export default {
         updateTreeState() {
             let keys = { ...this.d_value };
 
-            if (keys && this.options) {
+            if (keys && this.options?.length) {
                 this.updateTreeBranchState(null, null, keys);
             }
         },
@@ -518,7 +518,7 @@ export default {
         selectedNodes() {
             let selectedNodes = [];
 
-            if (this.d_value && this.options) {
+            if (this.d_value && this.options?.length) {
                 Object.keys(this.d_value).forEach((key) => {
                     const node = this.nodeMap[key];
 


### PR DESCRIPTION
Issue link here:
https://github.com/primefaces/primevue/issues/8290

## summary 
in JS an empty array is truthy:

```const isTruthy = [] ? true : false // ugh it is truthy!```


### Observed Problem
TreeSelect component throws an error if `options` prop is empty array.

### Expectation
TreeSelect component should not throw an error and simply show no options if `options` prop is empty array, just as it does for when `options` is undefined.

