### PR TITLE
fix(InputNumber): allow pasting formatted numbers with thousands separators

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -90,14 +90,14 @@
 </template>
 
 <script>
-import { cn } from '@primeuix/utils';
-import { clearSelection, getSelection } from '@primeuix/utils/dom';
-import { isEmpty, isNotEmpty } from '@primeuix/utils/object';
-import AngleDownIcon from '@primevue/icons/angledown';
-import AngleUpIcon from '@primevue/icons/angleup';
-import TimesIcon from '@primevue/icons/times';
-import InputText from 'primevue/inputtext';
-import BaseInputNumber from './BaseInputNumber.vue';
+import { cn } from '@primeuix/utils'
+import { clearSelection, getSelection } from '@primeuix/utils/dom'
+import { isEmpty, isNotEmpty } from '@primeuix/utils/object'
+import AngleDownIcon from '@primevue/icons/angledown'
+import AngleUpIcon from '@primevue/icons/angleup'
+import TimesIcon from '@primevue/icons/times'
+import InputText from 'primevue/inputtext'
+import BaseInputNumber from './BaseInputNumber.vue'
 
 export default {
     name: 'InputNumber',
@@ -613,15 +613,15 @@ export default {
             }
 
             event.preventDefault();
-            let data = (event.clipboardData || window['clipboardData']).getData('Text');
-            if (this.inputId === 'integeronly' && /[^\d-]/.test(data)) {
-                return;
-            }
+            const data = (event.clipboardData || window['clipboardData']).getData('Text');
 
             if (data) {
-                let filteredData = this.parseValue(data);
+                const filteredData = this.parseValue(data);
 
                 if (filteredData != null) {
+                    if (this.inputId === 'integeronly' && !Number.isInteger(filteredData)) {
+                        return;
+                    }
                     this.insert(event, filteredData.toString());
                 }
             }


### PR DESCRIPTION
## Defect Fixes

Fixed #8435 
                                   
Pasting numbers greater than 999 with formatting (e.g., "1,234") was blocked in InputNumber component.                                   
                                                           
## Root Cause                                               
The `onPaste` method was checking for non-digit characters in the raw pasted text before parsing, which prevented users from pasting formatted numbers like:     
* `"1,234"` (with thousands separator)                   
* `"$10,000"` (with currency symbol)                     
* `"1 234,56"` (locale-formatted numbers)
                                                              
## Solution                                                 
                                             
Changed the validation logic to:                         
1. First parse the pasted data using `parseValue()` which  correctly handles formatted numbers                      
2. Then validate the parsed result (for integeronly mode, check if the value is an integer)