### PR TITLE
fix(InputOTP): prevent paste when readonly

### DIFF
--- a/packages/primevue/src/inputotp/InputOtp.vue
+++ b/packages/primevue/src/inputotp/InputOtp.vue
@@ -175,6 +175,10 @@ export default {
             }
         },
         onPaste(event) {
+            if(this.readonly) {
+                return;
+            }
+
             let paste = event.clipboardData.getData('text');
 
             if (paste.length) {


### PR DESCRIPTION
Fixes #8401

InputOTP allowed pasting values even when the component was readonly.
The paste handler now exits early when readonly, aligning paste behavior
with other input interactions and expected readonly semantics.

Tested locally.
