### PR TITLE
Fix: (#7817) - BlockUI does not unblock when blocked property changes …

### DIFF
--- a/packages/primevue/src/blockui/BlockUI.vue
+++ b/packages/primevue/src/blockui/BlockUI.vue
@@ -82,6 +82,7 @@ export default {
 
                 const handleAnimationEnd = () => {
                     clearTimeout(fallbackTimer);
+                    this.removeMask();
                     this.mask.removeEventListener('animationend', handleAnimationEnd);
                     this.mask.removeEventListener('webkitAnimationEnd', handleAnimationEnd);
                 };


### PR DESCRIPTION
Added removeMask to the animation end callback.

When animations are enabled, there is a race condition between the fallback timer and the animation ending.
If the animation ends first, the timer is cancelled and removeMask is never called.
Appears to have been introduced in commit 162d1a6

