### PR TITLE
fix(DatePicker): update rawValue before recalculating metadata

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -628,8 +628,8 @@ export default {
         modelValue: {
             immediate: true,
             handler(newValue) {
-                this.updateCurrentMetaData();
                 this.rawValue = typeof newValue === 'string' ? this.parseValue(newValue) : newValue;
+                this.updateCurrentMetaData();
 
                 if (!this.typeUpdate && !this.inline && this.input) {
                     this.input.value = this.formatValue(this.rawValue);


### PR DESCRIPTION
Fixes #8231

Root cause:
updateCurrentMetaData() was called before rawValue was updated, causing
inline DatePicker to calculate visible month/year from stale state.

Solution:
Update rawValue first, then recalculate metadata.

Tested locally in showcase.
