### PR TITLE
Update DownloadDoc.vue

### DIFF
--- a/apps/showcase/doc/nuxt/DownloadDoc.vue
+++ b/apps/showcase/doc/nuxt/DownloadDoc.vue
@@ -17,14 +17,17 @@ export default {
 # Using npm
 npm install primevue @primeuix/themes
 npm install --save-dev @primevue/nuxt-module
+npm exec nuxi prepare
 
 # Using yarn
 yarn add primevue @primeuix/themes
 yarn add --dev @primevue/nuxt-module
+yarn exec nuxi prepare
 
 # Using pnpm
 pnpm add primevue @primeuix/themes
 pnpm add -D @primevue/nuxt-module
+pnpm exec nuxi prepare
 `
             }
         };


### PR DESCRIPTION
The following error appears in PrimeView in the nuxt.config configuration of Nuxt 4:

Object literal may only specify known properties, and ‘primevue’ does not exist in type ‘InputConfig<NuxtConfig, ConfigLayerMeta>’.

Running the command pnpm exec nuxi prepare solves the problem.

### Defect Fixes

When submitting a PR, please also create an issue documenting the error.

### Feature Requests

Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
