### PR TITLE
fix(Tree): tree node not reactive when drag drop initial state is false

### DIFF
--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -94,10 +94,32 @@ export default {
     watch: {
         expandedKeys(newValue) {
             this.d_expandedKeys = newValue;
+        },
+        droppableNodes() {
+            this.handleDragDropServiceState();
+        },
+        draggableNodes() {
+            this.handleDragDropServiceState();
         }
     },
     mounted() {
-        if (this.droppableNodes) {
+        this.handleDragDropServiceState();
+    },
+    beforeUnmount() {
+        this.cleanupDragDropService();
+    },
+    methods: {
+        handleDragDropServiceState() {
+            const needsDragDropService = this.draggableNodes || this.droppableNodes;
+
+            if (needsDragDropService) {
+                this.initializeDragDropService();
+            } else {
+                this.cleanupDragDropService();
+            }
+        },
+        initializeDragDropService() {
+            if (!this.dragDropService) {
             this.dragDropService = useTreeDragDropService();
 
             this.dragStartCleanup = this.dragDropService.onDragStart((event) => {
@@ -116,16 +138,24 @@ export default {
             });
         }
     },
-    beforeUnmount() {
+        cleanupDragDropService() {
         if (this.dragStartCleanup) {
             this.dragStartCleanup();
+                this.dragStartCleanup = null;
         }
 
         if (this.dragStopCleanup) {
             this.dragStopCleanup();
-        }
-    },
-    methods: {
+                this.dragStopCleanup = null;
+            }
+
+            this.dragDropService = null;
+            this.dragNode = null;
+            this.dragNodeSubNodes = null;
+            this.dragNodeIndex = null;
+            this.dragNodeScope = null;
+            this.dragHover = false;
+        },
         onNodeToggle(node) {
             const key = node.key;
 


### PR DESCRIPTION
### Defect Fixes

Fix https://github.com/primefaces/primevue/issues/8276

Fixes a runtime error that occurs when draggableNodes or droppableNodes props are initially set to false and then dynamically changed to true during runtime.

```
  Error:
  Uncaught TypeError: Cannot read properties of undefined (reading 'startDrag')
    at onNodeDragStart (TreeNode.vue:496)
```

###  Root Cause
The dragDropService in Tree component was only initialized in the mounted lifecycle hook when droppableNodes was true. This meant:

1. If both draggableNodes and droppableNodes were initially false, **the service was never initialized**
2. When these props were later changed to true, **the service remained uninitialized**
3. TreeNode would attempt to call this.$pcTree.dragDropService.startDrag() on **an undefined object**

###  Solution
Implemented reactive watchers for both draggableNodes and droppableNodes props that dynamically initialize or cleanup the dragDropService based on the current state.