### PR TITLE
Fix - remove duplicate class with misleading name and property from api docs

### DIFF
--- a/apps/showcase/doc/tailwind/AnimationsDoc.vue
+++ b/apps/showcase/doc/tailwind/AnimationsDoc.vue
@@ -36,10 +36,6 @@
                         <td>animation-name: leave; <br />--p-leave-opacity: initial; <br />--p-leave-scale: initial; <br />--p-leave-rotate: initial; <br />--p-leave-translate-x: initial; <br />--p-leave-translate-y: initial;</td>
                     </tr>
                     <tr>
-                        <td>animate-leave</td>
-                        <td>fadein 0.15s linear</td>
-                    </tr>
-                    <tr>
                         <td>animate-fadein</td>
                         <td>fadein 0.15s linear</td>
                     </tr>


### PR DESCRIPTION
same as [8273](https://github.com/primefaces/primevue/pull/8273) but for tailwind docs

<img width="1206" height="507" alt="image" src="https://github.com/user-attachments/assets/ecdc04c6-a34c-4c19-8dd2-07ff8b1165ee" />

url: https://primevue.org/tailwind/#animations

I notice there is duplicate docs with the same issue; I added previous PR details below

====================

<img width="1355" height="521" alt="image" src="https://github.com/user-attachments/assets/78ef11ca-036d-40eb-8547-eb69eb33722d" />

'animate-leave' has a duplicated

I think 'animate-leave' shouldn't equal to 'fadein 0.15s linear'
because 'animate-leave' already has it's own description on previous row
and 'fadein 0.15s linear' is already assign to 'animate-fadein'

url: https://volt.primevue.org/animations/