### PR TITLE
feat: expose filteredNodes in filter event for Tree and TreeSelect

### DIFF
--- a/apps/showcase/doc/common/apidoc/index.json
+++ b/apps/showcase/doc/common/apidoc/index.json
@@ -76092,6 +76092,14 @@
                             "type": "string",
                             "default": "",
                             "description": "Filter value"
+                        },
+                        {
+                            "name": "filteredNodes",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "TreeNode[]",
+                            "default": "",
+                            "description": "Filtered tree nodes after applying the filter.\nWhen the filter is empty, this contains the original unfiltered nodes."
                         }
                     ],
                     "methods": []
@@ -78308,6 +78316,19 @@
                             ],
                             "returnType": "void",
                             "description": "Callback to invoke when a node is collapsed."
+                        },
+                        {
+                            "name": "filter",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "optional": false,
+                                    "type": "TreeFilterEvent",
+                                    "description": "Custom filter event."
+                                }
+                            ],
+                            "returnType": "void",
+                            "description": "Callback to invoke on filter input."
                         }
                     ]
                 },

--- a/packages/primevue/src/tree/Tree.d.ts
+++ b/packages/primevue/src/tree/Tree.d.ts
@@ -95,6 +95,11 @@ export interface TreeFilterEvent {
      * Filter value
      */
     value: string;
+    /**
+     * Filtered tree nodes after applying the filter.
+     * When the filter is empty, this contains the original unfiltered nodes.
+     */
+    filteredNodes: TreeNode[];
 }
 
 /**

--- a/packages/primevue/src/tree/Tree.spec.js
+++ b/packages/primevue/src/tree/Tree.spec.js
@@ -61,6 +61,33 @@ describe('Tree.vue', () => {
         expect(wrapper.emitted('filter')[0][0].value).toEqual(key);
     });
 
+    it('emits filter event with filteredNodes', async () => {
+        wrapper = mount(Tree, {
+            props: {
+                filter: true,
+                value: [
+                    { key: '0', label: 'Documents', children: [] },
+                    { key: '1', label: 'Pictures', children: [] },
+                    { key: '2', label: 'Downloads', children: [] }
+                ]
+            }
+        });
+
+        let searchField = wrapper.find('input.p-inputtext');
+
+        await searchField.setValue('Doc');
+        await wrapper.vm.$nextTick();
+        await searchField.trigger('keyup', { key: 'c' });
+        await wrapper.vm.$nextTick();
+
+        const filterEvents = wrapper.emitted('filter');
+        const latestFilterEvent = filterEvents[filterEvents.length - 1][0];
+
+        expect(latestFilterEvent.filteredNodes).toBeDefined();
+        expect(latestFilterEvent.filteredNodes.length).toBe(1);
+        expect(latestFilterEvent.filteredNodes[0].label).toBe('Documents');
+    });
+
     it('should render icon', ({ expect }) => {
         expect(wrapper.find('span.pi-inbox').exists()).toBeTruthy();
         expect(wrapper.find('span.pi-inbox').classes('p-tree-node-icon')).toBeTruthy();

--- a/packages/primevue/src/tree/Tree.vue
+++ b/packages/primevue/src/tree/Tree.vue
@@ -233,7 +233,7 @@ export default {
                 event.preventDefault();
             }
 
-            this.$emit('filter', { originalEvent: event, value: event.target.value });
+            this.$emit('filter', { originalEvent: event, value: event.target.value, filteredNodes: this.valueToRender });
         },
         findFilteredNodes(node, paramsWithoutNode) {
             if (node) {

--- a/packages/primevue/src/treeselect/TreeSelect.d.ts
+++ b/packages/primevue/src/treeselect/TreeSelect.d.ts
@@ -11,7 +11,7 @@ import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } 
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ChipPassThroughOptions } from 'primevue/chip';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import type { TreeExpandedKeys, TreePassThroughOptions } from 'primevue/tree';
+import type { TreeExpandedKeys, TreeFilterEvent, TreePassThroughOptions } from 'primevue/tree';
 import type { TreeNode } from 'primevue/treenode';
 import { InputHTMLAttributes, TransitionProps, VNode } from 'vue';
 
@@ -568,6 +568,11 @@ export interface TreeSelectEmitsOptions {
      * @param {TreeNode} node - Node instance.
      */
     'node-collapse'(node: TreeNode): void;
+    /**
+     * Callback to invoke on filter input.
+     * @param {TreeFilterEvent} event - Custom filter event.
+     */
+    'filter'(event: TreeFilterEvent): void;
 }
 
 export declare type TreeSelectEmits = EmitFn<TreeSelectEmitsOptions>;

--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -87,6 +87,7 @@
                             :metaKeySelection="metaKeySelection"
                             @node-expand="$emit('node-expand', $event)"
                             @node-collapse="$emit('node-collapse', $event)"
+                            @filter="$emit('filter', $event)"
                             @node-select="onNodeSelect"
                             @node-unselect="onNodeUnselect"
                             @click.stop
@@ -147,7 +148,7 @@ export default {
     name: 'TreeSelect',
     extends: BaseTreeSelect,
     inheritAttrs: false,
-    emits: ['before-show', 'before-hide', 'change', 'show', 'hide', 'node-select', 'node-unselect', 'node-expand', 'node-collapse', 'focus', 'blur', 'update:expandedKeys'],
+    emits: ['before-show', 'before-hide', 'change', 'show', 'hide', 'node-select', 'node-unselect', 'node-expand', 'node-collapse', 'focus', 'blur', 'update:expandedKeys', 'filter'],
     inject: {
         $pcFluid: { default: null }
     },


### PR DESCRIPTION
Hello,

### Description
This PR enhances the filter event in both Tree and TreeSelect components by exposing the result of the search (`filteredNodes`). It also brings the filter event up to the TreeSelect component, which was previously burying the internal `TSTree` filter event.

### Motivation & Context
Currently, when a user types in the filter input of a Tree or TreeSelect, the filter event only emits the `originalEvent` and the value (the search string). It does not provide the actual nodes that resulted from the native filtering mechanism. 

**Use case:** 
Developers often need to react to search results to improve UX. For example: automatically expanding the remaining nodes if the filter results in a single path, or auto-selecting a node if it is the only one remaining after a filter. Without exposing `filteredNodes`, developers are forced to manually recreate the `filterBy` and `filterMode` logic externally to guess what the component is currently displaying.

### Implementation Details
- **Tree.vue**: Added `filteredNodes: this.valueToRender` to the `$emit('filter')` payload.
- **TreeSelect.vue**: Added the missing `@filter="$emit('filter', $event)"` listener on the internal `<TSTree>` component to forward the event, and declared it in the `emits` array.
- **TypeScript**: Updated TreeFilterEvent interface to include `filteredNodes: TreeNode[]` and added the filter event to TreeSelectEmitsOptions.
- **Consistency**: This approach is consistent with other components like ListBox (which exposes `filterValue` in its ListboxFilterEvent). I specifically named it `filteredNodes` to align with the Tree domain, just like the TreeNode type.
- **Tests**: Added a unit test in Tree.spec.js to ensure the filter event correctly carries the `filteredNodes` payload. All existing tests pass successfully.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [CONTRIBUTING](https://primevue.org/contribution/) guidelines
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

I hope I didn't forget anything.

Best regards,