### PR TITLE
fix(test): update Button.spec.js to match current component behavior

### DIFF
--- a/packages/primevue/src/button/Button.spec.js
+++ b/packages/primevue/src/button/Button.spec.js
@@ -6,7 +6,16 @@ describe('Button.vue', () => {
         const wrapper = mount(Button);
 
         expect(wrapper.find('.p-button.p-component').exists()).toBe(true);
+        expect(wrapper.find('.p-button-label').exists()).toBe(false);
+    });
+
+    it('should render label when label prop is provided', () => {
+        const wrapper = mount(Button, {
+            props: { label: 'Submit' }
+        });
+
         expect(wrapper.find('.p-button-label').exists()).toBe(true);
+        expect(wrapper.find('.p-button-label').text()).toBe('Submit');
     });
 });
 


### PR DESCRIPTION
### Defect Fixes

`Button.spec.js` fails because it asserts `.p-button-label` exists when mounting Button with no props. The label span only renders when a `label` prop is provided (`v-if="label"`).

### What changed

- Updated the existing test to correctly expect no label element without the prop
- Added a new test to verify label rendering when the `label` prop is set

### Discussion

https://github.com/orgs/primefaces/discussions/4634