### PR TITLE
Backport: Fix call d_columns.get() to avoid duplicate computed execution (for v3.53.x)

### DIFF
--- a/components/lib/datatable/DataTable.vue
+++ b/components/lib/datatable/DataTable.vue
@@ -337,8 +337,8 @@ export default {
     ],
     provide() {
         return {
-            $columns: this.d_columns,
-            $columnGroups: this.d_columnGroups
+            $columns: this.d_columns.get(),
+            $columnGroups: this.d_columnGroups.get()
         };
     },
     data() {


### PR DESCRIPTION
### Summary

This PR backports an existing bugfix from the v4.x branch to the v3.53.x line.

The issue has already been fixed in v4.x, however upgrading to v4 is not feasible for many users due to breaking changes and the size of the migration. This backport allows affected users to remain on v3 while still benefiting from the fix.

---

### Details

- The fix is minimal (2 lines) and matches the v4.x implementation exactly
- No breaking changes introduced
- No new dependencies
- Behavior is identical to the v4.x fix

Tested locally against v3.53.1.

---

### References

- Related issue: #7677  (already fixed in v4.x)
- Original fix (v4.x): [PR](https://github.com/primefaces/primevue/pull/7679)

---

### Notes for maintainers

If accepted, this change could be released as a patch version (e.g. v3.53.2) for users who cannot upgrade to v4.x at this time.
