### PR TITLE
ToastService: Add default options & methods for setting/getting default options

### DIFF
--- a/apps/showcase/doc/toast/ToastServiceDoc.vue
+++ b/apps/showcase/doc/toast/ToastServiceDoc.vue
@@ -7,6 +7,11 @@
         <p>The service is available with the <i>useToast</i> function for Composition API or using the <i>$toast</i> property of the application for Options API.</p>
     </div>
     <DocSectionCode :code="code2" hideToggleCode importCode hideStackBlitz />
+
+    <DocSectionText>
+        <p>You can provide default options when installing the service, or set defaults at runtime (including basing defaults off an existing message object). Defaults are shallow-merged with each message; message fields override defaults.</p>
+    </DocSectionText>
+    <DocSectionCode :code="code3" hideToggleCode importCode hideStackBlitz />
 </template>
 
 <script>
@@ -27,6 +32,18 @@ app.use(ToastService);
 import { useToast } from 'primevue/usetoast';
 
 const toast = useToast();
+`
+            },
+            code3: {
+                basic: `
+import {createApp} from 'vue';
+import ToastService from 'primevue/toastservice';
+
+const app = createApp(App);
+app.use(ToastService, {
+    life: 5000,
+    severity: 'error'
+});
 `
             }
         };

--- a/packages/primevue/src/toastservice/ToastService.d.ts
+++ b/packages/primevue/src/toastservice/ToastService.d.ts
@@ -6,9 +6,14 @@
  * @todo 'use' is not a valid name for a module. Next release will change.
  */
 import type { ToastMessageOptions } from 'primevue/toast';
-import { Plugin } from 'vue';
+import type { App } from 'vue';
 
-declare const plugin: Plugin;
+export type ToastServiceOptions = Partial<ToastMessageOptions>;
+
+declare const plugin: {
+    install(app: App, options?: ToastServiceOptions): void;
+};
+
 export default plugin;
 
 /**
@@ -37,6 +42,15 @@ export interface ToastServiceMethods {
      * Clears all the messages.
      */
     removeAllGroups(): void;
+    /**
+     * Sets default options for the toast service.
+     * @param {ToastServiceOptions} opts - Options to merge with defaults.
+     */
+    setOptions(opts: ToastServiceOptions): void;
+    /**
+     * Returns the current default options.
+     */
+    getOptions(): ToastServiceOptions;
 }
 
 declare module 'vue' {

--- a/packages/primevue/src/toastservice/ToastService.js
+++ b/packages/primevue/src/toastservice/ToastService.js
@@ -2,10 +2,13 @@ import ToastEventBus from 'primevue/toasteventbus';
 import { PrimeVueToastSymbol } from 'primevue/usetoast';
 
 export default {
-    install: (app) => {
+    install: (app, options = {}) => {
+        let defaults = options || {};
+
         const ToastService = {
             add: (message) => {
-                ToastEventBus.emit('add', message);
+                const merged = Object.assign({}, defaults, message);
+                ToastEventBus.emit('add', merged);
             },
             remove: (message) => {
                 ToastEventBus.emit('remove', message);
@@ -15,7 +18,11 @@ export default {
             },
             removeAllGroups: () => {
                 ToastEventBus.emit('remove-all-groups');
-            }
+            },
+            setOptions: (opts) => {
+                defaults = Object.assign({}, defaults, opts);
+            },
+            getOptions: () => ({ ...defaults })
         };
 
         app.config.globalProperties.$toast = ToastService;


### PR DESCRIPTION
# Add default options support to ToastService

This PR adds support for default toast options, reducing repetition (e.g. always setting `life`) while remaining fully backwards compatible. 

> **Documentation has been updated to demonstrate usage.**

## Impact

* Fully backwards compatible
* Minimal internal change
* Improved developer experience
* Documentation updated [`ToastServiceDoc.vue`](apps/showcase/doc/toast/ToastServiceDoc.vue)


## Why

Today users must repeat common options on every toast:

```js
toast.add({ severity: 'success', summary: 'Saved', life: 5000 });
toast.add({ severity: 'error', summary: 'Failed', life: 5000 });
````

This is repetitive and makes global consistency harder.

## What’s changed

### Install-time defaults

You can now pass defaults (supports all toastMessage parameters) when installing the service:

```js
app.use(ToastService, {
  life: 5000
});
```

> **Note:** If no options object is provided, the service behaves exactly as before. 


### Runtime APIs

Two new methods are available on the toast service:

```js
setOptions(opts: ToastServiceOptions)
```

Merges the provided options into the current defaults (shallow merge). Useful for dynamically adjusting behavior (for example: changing toast duration based on end user's preferences).

```js
getOptions(): ToastServiceOptions
```

Returns the current default options.

---

## Merge behavior

Each toast message is shallow-merged with defaults:

```js
Object.assign({}, defaults, message);
```
* No breaking behavior
* Defaults apply automatically
* Message-level values always override defaults


## Old vs New Usage

### Before (still supported)

```js
app.use(ToastService);

toast.add({
  severity: 'success',
  summary: 'Saved',
  life: 5000
});
```

### After (with defaults)

```js
app.use(ToastService, { life: 5000 });

toast.add({
  severity: 'success',
  summary: 'Saved'
});
```
--- 
Sorry for the longer description. I understand this may be considered a feature request, but it’s something I care about and believe offers a real DX improvement with very minimal impact. I added extra context to make the intent and scope clear, in case that helps with review or inspires a similar implementation by the core team.