### PR TITLE
fix(data-table): prevent self-click detection when clicking on overlay elements

### DIFF
--- a/packages/primevue/src/datatable/BodyCell.vue
+++ b/packages/primevue/src/datatable/BodyCell.vue
@@ -305,6 +305,10 @@ export default {
         bindDocumentEditListener() {
             if (!this.documentEditListener) {
                 this.documentEditListener = (event) => {
+                    if (this.isOverlayClicked(event.target)) {
+                        return;
+                    }
+
                     this.selfClick = this.$el && this.$el.contains(event.target);
 
                     if (this.editCompleteTimeout) {
@@ -320,6 +324,11 @@ export default {
 
                 document.addEventListener('mousedown', this.documentEditListener);
             }
+        },
+        isOverlayClicked(target) {
+            if (!target) return false;
+
+            return Boolean(target.closest('[data-pc-section="panel"], [data-pc-section="overlay"]'));
         },
         unbindDocumentEditListener() {
             if (this.documentEditListener) {


### PR DESCRIPTION
## Defect Fixes  
> fix: #8280

### 1. Background
- In a previous PR (https://github.com/primefaces/primevue/pull/6984), the event order of DataTable cell editing was modified to fix an issue where edited values were not being reflected when sorting.
- During this improvement, a new issue surfaced when using **overlay-based components** (e.g., MultiSelect, DatePicker) inside a DataTable with `editMode="cell"`.

<br/>

### 2. Issue Description

When interacting with overlay components inside a DataTable:

1. The user clicks a DataTable cell  
2. An overlay/panel opens  
3. The user clicks an option inside the overlay  
4. **Before the overlay’s click event fires, DataTable’s `mousedown` outside-click logic executes**
5. `completeEdit('outside')` is triggered prematurely  
6. The overlay closes immediately, and the user cannot select an option

#### (1) Root Cause: Event Ordering Mismatch

- **DataTable workflow**  
  `mousedown → cell-edit-init → (focus) → cell-edit-complete`
- **Overlay workflow**  
  `click → overlay-click`

Because `mousedown` fires earlier than `click`, overlay interactions are mistakenly interpreted as outside-clicks.
In summary, Overlay internal clicks lose the event race to DataTable.

<br/>

### 3. How To Resolve

#### (1) Attempt 1 > Reverting `mousedown` back to `click`
(Why this approach was not chosen)
Reverting outside-click detection from `mousedown` → `click` would fix the overlay issue.  
However, it reintroduces the regression fixed in the earlier PR:
```
Repeatedly clicking inside the DataTable after editing causes the value to copy to its previous edited value.
```

#### (2) Final Solution > Overlay-Aware Early Return (Temporary Workaround)

PrimeVue overlay components share common DOM markers:

- `[data-pc-section="panel"]`
- `[data-pc-section="overlay"]`

Thus, an early-return guard was added in `documentEditListener` to prevent valid overlay interactions from being treated as outside-clicks.

```js
if (this.isOverlayClicked(event.target)) {
    return; // Ignore overlay clicks — do not treat them as outside
}
```

<br/>

### 4. Test
#### (1) Overlay Interaction Behavior
|before|after|
|---|---|
|<video src="https://github.com/user-attachments/assets/e00e8fe5-ec37-4b23-bb5e-aa8e30645d00" />|<video src="https://github.com/user-attachments/assets/941747ac-2fe3-4915-bf1c-2c9c479a93f7" />|

- **Before:** When clicking inside the overlay, `completeEdit('outside')` is triggered first, causing the overlay to close immediately.  
- **After:** Overlay internal clicks are handled correctly, and options can be selected as expected.


<br/>



#### (2) Regression Check for Previous PR (#6984)


https://github.com/user-attachments/assets/4a49f55e-13e5-4163-92bf-9c23d65a782c

The following video confirms that the issue resolved in the previous PR  
(value restoration / sorting inconsistency) **does not reappear** after this update.

- Sorting behavior continues to work correctly.  
- Repeated clicks inside the DataTable do not cause edited values to revert or duplicate.  

<br/>

### 5. Additional Discussion

This PR resolves the issue with minimal risk and without altering fundamental lifecycle mechanics.
If there is a recommended architectural direction to align DataTable editing with overlay behavior, 
I would greatly appreciate feedback. Thank you :)