### PR TITLE
fix file limit handling

### DIFF
--- a/packages/primevue/src/fileupload/FileUpload.vue
+++ b/packages/primevue/src/fileupload/FileUpload.vue
@@ -313,10 +313,8 @@ export default {
         },
         onDragOver(event) {
             if (!this.disabled && (!this.hasFiles || this.multiple)) {
-                if (!this.isFileLimitReached()) {
-                    !this.isUnstyled && addClass(this.$refs.content, 'p-fileupload-highlight');
-                    this.$refs.content.setAttribute('data-p-highlight', true);
-                }
+                !this.isUnstyled && addClass(this.$refs.content, 'p-fileupload-highlight');
+                this.$refs.content.setAttribute('data-p-highlight', true);
                 event.stopPropagation();
                 event.preventDefault();
             }


### PR DESCRIPTION
### Defect Fixes

The `isFileLimitExceeded()` method, according to its name, correctly returns false if the limit is reached, and only `true` if the limit is exceeded. However, it is used directly to determine whether further files can be selected, which leads to the `FileUpload` component allowing to select one file more than the `fileLimit` allows for.

This PR fixes this by introducing a new `isFileLimitReached()` method, which will be used to determine if further files can be uploaded. The refactoring has made the `checkFileLimit()` method obsolete, I was not sure whether it is safe to remove it, however, and leave that to you to decide.