### PR TITLE
Fix DatePicker time parsing to use locale AM/PM labels 

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1934,7 +1934,9 @@ export default {
         },
         parseDateTime(text) {
             let date;
-            let parts = text.match(/(?:(.+?) )?(\d{2}:\d{2}(?::\d{2})?)(?: (am|pm))?/);
+            const amLabel = this.$primevue.config.locale.am.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+            const pmLabel = this.$primevue.config.locale.pm.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+            let parts = text.match(new RegExp(`(?:(.+?) )?(\\d{2}:\\d{2}(?::\\d{2})?)(?:\\s+(${amLabel}|${pmLabel}))?`, 'i'));
 
             if (this.timeOnly) {
                 date = new Date();


### PR DESCRIPTION
## Summary                                                                                                                       
  - Replace hardcoded `am|pm` regex in `parseDateTime` with dynamic pattern built from `locale.am` / `locale.pm`

fixes https://github.com/primefaces/primevue/issues/8462
bug was added in: https://github.com/primefaces/primevue/pull/8105