### PR TITLE
Fix calendar view jumping when selecting range start from second month (UX)

### DIFF
--- a/apps/showcase/doc/common/apidoc/index.json
+++ b/apps/showcase/doc/common/apidoc/index.json
@@ -24753,6 +24753,14 @@
                             "description": "Whether to hide the overlay on date selection is completed when selectionMode is range."
                         },
                         {
+                            "name": "preserveViewOnRangeStart",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "false",
+                            "description": "Whether to preserve the current visible months when selecting the start date in range mode with multiple months displayed.\nBy default, when numberOfMonths > 1 and you select a start date from the second (or later) visible month,\nthe calendar view jumps so that the selected month becomes the first visible month.\nWhen this property is enabled, the view remains stable during the initial selection, preventing the jump.\nOnce the range is complete (both start and end dates are selected), normal view behavior resumes."
+                        },
+                        {
                             "name": "timeSeparator",
                             "optional": true,
                             "readonly": false,

--- a/apps/showcase/doc/datepicker/RangeWithMultipleMonthsDoc.vue
+++ b/apps/showcase/doc/datepicker/RangeWithMultipleMonthsDoc.vue
@@ -1,0 +1,70 @@
+<template>
+    <DocSectionText v-bind="$attrs">
+        <p>
+            When using range selection with <i>numberOfMonths</i> greater than 1, selecting the start date from the second (or later) visible month causes the calendar view to jump so that the selected month becomes the first visible month. Enable <i>preserveViewOnRangeStart</i> to keep the current view stable until the range is complete (both start and end dates selected).
+        </p>
+    </DocSectionText>
+    <div class="card flex flex-col gap-4 justify-center">
+        <div>
+            <label for="range-multi-default" class="font-bold block mb-2">Default (view jumps when start is from second month)</label>
+            <DatePicker id="range-multi-default" v-model="datesDefault" selectionMode="range" :numberOfMonths="2" :manualInput="false" />
+        </div>
+        <div>
+            <label for="range-multi-preserve" class="font-bold block mb-2">With preserveViewOnRangeStart (stable view)</label>
+            <DatePicker id="range-multi-preserve" v-model="datesPreserved" selectionMode="range" :numberOfMonths="2" :preserveViewOnRangeStart="true" :manualInput="false" />
+        </div>
+    </div>
+    <DocSectionCode :code="code" />
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            datesDefault: null,
+            datesPreserved: null,
+            code: {
+                basic: `
+<DatePicker v-model="datesDefault" selectionMode="range" :numberOfMonths="2" :manualInput="false" />
+
+<DatePicker v-model="datesPreserved" selectionMode="range" :numberOfMonths="2" :preserveViewOnRangeStart="true" :manualInput="false" />
+`,
+                options: `
+<template>
+    <div class="card flex flex-col gap-4 justify-center">
+        <DatePicker v-model="datesDefault" selectionMode="range" :numberOfMonths="2" :manualInput="false" />
+        <DatePicker v-model="datesPreserved" selectionMode="range" :numberOfMonths="2" :preserveViewOnRangeStart="true" :manualInput="false" />
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            datesDefault: null,
+            datesPreserved: null
+        };
+    }
+};
+<\/script>
+`,
+                composition: `
+<template>
+    <div class="card flex flex-col gap-4 justify-center">
+        <DatePicker v-model="datesDefault" selectionMode="range" :numberOfMonths="2" :manualInput="false" />
+        <DatePicker v-model="datesPreserved" selectionMode="range" :numberOfMonths="2" :preserveViewOnRangeStart="true" :manualInput="false" />
+    </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const datesDefault = ref();
+const datesPreserved = ref();
+<\/script>
+`
+            }
+        };
+    }
+};
+</script>

--- a/apps/showcase/pages/datepicker/index.vue
+++ b/apps/showcase/pages/datepicker/index.vue
@@ -26,6 +26,7 @@ import MonthPickerDoc from '@/doc/datepicker/MonthPickerDoc.vue';
 import MultipleDoc from '@/doc/datepicker/MultipleDoc.vue';
 import MultipleMonthsDoc from '@/doc/datepicker/MultipleMonthsDoc.vue';
 import RangeDoc from '@/doc/datepicker/RangeDoc.vue';
+import RangeWithMultipleMonthsDoc from '@/doc/datepicker/RangeWithMultipleMonthsDoc.vue';
 import SizesDoc from '@/doc/datepicker/SizesDoc.vue';
 import TimeDoc from '@/doc/datepicker/TimeDoc.vue';
 import YearPickerDoc from '@/doc/datepicker/YearPickerDoc.vue';
