### PR TITLE
Reset selfClick flag to prevent double click for closing filter menu

### DIFF
--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -520,6 +520,7 @@ export default {
                 originalEvent: event,
                 target: this.overlay
             });
+            this.selfClick = false
         },
         onContentMouseDown() {
             this.selfClick = true;


### PR DESCRIPTION
I kept `this.selfClick = true` at the beginning to maintain compatibility with bubbling events and the **EventBus**, but added `this.selfClick = false` at the end to prevent the flag from leaking into the next event cycle due to the Capture Phase listener on the document.


fixes [ #8460](https://github.com/primefaces/primevue/issues/8460#issuecomment-3982602977)