### PR TITLE
Update data reactive in Step component

### DIFF
--- a/packages/primevue/src/step/Step.vue
+++ b/packages/primevue/src/step/Step.vue
@@ -35,20 +35,21 @@ export default {
     },
     mounted() {
         if (this.$el && this.$pcStepList) {
+            this.update();
+        }
+    },
+    updated() {
+        this.update();
+    },
+    methods: {
+        update() {
             let index = findIndexInList(this.$el, find(this.$pcStepper.$el, '[data-pc-name="step"]'));
             let activeIndex = findIndexInList(findSingle(this.$pcStepper.$el, '[data-pc-name="step"][data-p-active="true"]'), find(this.$pcStepper.$el, '[data-pc-name="step"]'));
             let stepLen = find(this.$pcStepper.$el, '[data-pc-name="step"]').length;
 
             this.isSeparatorVisible = index !== stepLen - 1;
             this.isCompleted = index < activeIndex;
-        }
-    },
-    updated() {
-        let index = findIndexInList(this.$el, find(this.$pcStepper.$el, '[data-pc-name="step"]'));
-        let activeIndex = findIndexInList(findSingle(this.$pcStepper.$el, '[data-pc-name="step"][data-p-active="true"]'), find(this.$pcStepper.$el, '[data-pc-name="step"]'));
-        this.isCompleted = index < activeIndex;
-    },
-    methods: {
+        },
         getPTOptions(key) {
             const _ptm = key === 'root' ? this.ptmi : this.ptm;
 


### PR DESCRIPTION
### Defect Fixes

The Step component inside the `Stepper` component never updates `isSeparatorVisible` which means that if there are new `Steps`s after mount the value will be off resulting in a missing separator. This PR updates both properties during mount and on update.

Issue: https://github.com/primefaces/primevue/issues/8377