### PR TITLE
fix(DatePicker): correct ISO week number calculation

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -2174,16 +2174,21 @@ export default {
             return date;
         },
         getWeekNumber(date) {
-            let checkDate = new Date(date.getTime());
+    const d = new Date(Date.UTC(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate()
+    ));
 
-            checkDate.setDate(checkDate.getDate() + 4 - (checkDate.getDay() || 7));
-            let time = checkDate.getTime();
+    const dayNum = d.getUTCDay() || 7;
 
-            checkDate.setMonth(0);
-            checkDate.setDate(1);
+    // ISO week date: Thursday determines the year
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
 
-            return Math.floor(Math.round((time - checkDate.getTime()) / 86400000) / 7) + 1;
-        },
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+
+    return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
+}
         onDateCellKeydown(event, date, groupIndex) {
             event.preventDefault();
             const cellContent = event.currentTarget;


### PR DESCRIPTION
**Problem:**
The calendar week number was calculated incorrectly around year boundaries, causing the second calendar week to be shown as Week 1 instead of following the ISO-8601 standard.

**Impact:**
This resulted in incorrect week labels in the DatePicker, leading to confusion for users relying on week-based planning, particularly in late December and early January.

**Solution:**
The getWeekNumber logic was updated to use an ISO-8601 compliant, UTC-based calculation, ensuring correct Week 1 handling and accurate week numbering across year transitions.

Fixes #6277 (Calendar: every calendar week is wrong)