### PR TITLE
fix(select): keep selected label when filtered

### DIFF
--- a/packages/primevue/src/select/Select.spec.js
+++ b/packages/primevue/src/select/Select.spec.js
@@ -366,3 +366,38 @@ describe('filter checks', () => {
         expect(wrapper.findAll('.p-select-option').length).toBe(2);
     });
 });
+
+describe('filter label persistence checks', () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = mount(Select, {
+            global: {
+                plugins: [PrimeVue],
+                stubs: {
+                    teleport: true
+                }
+            },
+            props: {
+                filter: true,
+                options: [
+                    { name: 'France', code: 'FR' },
+                    { name: 'Germany', code: 'DE' },
+                    { name: 'United States', code: 'US' }
+                ],
+                optionLabel: 'name',
+                optionValue: 'code',
+                modelValue: 'FR',
+                placeholder: 'Select a Country'
+            }
+        });
+    });
+
+    it('should keep selected label when filtered out', async () => {
+        expect(wrapper.find('.p-select-label').text()).toBe('France');
+
+        await wrapper.setData({ filterValue: 'United' });
+
+        expect(wrapper.find('.p-select-label').text()).toBe('France');
+    });
+});

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -1019,15 +1019,20 @@ export default {
         hasSelectedOption() {
             return this.$filled;
         },
-        label() {
-            const selectedOptionIndex = this.findSelectedOptionIndex();
+        selectedOption() {
+            const options = this.optionGroupLabel ? this.flatOptions(this.options) : this.options || [];
 
-            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+            return options.find((option) => !this.isOptionGroup(option) && this.isSelected(option));
+        },
+        label() {
+            const selectedOption = this.selectedOption;
+
+            return selectedOption ? this.getOptionLabel(selectedOption) : this.placeholder || 'p-emptylabel';
         },
         editableInputValue() {
-            const selectedOptionIndex = this.findSelectedOptionIndex();
+            const selectedOption = this.selectedOption;
 
-            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions[selectedOptionIndex]) : this.d_value || '';
+            return selectedOption ? this.getOptionLabel(selectedOption) : this.d_value || '';
         },
         equalityKey() {
             return this.optionValue ? null : this.dataKey;


### PR DESCRIPTION
Fixes #8275

## Summary

- Keep Select’s selected label visible even when the option is filtered out.
- Add a regression test for label persistence during filtering.

## Rationale
Select computes its display label from the filtered visibleOptions. When the selected option is not part of the filtered list, the label falls back to the placeholder and appears to disappear. This change resolves the selected label from the full options list (including option groups), so filtering no longer clears the displayed value.

## Test

pnpm --filter primevue test:unit -- Select.spec.js