### PR TITLE
fix: fix NaN for input number when pressing meta+backspace

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.spec.js
+++ b/packages/primevue/src/inputnumber/InputNumber.spec.js
@@ -87,12 +87,20 @@ describe('InputNumber.vue', () => {
         expect(wrapper.find('input.p-inputnumber-input').element._value).toBe('$12,345.00');
     });
 
-    it('should reset value to undefined when meta+backspace is pressed', async () => {
-        await wrapper.setProps({ modelValue: 20, mode: 'currency', currency: 'USD', locale: 'en-US' });
+    it('should reset value to undefined when meta+backspace is pressed with allow-empty', async () => {
+        await wrapper.setProps({ modelValue: 20, mode: 'currency', currency: 'USD', allowEmpty: true });
 
         await wrapper.vm.onInputKeyDown({ code: 'Backspace', metaKey: true, target: { value: 100 }, preventDefault: () => {} });
 
         expect(wrapper.find('input.p-inputnumber-input').element._value).toBe(undefined);
+    });
+
+    it('should reset value to 0 when meta+backspace is pressed without allow-empty', async () => {
+        await wrapper.setProps({ modelValue: 20, mode: 'currency', currency: 'USD', allowEmpty: false });
+
+        await wrapper.vm.onInputKeyDown({ code: 'Backspace', metaKey: true, target: { value: 100 }, preventDefault: () => {} });
+
+        expect(wrapper.find('input.p-inputnumber-input').element._value).toBe('$0.00');
     });
 
     it('should have prefix', async () => {

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -424,13 +424,15 @@ export default {
 
             const code = event.code || event.key;
 
-            if (event.metaKey && code === 'Backspace') {
-                this.updateModel(event, null);
-
-                return;
-            }
-
             if (event.altKey || event.ctrlKey || event.metaKey) {
+                if (event.metaKey && code === 'Backspace') {
+                    this.lastValue = this.allowEmpty ? null : '0';
+
+                    this.updateModel(event, this.lastValue);
+
+                    return;
+                }
+
                 this.isSpecialChar = true;
                 this.lastValue = this.$refs.input.$el.value;
 


### PR DESCRIPTION
### Defect Fixes

Fixes the error where pressing meta+backspace leads to `NaN` in the InputNumber in a Form with FormValue

Closes #8411 

