### PR TITLE
fix(select) - Filter - Only able to type one character when Input is not focused

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -450,7 +450,13 @@ export default {
                     if (!metaKey && isPrintableCharacter(event.key)) {
                         !this.overlayVisible && this.show();
                         !this.editable && this.searchOptions(event, event.key);
-                        this.filter && (this.filterValue = event.key);
+                        if(this.filter) {
+                            this.$nextTick(() => {
+                                if (this.$refs.filterInput) {
+                                    focus(this.$refs.filterInput.$el);
+                                }
+                            });
+                        }
                     }
 
                     break;


### PR DESCRIPTION
# Defect Fixes

The problem was that if user focused or opened the select without clicking on the input and started typing, it would be possible to type only one letter at a time until the input was focused.

Fixes: https://github.com/primefaces/primevue/issues/8427