### PR TITLE
Fix: prevent nested steppers from accessing ancestor StepItem

### DIFF
--- a/packages/primevue/src/stepper/BaseStepper.vue
+++ b/packages/primevue/src/stepper/BaseStepper.vue
@@ -19,7 +19,8 @@ export default {
     provide() {
         return {
             $pcStepper: this,
-            $parentInstance: this
+            $parentInstance: this,
+            $pcStepItem: null, //shadow any ancestor StepItem so nested steppers don’t see it
         };
     }
 };


### PR DESCRIPTION
Fixes #8310

The issue occurs because `$pcStepItem` of ancestor steppers is injected into Step/StepPanel components.

And when that happens, it breaks the check in the codebase that relies on the truthiness of `$pcStepItem` for computation.

<img width="706" height="56" alt="Screenshot 2025-12-17 at 17 37 48" src="https://github.com/user-attachments/assets/eadc775f-6fdc-401e-80c7-59832eeab4ff" />

E.g in a case of a horizontal stepper inside a vertical step item, the horizontal step `$pcStepItem` here is truthy which causes `activeValue` to return the wrong value.

In the above case, the same mismatch is also present in StepPanel's `isVertical` computed method and `dataP` generated class string.

This fix prevents Step/StepPanel components from having access to any ancestor's `$pcStepItem`. It now only has access to the `$pcStepItem` of its immediate parent stepper.