### PR TITLE
feat(paginator): add appendTo prop for dropdown components

### DIFF
--- a/packages/primevue/src/paginator/BasePaginator.vue
+++ b/packages/primevue/src/paginator/BasePaginator.vue
@@ -37,6 +37,14 @@ export default {
         alwaysShow: {
             type: Boolean,
             default: true
+        },
+        rowsPerPageDropdownAppendTo: {
+            type: [String, Object],
+            default: 'body'
+        },
+        jumpToPageDropdownAppendTo: {
+            type: [String, Object],
+            default: 'body'
         }
     },
     style: PaginatorStyle,

--- a/packages/primevue/src/paginator/JumpToPageDropdown.vue
+++ b/packages/primevue/src/paginator/JumpToPageDropdown.vue
@@ -9,6 +9,7 @@
         :disabled="disabled"
         :unstyled="unstyled"
         :pt="ptm('pcJumpToPageDropdown')"
+        :appendTo="appendTo"
         data-pc-group-section="pagedropdown"
     >
         <template v-if="templates['jumptopagedropdownicon']" #dropdownicon="slotProps">
@@ -30,7 +31,11 @@ export default {
         page: Number,
         pageCount: Number,
         disabled: Boolean,
-        templates: null
+        templates: null,
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
+        }
     },
     methods: {
         onChange(value) {

--- a/packages/primevue/src/paginator/Paginator.d.ts
+++ b/packages/primevue/src/paginator/Paginator.d.ts
@@ -7,7 +7,7 @@
  * @module paginator
  *
  */
-import type { DefineComponent, DesignToken, EmitFn, PassThrough } from '@primevue/core';
+import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { DropdownPassThroughOptions } from 'primevue/dropdown';
 import type { InputNumberPassThroughOptions } from 'primevue/inputnumber';
@@ -270,6 +270,16 @@ export interface PaginatorProps {
      * @defaultValue true
      */
     alwaysShow?: boolean | undefined;
+    /**
+     * A valid query selector or an HTMLElement to specify where the rows per page dropdown overlay gets appended.
+     * @defaultValue body
+     */
+    rowsPerPageDropdownAppendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
+    /**
+     * A valid query selector or an HTMLElement to specify where the jump to page dropdown overlay gets appended.
+     * @defaultValue body
+     */
+    jumpToPageDropdownAppendTo?: HintedString<'body' | 'self'> | undefined | HTMLElement;
     /**
      * It generates scoped CSS variables using design tokens for the component.
      */

--- a/packages/primevue/src/paginator/Paginator.vue
+++ b/packages/primevue/src/paginator/Paginator.vue
@@ -84,6 +84,7 @@
                             :templates="$slots"
                             :unstyled="unstyled"
                             :pt="pt"
+                            :appendTo="rowsPerPageDropdownAppendTo"
                         />
                         <JumpToPageDropdown
                             v-else-if="item === 'JumpToPageDropdown'"
@@ -95,6 +96,7 @@
                             :templates="$slots"
                             :unstyled="unstyled"
                             :pt="pt"
+                            :appendTo="jumpToPageDropdownAppendTo"
                         />
                         <JumpToPageInput v-else-if="item === 'JumpToPageInput'" :page="currentPage" @page-change="changePage($event)" :disabled="empty" :unstyled="unstyled" :pt="pt" />
                     </template>

--- a/packages/primevue/src/paginator/RowsPerPageDropdown.vue
+++ b/packages/primevue/src/paginator/RowsPerPageDropdown.vue
@@ -9,6 +9,7 @@
         :disabled="disabled"
         :unstyled="unstyled"
         :pt="ptm('pcRowPerPageDropdown')"
+        :appendTo="appendTo"
         data-pc-group-section="pagedropdown"
     >
         <template v-if="templates['rowsperpagedropdownicon']" #dropdownicon="slotProps">
@@ -30,7 +31,11 @@ export default {
         options: Array,
         rows: Number,
         disabled: Boolean,
-        templates: null
+        templates: null,
+        appendTo: {
+            type: [String, Object],
+            default: 'body'
+        }
     },
     methods: {
         onChange(value) {


### PR DESCRIPTION
## Summary

Add `rowsPerPageDropdownAppendTo` and `jumpToPageDropdownAppendTo` props to the Paginator component to allow controlling where the dropdown overlays are appended.

## Problem

When using Paginator inside dialogs (especially native `<dialog>` elements using `showModal()`), the dropdown overlays for "rows per page" and "jump to page" are teleported to `<body>` by default. This causes them to appear **behind** the dialog due to the browser's top-layer stacking context.

## Solution

This PR adds two new props to the Paginator component:

- `rowsPerPageDropdownAppendTo` - Controls where the rows-per-page Select overlay is appended
- `jumpToPageDropdownAppendTo` - Controls where the jump-to-page Select overlay is appended

Both props default to `'body'` (current behavior) for backward compatibility. Setting them to `'self'` renders the dropdown overlay inline within the component, solving the top-layer stacking issue.

## Usage

```vue
<Paginator 
  :rows="10"
  :totalRecords="100"
  :rowsPerPageOptions="[10, 20, 50]"
  rowsPerPageDropdownAppendTo="self"
/>
```

## Changes

- `BasePaginator.vue`: Added `rowsPerPageDropdownAppendTo` and `jumpToPageDropdownAppendTo` props
- `Paginator.vue`: Pass the new props to child dropdown components
- `RowsPerPageDropdown.vue`: Added `appendTo` prop and forward it to internal Select
- `JumpToPageDropdown.vue`: Added `appendTo` prop and forward it to internal Select
- `Paginator.d.ts`: Updated TypeScript definitions

## Testing

Tested with a Paginator inside a native `<dialog>` element using `showModal()`. The dropdown now appears correctly inside the dialog when `appendTo="self"`.