### PR TITLE
fix: correct DatePicker metadata update order and align stale unit tests

### DIFF
--- a/packages/primevue/src/button/Button.spec.js
+++ b/packages/primevue/src/button/Button.spec.js
@@ -6,7 +6,16 @@ describe('Button.vue', () => {
         const wrapper = mount(Button);
 
         expect(wrapper.find('.p-button.p-component').exists()).toBe(true);
+    });
+
+    it('renders label when label prop is provided', () => {
+        const label = 'Save';
+        const wrapper = mount(Button, {
+            props: { label }
+        });
+
         expect(wrapper.find('.p-button-label').exists()).toBe(true);
+        expect(wrapper.find('.p-button-label').text()).toBe(label);
     });
 });
 

--- a/packages/primevue/src/datepicker/DatePicker.spec.js
+++ b/packages/primevue/src/datepicker/DatePicker.spec.js
@@ -46,13 +46,21 @@ describe('DatePicker.vue', () => {
     });
 
     it('should calculate the correct view date when in range mode', async () => {
-        const dateOne = new Date();
-        const dateTwo = new Date();
+        const dateOne = new Date(2026, 1, 10, 8, 30, 0);
+        const dateTwo = new Date(2026, 1, 15, 8, 30, 0);
 
-        dateTwo.setFullYear(dateOne.getFullYear(), dateOne.getMonth(), dateOne.getDate() + 1);
         await wrapper.setProps({ selectionMode: 'range', showTime: true, modelValue: [dateOne, dateTwo] });
 
-        expect(wrapper.vm.viewDate).toEqual(dateTwo);
+        expect(wrapper.vm.viewDate).toEqual(dateOne);
+    });
+
+    it('should shift the view date when range end is outside visible months', async () => {
+        const dateOne = new Date(2026, 0, 10, 8, 30, 0);
+        const dateTwo = new Date(2026, 2, 12, 8, 30, 0);
+
+        await wrapper.setProps({ selectionMode: 'range', showTime: true, numberOfMonths: 2, modelValue: [dateOne, dateTwo] });
+
+        expect(wrapper.vm.viewDate).toEqual(new Date(2026, 1, 1));
     });
 
     it('should open a year view when there is selected date (fix: #6203)', async () => {

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -628,8 +628,8 @@ export default {
         modelValue: {
             immediate: true,
             handler(newValue) {
-                this.updateCurrentMetaData();
                 this.rawValue = typeof newValue === 'string' ? this.parseValue(newValue) : newValue;
+                this.updateCurrentMetaData();
 
                 if (!this.typeUpdate && !this.inline && this.input) {
                     this.input.value = this.formatValue(this.rawValue);

--- a/packages/primevue/src/speeddial/SpeedDial.spec.js
+++ b/packages/primevue/src/speeddial/SpeedDial.spec.js
@@ -88,7 +88,7 @@ describe('SpeedDial.vue', () => {
     });
 
     it('should have mask', async () => {
-        await wrapper.setProps({ mask: true });
+        await wrapper.setProps({ mask: true, visible: true });
 
         expect(wrapper.find('.p-speeddial-mask').exists()).toBe(true);
     });


### PR DESCRIPTION
Closes #8455

I made this PR so that we can update the primevue reference in `vuejs/ecosystem-ci` to the latest. The last time all tests passed was v4.3.1

`pnpm test:unit` now passes without errors after the following adjustments:

- set `rawValue` before `updateCurrentMetaData()` in DatePicker `modelValue` watcher so externally-updated values drive the correct year/month state (regression introduced in https://github.com/primefaces/primevue/commit/b001959ed)

- update range `viewDate` expectation to match the visible-window behavior and make the case deterministic with fixed dates (behavior changed in https://github.com/primefaces/primevue/commit/91937db92)

- add an explicit DatePicker spec for the branch where range end falls outside the current visible window

- move Button label assertion into a dedicated test with `label` prop (stale after Button stopped rendering empty labels in https://github.com/primefaces/primevue/commit/28bf77f24)

- update SpeedDial mask test to set `visible: true` because mask now renders only while open (stale after mask condition change in https://github.com/primefaces/primevue/commit/253274f68)