@@ -80,6 +81,11 @@ export default {
                     id: 'range',
                     label: 'Range',
                     component: RangeDoc
+                },
+                {
+                    id: 'rangewithmultiplemonths',
+                    label: 'Range with Multiple Months',
+                    component: RangeWithMultipleMonthsDoc
                 },
                 {
                     id: 'button',

--- a/packages/primevue/scripts/components/calendar.js
+++ b/packages/primevue/scripts/components/calendar.js
@@ -222,6 +222,12 @@ const CalendarProps = [
         description: 'Whether to hide the overlay on date selection is completed when selectionMode is range.'
     },
     {
+        name: 'preserveViewOnRangeStart',
+        type: 'boolean',
+        default: 'false',
+        description: 'Whether to preserve the current visible months when selecting the start date in range mode with multiple months displayed. By default, when numberOfMonths > 1 and you select a start date from the second (or later) visible month, the calendar view jumps so that the selected month becomes the first visible month. When enabled, the view remains stable during the initial selection. Once the range is complete (both start and end dates are selected), normal view behavior resumes.'
+    },
+    {
         name: 'timeSeparator',
         type: 'string',
         default: ':',

--- a/packages/primevue/scripts/components/datepicker.js
+++ b/packages/primevue/scripts/components/datepicker.js
@@ -222,6 +222,12 @@ const DatePickerProps = [
         description: 'Whether to hide the overlay on date selection is completed when selectionMode is range.'
     },
     {
+        name: 'preserveViewOnRangeStart',
+        type: 'boolean',
+        default: 'false',
+        description: 'Whether to preserve the current visible months when selecting the start date in range mode with multiple months displayed. By default, when numberOfMonths > 1 and you select a start date from the second (or later) visible month, the calendar view jumps so that the selected month becomes the first visible month. When enabled, the view remains stable during the initial selection. Once the range is complete (both start and end dates are selected), normal view behavior resumes.'
+    },
+    {
         name: 'timeSeparator',
         type: 'string',
         default: ':',

--- a/packages/primevue/src/datepicker/BaseDatePicker.vue
+++ b/packages/primevue/src/datepicker/BaseDatePicker.vue
@@ -147,6 +147,10 @@ export default {
             type: Boolean,
             default: false
         },
+        preserveViewOnRangeStart: {
+            type: Boolean,
+            default: false
+        },
         timeSeparator: {
             type: String,
             default: ':'

--- a/packages/primevue/src/datepicker/DatePicker.d.ts
+++ b/packages/primevue/src/datepicker/DatePicker.d.ts
@@ -698,6 +698,15 @@ export interface DatePickerProps {
      */
     hideOnRangeSelection?: boolean | undefined;
     /**
+     * Whether to preserve the current visible months when selecting the start date in range mode with multiple months displayed.
+     * By default, when numberOfMonths > 1 and you select a start date from the second (or later) visible month,
+     * the calendar view jumps so that the selected month becomes the first visible month.
+     * When this property is enabled, the view remains stable during the initial selection, preventing the jump.
+     * Once the range is complete (both start and end dates are selected), normal view behavior resumes.
+     * @defaultValue false
+     */
+    preserveViewOnRangeStart?: boolean | undefined;
+    /**
      * Separator of time selector.
      * @defaultValue :
      */

--- a/packages/primevue/src/datepicker/DatePicker.spec.js
+++ b/packages/primevue/src/datepicker/DatePicker.spec.js
@@ -118,4 +118,95 @@ describe('DatePicker.vue', () => {
 
         expect(wrapper.find('.p-datepicker-decade').text()).toBe('1980 - 1989');
     });
+
+    it('should preserve view when selecting start date in range mode with preserveViewOnRangeStart enabled', async () => {
+        const startMonth = 5; // June
+        const startYear = 2024;
+
+        await wrapper.setProps({
+            inline: true,
+            selectionMode: 'range',
+            numberOfMonths: 2,
+            preserveViewOnRangeStart: true,
+            modelValue: null
+        });
+
+        // Set the initial view to a specific month
+        wrapper.vm.currentMonth = startMonth;
+        wrapper.vm.currentYear = startYear;
+        await wrapper.vm.$nextTick();
+
+        const initialMonth = wrapper.vm.currentMonth;
+        const initialYear = wrapper.vm.currentYear;
+
+        // Simulate internal selection flow: updateModel sets rawValue before watcher runs
+        const startDate = new Date(startYear, startMonth + 1, 15); // July 15, 2024
+
+        wrapper.vm.rawValue = [startDate, null];
+        wrapper.vm.updateCurrentMetaData();
+        await wrapper.vm.$nextTick();
+
+        // The view should NOT have jumped - currentMonth and currentYear should remain the same
+        expect(wrapper.vm.currentMonth).toBe(initialMonth);
+        expect(wrapper.vm.currentYear).toBe(initialYear);
+    });
+
+    it('should update view when selecting start date in range mode without preserveViewOnRangeStart', async () => {
+        const startMonth = 5; // June
+        const startYear = 2024;
+
+        await wrapper.setProps({
+            inline: true,
+            selectionMode: 'range',
+            numberOfMonths: 2,
+            preserveViewOnRangeStart: false,
+            modelValue: null
+        });
+
+        // Set the initial view to a specific month
+        wrapper.vm.currentMonth = startMonth;
+        wrapper.vm.currentYear = startYear;
+        await wrapper.vm.$nextTick();
+
+        // Simulate internal selection flow: updateModel sets rawValue before watcher runs
+        const startDate = new Date(startYear, startMonth + 1, 15); // July 15, 2024
+
+        wrapper.vm.rawValue = [startDate, null];
+        wrapper.vm.updateCurrentMetaData();
+        await wrapper.vm.$nextTick();
+
+        // The view SHOULD have jumped to show the selected month as the first month
+        expect(wrapper.vm.currentMonth).toBe(startMonth + 1); // July
+        expect(wrapper.vm.currentYear).toBe(startYear);
+    });
+
+    it('should update view when range selection is complete even with preserveViewOnRangeStart enabled', async () => {
+        const startMonth = 5; // June
+        const startYear = 2024;
+
+        await wrapper.setProps({
+            inline: true,
+            selectionMode: 'range',
+            numberOfMonths: 2,
+            preserveViewOnRangeStart: true,
+            modelValue: null
+        });
+
+        // Set the initial view to a specific month
+        wrapper.vm.currentMonth = startMonth;
+        wrapper.vm.currentYear = startYear;
+        await wrapper.vm.$nextTick();
+
+        // Simulate completing a range selection (both dates set)
+        const startDate = new Date(startYear, startMonth + 1, 15); // July 15, 2024
+        const endDate = new Date(startYear, startMonth + 1, 20); // July 20, 2024
+
+        wrapper.vm.rawValue = [startDate, endDate];
+        wrapper.vm.updateCurrentMetaData();
+        await wrapper.vm.$nextTick();
+
+        // When both dates are set, the view should update normally
+        expect(wrapper.vm.currentMonth).toBe(startMonth + 1); // July
+        expect(wrapper.vm.currentYear).toBe(startYear);
+    });
 });

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1860,10 +1860,24 @@ export default {
             setTimeout(this.updateFocus, 0);
         },
         updateCurrentMetaData() {
+            // When preserveViewOnRangeStart is enabled and we're selecting the start date of a range
+            // with multiple months visible, don't update the view position to prevent jumping
+            const shouldPreserveView =
+                this.preserveViewOnRangeStart &&
+                this.isRangeSelection() &&
+                this.numberOfMonths > 1 &&
+                Array.isArray(this.rawValue) &&
+                this.rawValue.length >= 1 &&
+                this.rawValue[0] &&
+                !this.rawValue[1] &&
+                this.currentMonth !== null; // Only preserve if already initialized
+
             const viewDate = this.viewDate;
 
-            this.currentMonth = viewDate.getMonth();
-            this.currentYear = viewDate.getFullYear();
+            if (!shouldPreserveView) {
+                this.currentMonth = viewDate.getMonth();
+                this.currentYear = viewDate.getFullYear();
+            }
 
             if (this.showTime || this.timeOnly) {
                 let timeDate = viewDate;


### PR DESCRIPTION
## Problem

When the datepicker shows multiple months (`numberOfMonths > 1`) and selection mode is range, selecting the **start** date from the **second** (or later) visible month causes the calendar view to jump so that the selected month becomes the first. That’s confusing: the user chose a date in a month they could already see, and the layout shifts before they pick the end date.

## Solution

A new optional prop, **`preserveViewOnRangeStart`**, keeps the visible months stable until the range is complete (both start and end selected). With it enabled, users can:

- Select the start date in any visible month without the view jumping
- Then select the end date in the same, stable view
- Avoid the previous “jump then correct” behavior that made the control feel unpredictable

## Behaviour

- **Default:** `preserveViewOnRangeStart` is `false`, so existing behaviour is unchanged.
- **When enabled:** The view no longer jumps when only the start date is set; it updates as usual once both start and end are selected.

This improves UX wherever range selection is used together with multiple visible months (e.g. the “Range with Multiple Months” example in the docs).