### PR TITLE
fix(InputNumber): prevent paste when disabled

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -608,7 +608,7 @@ export default {
             }
         },
         onPaste(event) {
-            if (this.readonly) {
+            if (this.readonly || this.disabled) {
                 return;
             }
 


### PR DESCRIPTION
Fixes #8391

InputNumber allowed pasting values even when the component was disabled.
The paste handler now exits early when disabled, aligning paste behavior
with other input interactions and with expected disabled semantics.

Tested locally.