### PR TITLE
fix(eventbus): add missing type declarations for EventBus subpath exports

### DIFF
--- a/packages/primevue/src/confirmationeventbus/ConfirmationEventBus.d.ts
+++ b/packages/primevue/src/confirmationeventbus/ConfirmationEventBus.d.ts
@@ -1,0 +1,47 @@
+/**
+ *
+ * @module confirmationeventbus
+ *
+ */
+import type { ConfirmationOptions } from 'primevue/confirmationoptions';
+
+/**
+ * Confirmation EventBus methods.
+ *
+ * @group Model
+ *
+ */
+export interface ConfirmationEventBusOptions {
+    /**
+     * Registers a handler for the 'confirm' event.
+     */
+    on(type: 'confirm', handler: (options: ConfirmationOptions) => void): void;
+    /**
+     * Registers a handler for the 'close' event.
+     */
+    on(type: 'close', handler: () => void): void;
+    /**
+     * Removes a handler for the 'confirm' event.
+     */
+    off(type: 'confirm', handler: (options: ConfirmationOptions) => void): void;
+    /**
+     * Removes a handler for the 'close' event.
+     */
+    off(type: 'close', handler: () => void): void;
+    /**
+     * Emits a 'confirm' event with the given options.
+     */
+    emit(type: 'confirm', options: ConfirmationOptions): void;
+    /**
+     * Emits a 'close' event.
+     */
+    emit(type: 'close'): void;
+    /**
+     * Removes all handlers.
+     */
+    clear(): void;
+}
+
+declare const ConfirmationEventBus: ConfirmationEventBusOptions;
+
+export default ConfirmationEventBus;

--- a/packages/primevue/src/confirmationeventbus/package.json
+++ b/packages/primevue/src/confirmationeventbus/package.json
@@ -1,4 +1,5 @@
 {
     "main": "./ConfirmationEventBus.js",
-    "module": "./ConfirmationEventBus.js"
+    "module": "./ConfirmationEventBus.js",
+    "types": "./ConfirmationEventBus.d.ts"
 }

--- a/packages/primevue/src/dynamicdialogeventbus/DynamicDialogEventBus.d.ts
+++ b/packages/primevue/src/dynamicdialogeventbus/DynamicDialogEventBus.d.ts
@@ -1,0 +1,77 @@
+/**
+ *
+ * @module dynamicdialogeventbus
+ *
+ */
+import type { DynamicDialogInstance } from 'primevue/dynamicdialogoptions';
+
+/**
+ * Event payload for the 'open' event.
+ *
+ * @group Model
+ *
+ */
+export interface DynamicDialogEventBusOpenEvent {
+    /**
+     * The dialog instance being opened.
+     */
+    instance: DynamicDialogInstance;
+}
+
+/**
+ * Event payload for the 'close' event.
+ *
+ * @group Model
+ *
+ */
+export interface DynamicDialogEventBusCloseEvent {
+    /**
+     * The dialog instance being closed.
+     */
+    instance: DynamicDialogInstance;
+    /**
+     * Optional parameters passed to the close method.
+     */
+    params?: any;
+}
+
+/**
+ * DynamicDialog EventBus methods.
+ *
+ * @group Model
+ *
+ */
+export interface DynamicDialogEventBusOptions {
+    /**
+     * Registers a handler for the 'open' event.
+     */
+    on(type: 'open', handler: (event: DynamicDialogEventBusOpenEvent) => void): void;
+    /**
+     * Registers a handler for the 'close' event.
+     */
+    on(type: 'close', handler: (event: DynamicDialogEventBusCloseEvent) => void): void;
+    /**
+     * Removes a handler for the 'open' event.
+     */
+    off(type: 'open', handler: (event: DynamicDialogEventBusOpenEvent) => void): void;
+    /**
+     * Removes a handler for the 'close' event.
+     */
+    off(type: 'close', handler: (event: DynamicDialogEventBusCloseEvent) => void): void;
+    /**
+     * Emits an 'open' event with the given event payload.
+     */
+    emit(type: 'open', event: DynamicDialogEventBusOpenEvent): void;
+    /**
+     * Emits a 'close' event with the given event payload.
+     */
+    emit(type: 'close', event: DynamicDialogEventBusCloseEvent): void;
+    /**
+     * Removes all handlers.
+     */
+    clear(): void;
+}
+
+declare const DynamicDialogEventBus: DynamicDialogEventBusOptions;
+
+export default DynamicDialogEventBus;

