### PR TITLE
Fix: BlockUI mask blocking interactions during exit animation

### DIFF
--- a/packages/primevue/src/blockui/BlockUI.vue
+++ b/packages/primevue/src/blockui/BlockUI.vue
@@ -77,13 +77,18 @@ export default {
             this.$emit('block');
         },
         unblock() {
+            this.isBlocked = false;
+            this.$emit('unblock');
+
             if (this.mask) {
+                this.mask.style.pointerEvents = 'none';
                 !this.isUnstyled && addClass(this.mask, 'p-overlay-mask-leave-active');
 
                 const handleAnimationEnd = () => {
                     clearTimeout(fallbackTimer);
                     this.mask.removeEventListener('animationend', handleAnimationEnd);
                     this.mask.removeEventListener('webkitAnimationEnd', handleAnimationEnd);
+                    this.removeMask();
                 };
 
                 const fallbackTimer = setTimeout(() => {
@@ -99,6 +104,10 @@ export default {
             }
         },
         removeMask() {
+            if (!this.mask) {
+                return;
+            }
+
             ZIndex.clear(this.mask);
 
             if (this.fullScreen) {
@@ -108,8 +117,7 @@ export default {
                 this.$refs.container?.removeChild(this.mask);
             }
 
-            this.isBlocked = false;
-            this.$emit('unblock');
+            this.mask = null;
         }
     }
 };


### PR DESCRIPTION
## Issue
When the `blocked` prop was toggled rapidly (e.g., fast API calls completing around 50-150ms), the BlockUI mask element would remain in the DOM during its exit animation and continue blocking pointer events. This prevented users from interacting with elements underneath, even though the visual overlay had faded out and `isBlocked` was `false`.

The problem was most noticeable during stress testing or rapid pagination where block/unblock cycles happened faster than the CSS animation duration (~300ms).

Reproducer link: https://stackblitz.com/edit/primevue-4-vite-issue-template-jg3s6cmh?file=src%2FBlockUITest.vue

closes https://github.com/primefaces/primevue/issues/7817

## Root Cause
The `unblock()` method was setting `isBlocked = false` only after the exit animation completed (in `removeMask()`). While the mask element remained in the DOM during the animation, it still had pointer events enabled, blocking all user interactions with the underlying content.

## Solution
Set `pointer-events: none` on the mask element immediately when `unblock()` is called, before the exit animation begins:
```javascript
this.mask.style.pointerEvents = 'none';
```

This allows click events to pass through the mask to the content below while the mask visually animates out. The mask element is still properly cleaned up after the animation completes.

Additionally, moved `isBlocked = false` and the `unblock` event emission to the beginning of the `unblock()` method for immediate state updates.

## Testing
Verified fix using the same testing component from the stackblitz reproducer:  


https://github.com/user-attachments/assets/9ede7402-3054-4ac3-bb7a-5994381802a1





