### PR TITLE
Fix ColorPicker initial value with Form initialValues

### DIFF
--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -54,7 +54,7 @@ export default {
     hueView: null,
     hueHandle: null,
     watch: {
-        modelValue: {
+        d_value: {
             immediate: true,
             handler(newValue) {
                 this.hsbValue = this.toHSB(newValue);


### PR DESCRIPTION
Fixes #8135

Context
- ColorPicker did not pick up Form initialValues when used with name + Form.
- The component was only watching modelValue, while Form-driven state updates d_value.

Changes
- Watch d_value in ColorPicker to keep UI in sync with Form initialValues and regular v-model/defaultValue usage.

Repro
1. Use <Form :initialValues="{ color: '00ffff' }"> with <ColorPicker name="color" />
2. Before: picker stays red
3. After: picker starts at 00ffff

Testing
- Manual (local): Form + ColorPicker initialValues in apps/showcase/pages/test.vue
- Manual (local): ColorPicker v-model without Form
