### PR TITLE
fix(formfield): rename duplicate FormEmits type to FormFieldEmits

### DIFF
--- a/packages/forms/src/formfield/FormField.d.ts
+++ b/packages/forms/src/formfield/FormField.d.ts
@@ -63,7 +63,7 @@ export interface FormFieldPassThroughAttributes {
 }
 
 /**
- * Resolver options for Form component.
+ * Resolver options for FormField component.
  */
 export interface FormFieldResolverOptions {
     /**
@@ -77,7 +77,7 @@ export interface FormFieldResolverOptions {
 }
 
 /**
- * Defines valid properties in Form component.
+ * Defines valid properties in FormField component.
  */
 export interface FormFieldProps {
     /**
@@ -141,7 +141,7 @@ export interface FormFieldProps {
 }
 
 /**
- * Defines valid slots in Form component.
+ * Defines valid slots in FormField component.
  */
 export interface FormFieldSlots {
     /**
@@ -195,11 +195,11 @@ export interface FormFieldSlots {
 }
 
 /**
- * Defines valid emits in Form component.
+ * Defines valid emits in FormField component.
  */
 export interface FormFieldEmitsOptions {}
 
-export declare type FormEmits = EmitFn<FormFieldEmitsOptions>;
+export declare type FormFieldEmits = EmitFn<FormFieldEmitsOptions>;
 
 /**
  * **PrimeVue - FormField**
@@ -213,11 +213,11 @@ export declare type FormEmits = EmitFn<FormFieldEmitsOptions>;
  * @group Component
  *
  */
-declare const FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormEmits>;
+declare const FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormFieldEmits>;
 
 declare module 'vue' {
     export interface GlobalComponents {
-        FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormEmits>;
+        FormField: DefineComponent<FormFieldProps, FormFieldSlots, FormFieldEmits>;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8420

`@primevue/forms` exports `FormEmits` from both the Form and FormField modules. When a project uses `skipLibCheck: false`, TypeScript reports TS2308 — a duplicate export collision that prevents clean type-checking of `@primevue/forms`.

## Problem

```ts
// @primevue/forms/index.d.ts
export * from '@primevue/forms/form';       // exports FormEmits
export * from '@primevue/forms/formfield';  // also exports FormEmits — collision!
```

```
error TS2308: Module '@primevue/forms/form' has already exported
a member named 'FormEmits'. Consider explicitly re-exporting to
resolve the ambiguity.
```

`FormField.d.ts` was copied from `Form.d.ts` and the type name wasn't updated during copy-paste. The `FormFieldEmitsOptions` interface is already correctly named — only the type alias and `DefineComponent` declarations were missed.

## Changes

- Rename `FormEmits` → `FormFieldEmits` in `formfield/FormField.d.ts` (type alias + 2 `DefineComponent` usages)
- Fix 4 JSDoc comments: "Form component" → "FormField component"

Follows the existing `[ComponentName]Emits` naming convention used by all 100+ PrimeVue components (`ButtonEmits`, `AccordionEmits`, `TreeSelectEmits`, etc.).

## Scope / Impact

- **No breaking changes** — `FormEmits` from FormField was unusable due to the collision anyway
- **No runtime changes** — types only (.d.ts file)
- **Fixes TS2308** for all consumers using `skipLibCheck: false`

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` in `packages/forms/` | TS2308 resolved |
| Naming convention audit (100+ components) | All use `[ComponentName]Emits` |
| All CI gates (format, lint, test, build) | PASS |
