### PR TITLE
fix(select): resolve conflict when editable and filter props are both enabled

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -450,7 +450,7 @@ export default {
                     if (!metaKey && isPrintableCharacter(event.key)) {
                         !this.overlayVisible && this.show();
                         !this.editable && this.searchOptions(event, event.key);
-                        this.filter && (this.filterValue = event.key);
+                        !this.editable && this.filter && (this.filterValue = event.key);
                     }
 
                     break;
@@ -715,7 +715,7 @@ export default {
             this.$attrSelector && el.setAttribute(this.$attrSelector, '');
 
             setTimeout(() => {
-                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
+                this.autoFilterFocus && this.filter && !this.editable && focus(this.$refs.filterInput.$el);
                 this.autoUpdateModel();
             }, 1);
         },


### PR DESCRIPTION
## Summary

Fixes #8380

When both `editable` and `filter` props are enabled on the Select component, two issues occur:

1. **Filter value incorrectly set on keydown** - Typing a character would set `filterValue` to just that single character, causing incorrect filtering while the editable input contained the full text
2. **Focus jumps to filter input** - When the overlay opens, focus incorrectly moves to the filter input instead of staying on the editable input

## Changes

- Added `!this.editable` guard to prevent `filterValue` from being set during keydown when in editable mode (line 453)
- Added `!this.editable` check to `onOverlayEnter` to prevent auto-focusing the filter input when editable is true, matching the existing logic in `onOverlayLeave` (line 718)

## Test Plan

- [x] Manually tested with `editable` and `filter` both enabled
- [x] Verified typing in editable input no longer causes incorrect filtering
- [x] Verified focus stays in editable input when overlay opens
- [x] All existing Select unit tests pass