### PR TITLE
fix: inject SSR styles only for rendered components (#7964)

### DIFF
--- a/packages/core/src/base/style/BaseStyle.js
+++ b/packages/core/src/base/style/BaseStyle.js
@@ -41,7 +41,7 @@ export default {
             const css = minifyCSS(computedStyle);
 
             if (options._styleCollect) {
-                options._styleCollect(options.name || this.name, css);
+                options._styleCollect(options.name || this.name, css, options);
 
                 return {};
             }

--- a/packages/core/src/base/style/BaseStyle.js
+++ b/packages/core/src/base/style/BaseStyle.js
@@ -37,7 +37,19 @@ export default {
     load(style, options = {}, transform = (cs) => cs) {
         const computedStyle = transform(Css`${style}`);
 
-        return isNotEmpty(computedStyle) ? useStyle(minifyCSS(computedStyle), { name: this.name, ...options }) : {};
+        if (isNotEmpty(computedStyle)) {
+            const css = minifyCSS(computedStyle);
+
+            if (options._styleCollect) {
+                options._styleCollect(options.name || this.name, css);
+
+                return {};
+            }
+
+            return useStyle(css, { name: this.name, ...options });
+        }
+
+        return {};
     },
     loadCSS(options = {}) {
         return this.load(this.css, options);

--- a/packages/core/src/basecomponent/BaseComponent.vue
+++ b/packages/core/src/basecomponent/BaseComponent.vue
@@ -82,6 +82,11 @@ export default {
     },
     created() {
         this._hook('onCreated');
+
+        // During SSR, beforeMount doesn't fire, so trigger full style loading here
+        if (this.$styleOptions._styleCollect) {
+            this._loadStyles();
+        }
     },
     beforeMount() {
         // @deprecated - remove in v5
@@ -351,7 +356,7 @@ export default {
             return { classes: undefined, inlineStyles: undefined, load: () => {}, loadCSS: () => {}, loadStyle: () => {}, ...(this._getHostInstance(this) || {}).$style, ...this.$options.style };
         },
         $styleOptions() {
-            return { nonce: this.$primevueConfig?.csp?.nonce };
+            return { nonce: this.$primevueConfig?.csp?.nonce, _styleCollect: this.$primevueConfig?._styleCollect };
         },
         $primevueConfig() {
             return this.$primevue?.config;

--- a/packages/core/src/basedirective/BaseDirective.js
+++ b/packages/core/src/basedirective/BaseDirective.js
@@ -70,7 +70,7 @@ const BaseDirective = {
     },
     _loadStyles: (instance = {}, binding, vnode) => {
         const config = BaseDirective._getConfig(binding, vnode);
-        const useStyleOptions = { nonce: config?.csp?.nonce };
+        const useStyleOptions = { nonce: config?.csp?.nonce, _styleCollect: config?._styleCollect };
 
         BaseDirective._loadCoreStyles(instance, useStyleOptions);
         BaseDirective._loadThemeStyles(instance, useStyleOptions);

--- a/packages/core/src/config/PrimeVue.js
+++ b/packages/core/src/config/PrimeVue.js
@@ -198,7 +198,7 @@ export function setupConfig(app, PrimeVue) {
         // common
         if (!Theme.isStyleNameLoaded('common')) {
             const { primitive, semantic, global, style } = BaseStyle.getCommonTheme?.() || {};
-            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce };
+            const styleOptions = { nonce: PrimeVue.config?.csp?.nonce, _styleCollect: PrimeVue.config?._styleCollect };
 
             BaseStyle.load(primitive?.css, { name: 'primitive-variables', ...styleOptions });
             BaseStyle.load(semantic?.css, { name: 'semantic-variables', ...styleOptions });

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -129,7 +129,21 @@ export default defineNuxtPlugin((nuxtApp) => {
     Theme.clearLoadedStyleNames();
     const collected = new Map();
     nuxtApp.ssrContext.event.context._primevueStyles = collected;
-    ssrCollect = { _styleCollect: (name, css) => collected.set(name, css) };
+    ssrCollect = {
+      // \`first: true\` mirrors useStyle's prepend path — 'layer-order' must
+      // reach the SSR HTML before any @layer primevue {} block, otherwise
+      // CSS first-mention semantics lock primevue in as the lowest layer.
+      _styleCollect: (name, css, opts) => {
+        if (opts && opts.first) {
+          const rest = Array.from(collected.entries()).filter(([k]) => k !== name);
+          collected.clear();
+          collected.set(name, css);
+          for (const [k, v] of rest) collected.set(k, v);
+        } else {
+          collected.set(name, css);
+        }
+      }
+    };
   }
 
   usePrimeVue && vueApp.use(PrimeVue, { ...options, ...pt, ...theme, ...ssrCollect });

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -53,8 +53,7 @@ export default defineNuxtModule<ModuleOptions>({
         const hasTheme = options?.theme !== 'none' && (importTheme || options?.theme) && !options?.unstyled;
 
         nuxt.options.runtimeConfig.public.primevue = {
-            ...moduleOptions,
-            ...registered
+            ...moduleOptions
         };
 
         //nuxt.options.build.transpile.push('nuxt');

--- a/packages/nuxt-module/src/module.ts
+++ b/packages/nuxt-module/src/module.ts
@@ -62,8 +62,6 @@ export default defineNuxtModule<ModuleOptions>({
         hasTheme && nuxt.options.build.transpile.push('@primevue/themes');
         hasTheme && nuxt.options.build.transpile.push('@primeuix/themes');
 
-        let registeredStyles: MetaType[] = registered.styles;
-
         if (autoImport) {
             const dts = isNotEmpty(moduleOptions.components?.prefix) || isNotEmpty(moduleOptions.directives?.prefix);
 
@@ -82,44 +80,17 @@ export default defineNuxtModule<ModuleOptions>({
         }
 
         const styleContent = () => {
-            if (!loadStyles) return `export const styles = [], stylesToTop = [], themes = [];`;
-
-            const uniqueRegisteredStyles = Array.from(new Map(registeredStyles?.map((m: MetaType) => [m.name, m])).values());
+            if (!loadStyles) return `export const styles = '', stylesToTop = '', themes = '';`;
 
             return `
-import { useRuntimeConfig } from '#imports';
-${uniqueRegisteredStyles?.map((style: MetaType) => `import ${style.as} from '${style.from}';`).join('\n')}
-${
-    hasTheme
-        ? `import { Theme } from '@primeuix/styled';
-${importTheme ? `import ${importTheme.as} from '${normalize(importTheme.from)}';\n` : ''}`
-        : ''
-}
+${hasTheme ? `import { Theme } from '@primeuix/styled';
+${importTheme ? `import ${importTheme.as} from '${normalize(importTheme.from)}';\n` : ''}` : ''}
 
-const runtimeConfig = useRuntimeConfig();
-const config = runtimeConfig?.public?.primevue ?? {};
-const { options = {} } = config;
+const stylesToTop = ${registered.injectStylesAsStringToTop.length ? `[${registered.injectStylesAsStringToTop.join('')}].join('')` : `''`};
+const styles = '';
+const themes = '';
 
-const stylesToTop = [${registered.injectStylesAsStringToTop.join('')}].join('');
-const styleProps = {
-    ${options?.csp?.nonce ? `nonce: ${options?.csp?.nonce}` : ''}
-}
-const styles = [
-    ${registered.injectStylesAsString.join('')},
-    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getStyleSheet ? ${item.as}.getStyleSheet(undefined, styleProps) : ''`).join(',')}
-].join('');
-
-${hasTheme ? `Theme.setTheme(${importTheme?.as} || options?.theme)` : ''}
-
-const themes = ${
-                !hasTheme
-                    ? `[]`
-                    : `
-[
-    ${`${uniqueRegisteredStyles?.[0].as} && ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet ? ${uniqueRegisteredStyles?.[0].as}.getCommonThemeStyleSheet(undefined, styleProps) : ''`},
-    ${uniqueRegisteredStyles?.map((item: MetaType) => `${item.as} && ${item.as}.getThemeStyleSheet ? ${item.as}.getThemeStyleSheet(undefined, styleProps) : ''`).join(',')}
-].join('');`
-            }
+${hasTheme ? `Theme.setTheme(${importTheme?.as} || {})` : ''}
 
 export { styles, stylesToTop, themes };
 `;
@@ -137,20 +108,32 @@ export { styles, stylesToTop, themes };
             getContents() {
                 return `
 import { defineNuxtPlugin, useRuntimeConfig } from '#imports';
+import Base from '@primevue/core/base';
+import { Theme } from '@primeuix/styled';
 ${registered.config.map((config: MetaType) => `import ${config.as} from '${config.from}';`).join('\n')}
 ${registered.services.map((service: MetaType) => `import ${service.as} from '${service.from}';`).join('\n')}
 ${!autoImport && registered.directives.map((directive: MetaType) => `import ${directive.as} from '${directive.from}';`).join('\n')}
 ${importPT ? `import ${importPT.as} from '${normalize(importPT.from)}';\n` : ''}
 ${hasTheme && importTheme ? `import ${importTheme.as} from '${normalize(importTheme.from)}';\n` : ''}
 
-export default defineNuxtPlugin(({ vueApp }) => {
+export default defineNuxtPlugin((nuxtApp) => {
+  const { vueApp } = nuxtApp;
   const runtimeConfig = useRuntimeConfig();
   const config = runtimeConfig?.public?.primevue ?? {};
   const { usePrimeVue = true, options = {} } = config;
   const pt = ${importPT ? `{ pt: ${importPT.as} }` : `{}`};
   const theme = ${hasTheme ? `{ theme: ${importTheme?.as} || options?.theme }` : `{}`};
 
-  usePrimeVue && vueApp.use(PrimeVue, { ...options, ...pt, ...theme });
+  let ssrCollect = {};
+  if (import.meta.server && nuxtApp.ssrContext?.event) {
+    Base.clearLoadedStyleNames();
+    Theme.clearLoadedStyleNames();
+    const collected = new Map();
+    nuxtApp.ssrContext.event.context._primevueStyles = collected;
+    ssrCollect = { _styleCollect: (name, css) => collected.set(name, css) };
+  }
+
+  usePrimeVue && vueApp.use(PrimeVue, { ...options, ...pt, ...theme, ...ssrCollect });
   ${registered.services.map((service: MetaType) => `vueApp.use(${service.as});`).join('\n')}
   ${!autoImport && registered.directives.map((directive: MetaType) => `vueApp.directive('${directive.name}', ${directive.as});`).join('\n')}
 });

--- a/packages/nuxt-module/src/register.ts
+++ b/packages/nuxt-module/src/register.ts
@@ -2,7 +2,6 @@ import { addComponent, addImports } from '@nuxt/kit';
 import { isNotEmpty, isString, resolve } from '@primeuix/utils/object';
 import type { MetaType } from '@primevue/metadata';
 import { components, composables, directives } from '@primevue/metadata';
-import type { PrimeVueConfiguration } from 'primevue/config';
 import type { ConstructsType, ModuleOptions, ResolvePathOptions } from './types';
 import { Utils } from './utils';
 
@@ -102,8 +101,6 @@ function registerServices(resolvePath: any, registered: any) {
 }
 
 function registerStyles(resolvePath: any, registered: any, moduleOptions: ModuleOptions) {
-    const options: PrimeVueConfiguration = moduleOptions.options || {};
-
     const styles: MetaType[] = [
         {
             name: 'BaseStyle',
@@ -111,32 +108,6 @@ function registerStyles(resolvePath: any, registered: any, moduleOptions: Module
             from: resolvePath({ name: 'BaseStyle', as: 'BaseStyle', from: '@primevue/core/base/style', type: 'style' })
         }
     ];
-
-    if (!options?.unstyled) {
-        // !moduleOptions.autoImport && !options?.unstyled
-        if (isNotEmpty(registered?.components)) {
-            styles.push({
-                name: 'BaseComponentStyle',
-                as: 'BaseComponentStyle',
-                from: resolvePath({ name: 'BaseComponentStyle', as: 'BaseComponentStyle', from: '@primevue/core/basecomponent/style', type: 'style' })
-            });
-        }
-
-        [registered.components, registered.directives]
-            .flat()
-            .reduce((acc: any[], citem: any) => (acc.some((item) => item.as.toLowerCase() === citem.as.toLowerCase()) ? acc : [...acc, citem]), [])
-            .forEach((item: any) => {
-                if (item.from.toLowerCase().includes('badgedirective')) {
-                    return;
-                }
-
-                styles.push({
-                    name: `${item.as}Style`,
-                    as: `${item.as}Style`,
-                    from: resolvePath({ name: `${item.as}Style`, as: `${item.as}Style`, from: `${item.from.toLowerCase()}/style`, type: 'style' })
-                });
-            });
-    }
 
     return styles;
 }

--- a/packages/nuxt-module/src/runtime/plugin.server.ts
+++ b/packages/nuxt-module/src/runtime/plugin.server.ts
@@ -1,7 +1,6 @@
 import type { NitroApp } from 'nitropack/types';
 // @ts-expect-error
-import { styles, stylesToTop, themes } from '#primevue-style';
-//import { useRuntimeConfig } from '#imports';
+import { stylesToTop } from '#primevue-style';
 
 type NitroAppPlugin = (nitro: NitroApp) => void;
 
@@ -17,10 +16,13 @@ interface NuxtRenderHTMLContext {
 const defineNitroPlugin = (def: NitroAppPlugin): NitroAppPlugin => def;
 
 export default defineNitroPlugin(async (nitroApp) => {
-    nitroApp.hooks.hook('render:html' as any, (html: NuxtRenderHTMLContext) => {
+    nitroApp.hooks.hook('render:html' as any, (html: NuxtRenderHTMLContext, { event }: any) => {
         html.head.unshift(stylesToTop);
-        html.head.push(styles);
-        html.head.push(themes);
-        //html.htmlAttrs.push('class="p-dark"'); // @todo
+        const collected: Map<string, string> | undefined = event?.context?._primevueStyles;
+        if (collected) {
+            const styleHtml = Array.from(collected.entries()).map(([name, css]) => `<style type="text/css" data-primevue-style-id="${name}">${css}</style>`).join('');
+
+            html.head.push(styleHtml);
+        }
     });
 });


### PR DESCRIPTION
Hi! I ran into a performance issue where PrimeVue's Nuxt module injects all ~80 component stylesheets into every SSR response, regardless of which components are actually used on the page. This causes significant HTML bloat, especially on pages that only use a few components. I wanted to contribute a fix for this (#7964).

## Summary

- Replace static bulk-injection of ALL component styles during SSR with a per-request collector that captures only styles from components that actually render on the page
- Significantly reduces SSR HTML payload by eliminating unused component CSS (~80 component stylesheets were injected regardless of page content)
- Core library remains framework-agnostic — uses an optional `_styleCollect` callback pattern with no Nuxt/SSR dependencies

## How it works

**Core (pluggable collector):** `BaseStyle.load()` checks for an optional `_styleCollect` callback in style options. When present, it routes CSS to the callback instead of calling `useStyle()` (which is a no-op during SSR anyway). The callback is threaded through `BaseComponent.$styleOptions`, `BaseDirective._loadStyles()`, and `PrimeVue.loadCommonTheme()`.

**Nuxt module:** The generated plugin creates a per-request `Map<string, string>` on the SSR event context and passes a `_styleCollect` callback that populates it. It also clears `Base`/`Theme` loaded-style-name tracking per request to prevent cross-request state leakage. The Nitro server plugin reads the collected map and injects only those styles as `<style>` tags.

**SSR lifecycle fix:** Since Vue's `beforeMount()` doesn't fire during SSR, component theme styles were never loaded. Added a `_loadStyles()` call in `created()` when `_styleCollect` is present so that component theme variables and styles are collected during server rendering.

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/base/style/BaseStyle.js` | `load()` routes CSS to `_styleCollect` callback when present |
| `packages/core/src/basecomponent/BaseComponent.vue` | Thread `_styleCollect` via `$styleOptions`; call `_loadStyles()` in `created()` for SSR |
| `packages/core/src/config/PrimeVue.js` | Pass `_styleCollect` in `loadCommonTheme()` style options |
| `packages/core/src/basedirective/BaseDirective.js` | Pass `_styleCollect` in `_loadStyles()` style options |
| `packages/nuxt-module/src/register.ts` | Remove per-component style registration (no longer needed) |
| `packages/nuxt-module/src/module.ts` | Simplify `styleContent()`; add SSR collector + loaded-name reset to plugin template |
| `packages/nuxt-module/src/runtime/plugin.server.ts` | Inject per-request collected styles instead of static bulk styles |


Closes #7964
