### PR TITLE
Select/MultiSelect: add generic type parameter for typed options array

### DIFF
--- a/packages/primevue/src/multiselect/MultiSelect.d.ts
+++ b/packages/primevue/src/multiselect/MultiSelect.d.ts
@@ -315,7 +315,7 @@ export interface MultiSelectContext {
 /**
  * Defines valid properties in MultiSelect component.
  */
-export interface MultiSelectProps {
+export interface MultiSelectProps<T = any> {
     /**
      * Value of the component.
      */
@@ -331,7 +331,7 @@ export interface MultiSelectProps {
     /**
      * An array of select items to display as the available options.
      */
-    options?: any[] | undefined;
+    options?: T[] | undefined;
     /**
      * Property name or getter function to use as the label of an option.
      */

--- a/packages/primevue/src/select/Select.d.ts
+++ b/packages/primevue/src/select/Select.d.ts
@@ -290,7 +290,7 @@ export interface SelectContext {
 /**
  * Defines valid properties in Select component.
  */
-export interface SelectProps {
+export interface SelectProps<T = any> {
     /**
      * Value of the component.
      */
@@ -306,7 +306,7 @@ export interface SelectProps {
     /**
      * An array of select items to display as the available options.
      */
-    options?: any[];
+    options?: T[];
     /**
      * Property name or getter function to use as the label of an option.
      */


### PR DESCRIPTION
### Defect Fixes

`SelectProps.options` and `MultiSelectProps.options` are typed as `any[]`, preventing TypeScript from inferring option types when passing a typed array.

### What changed

Added `<T = any>` to `SelectProps` and `MultiSelectProps`, changed `options` from `any[]` to `T[]`. 4 lines across 2 `.d.ts` files.

### Precedent

Follows the exact pattern from PR #7427 (`DataTableProps<T = any>`), shipped as a non-breaking patch in v4.3.3.

### Breaking changes

None. `T = any` default preserves existing behavior for all consumers.

### Discussion

https://github.com/orgs/primefaces/discussions/4633