### PR TITLE
fix: guard against null container in Dialog drag listener

### DIFF
--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -321,7 +321,7 @@ export default {
         },
         bindDocumentDragListener() {
             this.documentDragListener = (event) => {
-                if (this.dragging) {
+                if (this.dragging && this.container) {
                     let width = getOuterWidth(this.container);
                     let height = getOuterHeight(this.container);
                     let deltaX = event.pageX - this.lastPageX;


### PR DESCRIPTION
## Summary
- Added a null check for `this.container` in `bindDocumentDragListener` to prevent `TypeError: Cannot read properties of null (reading 'getBoundingClientRect')` when a draggable Dialog is destroyed during an active drag operation.

## Root Cause
When a draggable Dialog's container is destroyed while a drag is in progress (e.g., parent component unmounts or visibility changes), `this.container` becomes `null` before the `mousemove` listener is cleaned up. The listener then crashes on `this.container.getBoundingClientRect()`.

## Fix
Changed `if (this.dragging)` to `if (this.dragging && this.container)` in the document drag listener callback.