### PR TITLE
fix(inputtext,datepicker): remove unreachable undefined from emit types

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.d.ts
+++ b/packages/primevue/src/datepicker/DatePicker.d.ts
@@ -1171,14 +1171,14 @@ export interface DatePickerSlots {
 export interface DatePickerEmitsOptions {
     /**
      * Emitted when the value changes.
-     * @param {string | Date | string[] | Date[] | undefined} value - New value.
+     * @param {string | Date | string[] | Date[] | null} value - New value.
      */
-    'update:modelValue'(value: Date | Array<Date> | Array<Date | null> | undefined | null): void;
+    'update:modelValue'(value: Date | Array<Date> | Array<Date | null> | null): void;
     /**
      * Emitted when the value changes in uncontrolled mode.
-     * @param {string | Date | string[] | Date[] | undefined} value - New value.
+     * @param {string | Date | string[] | Date[] | null} value - New value.
      */
-    'value-change'(value: Date | Array<Date> | Array<Date | null> | undefined | null): void;
+    'value-change'(value: Date | Array<Date> | Array<Date | null> | null): void;
     /**
      * Callback to invoke when input field is being typed.
      * @param {Event} event - Browser event

--- a/packages/primevue/src/inputtext/InputText.d.ts
+++ b/packages/primevue/src/inputtext/InputText.d.ts
@@ -152,12 +152,12 @@ export interface InputTextEmitsOptions {
      * Emitted when the value changes.
      * @param {string} value - New value.
      */
-    'update:modelValue'(value: string | undefined): void;
+    'update:modelValue'(value: string): void;
     /**
      * Emitted when the value changes in uncontrolled mode.
      * @param {string} value - New value.
      */
-    'value-change'(value: string | undefined): void;
+    'value-change'(value: string): void;
 }
 
 export declare type InputTextEmits = EmitFn<InputTextEmitsOptions>;


### PR DESCRIPTION
### Defect Fixes

Fixes #8441

`InputText` and `DatePicker` declare `| undefined` in their `update:modelValue` and `value-change` emit signatures, but neither component can emit `undefined` at runtime. With `strictTemplates: true`, the emitted `| undefined` is not assignable to the consumer's ref type, producing **39 false-positive type errors** that block adoption of `strictTemplates`.

Related: #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-emit-undefined-repro?file=src%2FApp.vue) — run `bun run type-check` in terminal (TS2322 false positive), then `bun run patch && bun run type-check` (0 errors)

## Problem

```vue
<InputText v-model="name" />
<!-- name: Ref<string> -->
<!--
  error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  38 occurrences across a typical project — all false positives
-->
```

After this fix, `v-model` correctly matches the consumer's type — no error.

| Component | Emit signature before | Emit signature after | Consumer ref | Errors fixed |
|---|---|---|---|---|
| InputText | `string \| undefined` | `string` | `Ref<string>` | 38 |
| DatePicker | `Date \| ... \| undefined \| null` | `Date \| ... \| null` | `Ref<Date \| null>` | 1 |

## Root cause

**InputText:** Single emission path — `onInput(event)` -> `writeValue(event.target.value)`. `HTMLInputElement.value` is always `string` per HTML spec. Full inheritance chain audited — no `resetValue()`, `clear()`, or watcher re-emission exists. No path can emit `undefined`.

**DatePicker:** All 9 emission paths traced through `updateModel()` -> `writeValue()` -> `$emit()`. Clear button emits `null`. Invalid text input throws (no emission). Range mode maps `undefined` -> `null` before calling `formatDateTime`. 7 edge cases pressure-tested (empty input, invalid text, range incomplete, multi deselect). `undefined` is never passed to `writeValue()`.

## Changes

- `inputtext/InputText.d.ts`: `string | undefined` -> `string` (2 emit signatures)
- `datepicker/DatePicker.d.ts`: remove `| undefined`, preserve `| null` (2 emit signatures)

## Scope / Impact

- **No breaking changes** — removes an impossible type from emit signatures
- **No runtime changes** — types only (.d.ts files)
- **Eliminates 39 false-positive errors** blocking `strictTemplates` adoption

## Verification

| Gate | Result |
|---|---|
| InputText source audit | Single emission path — only emits `string` |
| DatePicker source audit | All 9 paths traced — none emit `undefined` |
| DatePicker edge cases | 7 edge cases pressure-tested |
| `vue-tsc --noEmit` with `strictTemplates` | 39 errors eliminated, 0 introduced |
| All CI gates (format, lint, test, build) | PASS |
