### PR TITLE
fix: pass boolean instead of items array to hasSubmenu prop in TieredSubMenu

### DIFF
--- a/packages/primevue/src/tieredmenu/TieredMenuSub.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenuSub.vue
@@ -38,7 +38,7 @@
                                 </template>
                             </a>
                         </template>
-                        <component v-else :is="templates.item" :item="processedItem.item" :hasSubmenu="getItemProp(processedItem, 'items')" :label="getItemLabel(processedItem)" :props="getMenuItemProps(processedItem, index)"></component>
+                        <component v-else :is="templates.item" :item="processedItem.item" :hasSubmenu="isItemGroup(processedItem)" :label="getItemLabel(processedItem)" :props="getMenuItemProps(processedItem, index)"></component>
                     </div>
                     <TieredMenuSub
                         v-if="isItemVisible(processedItem) && isItemGroup(processedItem)"


### PR DESCRIPTION
### Defect Fixes

TieredMenus slot prop `hasSubmenu" was passing in the items array instead of a boolean property