--- a/packages/primevue/src/dynamicdialogeventbus/package.json
+++ b/packages/primevue/src/dynamicdialogeventbus/package.json
@@ -1,4 +1,5 @@
 {
     "main": "./DynamicDialogEventBus.js",
-    "module": "./DynamicDialogEventBus.js"
+    "module": "./DynamicDialogEventBus.js",
+    "types": "./DynamicDialogEventBus.d.ts"
 }

--- a/packages/primevue/src/overlayeventbus/OverlayEventBus.d.ts
+++ b/packages/primevue/src/overlayeventbus/OverlayEventBus.d.ts
@@ -1,0 +1,51 @@
+/**
+ *
+ * @module overlayeventbus
+ *
+ */
+
+/**
+ * Event payload for the 'overlay-click' event.
+ *
+ * @group Model
+ *
+ */
+export interface OverlayEventBusClickEvent {
+    /**
+     * The original browser event.
+     */
+    originalEvent: Event;
+    /**
+     * The target element of the overlay.
+     */
+    target: HTMLElement;
+}
+
+/**
+ * Overlay EventBus methods.
+ *
+ * @group Model
+ *
+ */
+export interface OverlayEventBusOptions {
+    /**
+     * Registers a handler for the 'overlay-click' event.
+     */
+    on(type: 'overlay-click', handler: (event: OverlayEventBusClickEvent) => void): void;
+    /**
+     * Removes a handler for the 'overlay-click' event.
+     */
+    off(type: 'overlay-click', handler: (event: OverlayEventBusClickEvent) => void): void;
+    /**
+     * Emits an 'overlay-click' event with the given event payload.
+     */
+    emit(type: 'overlay-click', event: OverlayEventBusClickEvent): void;
+    /**
+     * Removes all handlers.
+     */
+    clear(): void;
+}
+
+declare const OverlayEventBus: OverlayEventBusOptions;
+
+export default OverlayEventBus;

--- a/packages/primevue/src/overlayeventbus/package.json
+++ b/packages/primevue/src/overlayeventbus/package.json
@@ -1,4 +1,5 @@
 {
     "main": "./OverlayEventBus.js",
-    "module": "./OverlayEventBus.js"
+    "module": "./OverlayEventBus.js",
+    "types": "./OverlayEventBus.d.ts"
 }

