### PR TITLE
Add enterkeyhint="enter" to the input on Autocomplete

### DIFF
--- a/packages/primevue/src/autocomplete/AutoComplete.vue
+++ b/packages/primevue/src/autocomplete/AutoComplete.vue
@@ -107,6 +107,7 @@
                     @keydown="onKeyDown"
                     @input="onInput"
                     @change="onChange"
+                    enterkeyhint="enter"
                     v-bind="ptm('input')"
                 />
             </li>


### PR DESCRIPTION
### Defect Fixes

On some mobile devices (e.g tested with Google Pixel 7 + Google Keyboard) the default behaviour of the form input is to "Tab" or go to next input. 

This "Next" action replaces the Enter key on the mobile keyboard rendering the control useless in some scenarios e.g `:typeahead="false"` where it relies on the user pressing Enter to add the text as a chip.

Fortunately modern browsers allow the behaviour to be hinted at with `enterkeyhint="enter"`. 
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/enterkeyhint

I've tested this on my mobile device and it works as intended with the keyboard having an Enter button allowing inserting of chip when typeahead is disabled.

This resolves https://github.com/primefaces/primevue/issues/3694 which was incorrect (IMHO) closed without actually being fixed.

The default behaviour should work across all devices.
