### PR TITLE
AutoComplete: fix layout breaks inside InputGroup when using multiple mode

### DIFF
--- a/packages/primevue/src/autocomplete/style/AutoCompleteStyle.js
+++ b/packages/primevue/src/autocomplete/style/AutoCompleteStyle.js
@@ -24,7 +24,8 @@ const classes = {
         'p-autocomplete-input-multiple',
         {
             'p-variant-filled': instance.$variant === 'filled',
-            'p-disabled': props.disabled
+            'p-disabled': props.disabled,
+            'p-component': true
         }
     ],
     clearIcon: 'p-autocomplete-clear-icon',


### PR DESCRIPTION
Fixes #8298

Tested with putting the following code snippet inside `./apps/showcase/doc/autocomplete/MultipleDoc.vue`:

```vue
<div class="card">
    <label for="multiple-ac-1" class="font-bold mb-2 block">Without multiple</label>
    <InputGroup>
        <AutoComplete v-model="value1" inputId="multiple-ac-1" fluid :suggestions="items" @complete="search" />
        <InputGroupAddon style="background: var(--p-autocomplete-dropdown-background);">
            <Button icon="pi pi-user-plus" text rounded />
        </InputGroupAddon>
    </InputGroup>

    <label for="multiple-ac-2" class="font-bold mt-8 mb-2 block">With multiple</label>
    <InputGroup>
        <AutoComplete v-model="value2" inputId="multiple-ac-2" multiple fluid @complete="search"
            :typeahead="false" />
        <InputGroupAddon style="background: var(--p-autocomplete-dropdown-background);">
            <Button icon="pi pi-user-plus" text rounded />
        </InputGroupAddon>
    </InputGroup>
</div>
```