### PR TITLE
fix(datepicker): normalize year-change event month to be consistently 0-based

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -23,7 +23,7 @@
             :aria-controls="overlayVisible ? panelId : undefined"
             :aria-labelledby="ariaLabelledby"
             :aria-label="ariaLabel"
-            inputmode="none"
+            inputmode="none
             :disabled="disabled"
             :readonly="!manualInput || readonly"
             :tabindex="0"
@@ -1215,7 +1215,7 @@ export default {
         },
         onYearDropdownChange(value) {
             this.currentYear = parseInt(value);
-            this.$emit('year-change', { month: this.currentMonth + 1, year: this.currentYear });
+            this.$emit('year-change', { month: this.currentMonth, year: this.currentYear });
         },
         onDateSelect(event, dateMeta) {
             if (this.disabled || !dateMeta.selectable) {
@@ -1854,7 +1854,7 @@ export default {
             } else {
                 this.currentYear = year.value;
                 this.currentView = 'month';
-                this.$emit('year-change', { month: this.currentMonth + 1, year: this.currentYear });
+                this.$emit('year-change', { month: this.currentMonth, year: this.currentYear });
             }
 
             setTimeout(this.updateFocus, 0);


### PR DESCRIPTION
## Description

The `year-change` event emits the `month` property inconsistently depending on the navigation method used:

- `navBackward` / `navForward` emit `month: this.currentMonth` **(0-based)**
- `onYearDropdownChange` and year picker overlay selection emit `month: this.currentMonth + 1` **(1-based)**

This makes it impossible to reliably use the `year-change` event without special-casing each navigation path.

## Root Cause

In `packages/primevue/src/datepicker/DatePicker.vue`:
- Lines for `navBackward`/`navForward` were already using `this.currentMonth` (correct, 0-based)
- Lines for `onYearDropdownChange` and year picker overlay selection were using `this.currentMonth + 1` (incorrect, 1-based)

## Fix

Changed lines 1218 and 1857 to emit `month: this.currentMonth` instead of `month: this.currentMonth + 1`, making all `year-change` event emissions consistently 0-based.

## Related Issue

Fixes #8436