### PR TITLE
fix(splitter): fix touch listener typo, null guard, and cleanup on unmount

### DIFF
--- a/packages/primevue/src/splitter/Splitter.vue
+++ b/packages/primevue/src/splitter/Splitter.vue
@@ -58,8 +58,10 @@ export default {
         this.initializePanels();
     },
     beforeUnmount() {
+        this.clearTimer();
         this.clear();
         this.unbindMouseListeners();
+        this.unbindTouchListeners();
     },
     methods: {
         isSplitterPanel(child) {


### PR DESCRIPTION
## Summary
Three small bug fixes for the Splitter component. They prevent throwing exceptions.

- **fix typo in touchEndListener**: `this.resizeEnd(event)` → `this.onResizeEnd(event)` — the method `resizeEnd` does not exist, so touch-based resize silently fails on touch-end
- **guard against null panel elements in onResize**: `clear()` sets `prevPanelElement` and `nextPanelElement` to null; if a mousemove/touchmove fires after cleanup, `onResize` crashes accessing `.style.flexBasis` on null
- **clean up timer and touch listeners in beforeUnmount**: `beforeUnmount` was missing `clearTimer()` and `unbindTouchListeners()`, so a keyboard-repeat timer or touch listeners could keep firing after the component is destroyed