### PR TITLE
fix(autocomplete): `clear` event not emitted on clear icon click

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -606,6 +606,7 @@ export default {
         },
         onClearClick(event) {
             this.updateModel(event, null);
+            this.$emit('clear');
         },
         onOverlayClick(event) {
             OverlayEventBus.emit('overlay-click', {


### PR DESCRIPTION
This commit introduces a new feature to the AutoComplete component. Now, when the clear button is clicked, a 'clear' event is emitted. This allows parent components to listen for and react to the clear action.

closes #8459