--- a/packages/primevue/src/toasteventbus/ToastEventBus.d.ts
+++ b/packages/primevue/src/toasteventbus/ToastEventBus.d.ts
@@ -1,0 +1,73 @@
+/**
+ *
+ * [Live Demo](https://www.primevue.org/toast/)
+ *
+ * @module toasteventbus
+ *
+ */
+import type { ToastMessageOptions } from 'primevue/toast';
+
+/**
+ * Toast EventBus methods.
+ *
+ * @group Model
+ *
+ */
+export interface ToastEventBusOptions {
+    /**
+     * Registers a handler for the 'add' event.
+     */
+    on(type: 'add', handler: (message: ToastMessageOptions) => void): void;
+    /**
+     * Registers a handler for the 'remove' event.
+     */
+    on(type: 'remove', handler: (message: ToastMessageOptions) => void): void;
+    /**
+     * Registers a handler for the 'remove-group' event.
+     */
+    on(type: 'remove-group', handler: (group: string) => void): void;
+    /**
+     * Registers a handler for the 'remove-all-groups' event.
+     */
+    on(type: 'remove-all-groups', handler: () => void): void;
+    /**
+     * Removes a handler for the 'add' event.
+     */
+    off(type: 'add', handler: (message: ToastMessageOptions) => void): void;
+    /**
+     * Removes a handler for the 'remove' event.
+     */
+    off(type: 'remove', handler: (message: ToastMessageOptions) => void): void;
+    /**
+     * Removes a handler for the 'remove-group' event.
+     */
+    off(type: 'remove-group', handler: (group: string) => void): void;
+    /**
+     * Removes a handler for the 'remove-all-groups' event.
+     */
+    off(type: 'remove-all-groups', handler: () => void): void;
+    /**
+     * Emits an 'add' event with the given message.
+     */
+    emit(type: 'add', message: ToastMessageOptions): void;
+    /**
+     * Emits a 'remove' event with the given message.
+     */
+    emit(type: 'remove', message: ToastMessageOptions): void;
+    /**
+     * Emits a 'remove-group' event with the given group name.
+     */
+    emit(type: 'remove-group', group: string): void;
+    /**
+     * Emits a 'remove-all-groups' event.
+     */
+    emit(type: 'remove-all-groups'): void;
+    /**
+     * Removes all handlers.
+     */
+    clear(): void;
+}
+
+declare const ToastEventBus: ToastEventBusOptions;
+
+export default ToastEventBus;

--- a/packages/primevue/src/toasteventbus/package.json
+++ b/packages/primevue/src/toasteventbus/package.json
@@ -1,4 +1,5 @@
 {
     "main": "./ToastEventBus.js",
-    "module": "./ToastEventBus.js"
+    "module": "./ToastEventBus.js",
+    "types": "./ToastEventBus.d.ts"
 }


### PR DESCRIPTION
### Defect Fixes

Fixes #8422

The four EventBus subpath exports (`primevue/toasteventbus`, `primevue/overlayeventbus`, `primevue/confirmationeventbus`, `primevue/dynamicdialogeventbus`) ship JavaScript but no `.d.ts` type declarations. Projects using `skipLibCheck: false` get TS7016 errors — every other PrimeVue subpath export (100+ modules) includes type declarations except these four.

## Problem

```ts
import ToastEventBus from 'primevue/toasteventbus';
// TS7016: Could not find a declaration file for module 'primevue/toasteventbus'

ToastEventBus.on('add', (message) => {
  // message: any — no type safety for event payloads
});
```

After this fix, all event bus operations are fully typed:

```ts
import ToastEventBus from 'primevue/toasteventbus';

ToastEventBus.on('add', (message) => {
  // message: ToastMessageOptions — full autocomplete and type checking
  console.log(message.severity, message.summary);
});
```

## Root cause

The source directories for these four modules only contain `.js` and `package.json` files — no `.d.ts` — so the build pipeline (`copyDependencies` in `postbuild.mjs`) has nothing to copy to `dist/`.

## Changes

- Add `index.d.ts` for each EventBus module with typed overloads for `on`, `off`, `emit`, and `clear`
- Add `"types": "./index.d.ts"` to each module's `package.json`
- Event types reuse existing PrimeVue types (`ToastMessageOptions`, `ConfirmationOptions`, `DynamicDialogInstance`)
- Follows the inline typing pattern used by `TerminalService.d.ts`

## Scope / Impact

- **No breaking changes** — adds missing declarations, previously resolved as `any`
- **No runtime changes** — types only (.d.ts + package.json `types` field)
- **4 modules**: toasteventbus, overlayeventbus, confirmationeventbus, dynamicdialogeventbus

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` with `skipLibCheck: false` | TS7016 resolved for all 4 modules |
| Event types match runtime behavior | Verified against source |
| All CI gates (format, lint, test, build) | PASS |
