### PR TITLE
fix(column): add phantom of prop for typed slot inference

### DIFF
--- a/packages/primevue/src/column/Column.d.ts
+++ b/packages/primevue/src/column/Column.d.ts
@@ -18,7 +18,7 @@ import type { PassThroughOptions } from 'primevue/passthrough';
 import type { RadioButtonPassThroughOptionType } from 'primevue/radiobutton';
 import type { SelectPassThroughOptionType } from 'primevue/select';
 import type { VirtualScrollerLoaderOptions } from 'primevue/virtualscroller';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type ColumnPassThroughOptionType = ColumnPassThroughAttributes | ((options: ColumnPassThroughMethodOptions) => ColumnPassThroughAttributes | string) | string | null | undefined;
 
@@ -640,7 +640,7 @@ export interface ColumnContext {
 /**
  * Defines valid slots in Column component.
  */
-export interface ColumnSlots {
+export interface ColumnSlots<T = any> {
     /**
      * Custom body template for DataTable.
      * @param {Object} scope - body slot's params.
@@ -649,11 +649,11 @@ export interface ColumnSlots {
         /**
          * Row data.
          */
-        data: any;
+        data: T;
         /**
          * Row node data.
          */
-        node: any;
+        node: T;
         /**
          * Column node.
          */
@@ -661,7 +661,7 @@ export interface ColumnSlots {
         /**
          * Column field.
          */
-        field: string | ((item: any) => string) | undefined;
+        field: string | ((item: T) => string) | undefined;
         /**
          * Row index.
          */
@@ -689,11 +689,11 @@ export interface ColumnSlots {
         /**
          * Row data.
          */
-        data: any;
+        data: T;
         /**
          * Row node data.
          */
-        node: any;
+        node: T;
         /**
          * Column node.
          */
@@ -749,7 +749,7 @@ export interface ColumnSlots {
         /**
          * Row data.
          */
-        data: any;
+        data: T;
         /**
          * Column node.
          */
@@ -884,7 +884,7 @@ export interface ColumnSlots {
         /**
          * Row data.
          */
-        data: any;
+        data: T;
         /**
          * Column node.
          */
@@ -1033,13 +1033,21 @@ export declare type ColumnEmits = EmitFn<ColumnEmitsOptions>;
  * @group Component
  *
  */
-declare const Column: DefineComponent<ColumnProps, ColumnSlots, ColumnEmits>;
+declare const Column: {
+    new <T = any>(
+        props: ColumnProps & { of?: readonly T[] | T[] | null }
+    ): {
+        $props: ColumnProps & { of?: readonly T[] | T[] | null } & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: ColumnSlots<T>;
+        $emit: EmitFn<ColumnEmitsOptions>;
+    };
+};
 
 export type ColumnNode = { props: ColumnProps };
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Column: DefineComponent<ColumnProps, ColumnSlots, ColumnEmits>;
+        Column: typeof Column;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8483

Column's `#body`, `#editor`, `#node`, and `#loading` slots are all typed as `any`. Even with DataTable's `T` generic (#8444), Column is a separate component — Vue's type system cannot propagate parent component generics to child component slots.

This affects the most common DataTable interaction: accessing row data in Column templates.

Related: #7426, #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-generic-type-repro?file=src%2FApp.vue) — `bun run type-check` (0 errors, typo undetected) → `bun run patch && bun run type-check` (TS2339 catches it)

## Problem

```vue
<DataTable :value="orders">  <!-- T = Order (inferred from #8444) -->
  <Column field="id">
    <template #body="{ data }">
      {{ data.stauts }}
      <!-- No error — `data` is `any` despite DataTable knowing T = Order -->
    </template>
  </Column>
</DataTable>
```

DataTable's `T` (from #8444) types DataTable's own slots (`#groupheader`, `#expansion`), but cannot flow to Column — Vue provides no mechanism for parent generics to propagate to child component slots.

## Solution: phantom `of` prop

An opt-in `of` prop carries type information without affecting runtime:

```vue
<DataTable :value="orders">
  <Column :of="orders" field="id">
    <template #body="{ data }">
      {{ data.stauts }}
      <!-- TS2339: Property 'stauts' does not exist on type 'Order' -->
    </template>
  </Column>
</DataTable>
```

By binding `:of="orders"` (the same array passed to DataTable's `:value`), TypeScript infers `T` from the array type and flows it to all slot scoped data. The `of` prop is never read at runtime — it exists purely for TypeScript inference.

Without `:of`, `T` defaults to `any` — fully backward compatible. Adoption is opt-in per Column.

### Why `of`?

- Short, readable: `<Column :of="orders" field="name">`
- Semantically clear: "this column is *of* this data"
- No conflict with existing Column props
- Works with both DataTable and TreeTable

## Changes

- `ColumnSlots<T = any>` — `data: T`, `node: T` in body/node/editor/loading slots, `field: (item: T) => string`
- Generic constructor with phantom prop: `new <T = any>(props: ColumnProps & { of?: readonly T[] | T[] | null })`
- `readonly T[]` supports read-only query results (e.g., Zero, TanStack Query)

## What gets typed

| Slot | Without `:of` | With `:of="orders"` |
|---|---|---|
| `#body` `data` / `node` | `any` | `T` |
| `#node` `data` / `node` | `any` | `T` |
| `#editor` `data` | `any` | `T` |
| `#loading` `data` | `any` | `T` |
| `#body` `field` callback | `(item: any) => string` | `(item: T) => string` |

## Scope / Impact

- **No breaking changes** — without `:of`, `T` defaults to `any` (same as before)
- **No runtime changes** — `of` is never read by Column's runtime code
- **Opt-in** — consumers add `:of="dataArray"` only where they want typed slots
- Works with DataTable and TreeTable

## Verification

| Gate | Result |
|---|---|
| `vue-tsc --noEmit` with `strictTemplates` | 0 new errors |
| Column without `:of` (backward compat) | `data: any`, zero errors |
| Column with `:of="orders"` | Full `T` inference, autocomplete works |
| All CI gates (format, lint, test, build) | PASS |

## Series

This is part of a series bringing generic type inference to all PrimeVue data components:

| PR | Components | Status |
|---|---|---|
| #8444 | DataTable, DatePicker | Open |
| #8484 | Select, MultiSelect, Listbox | Open |
| **#8485** | **Column (phantom `of` prop)** | **This PR** |
| #8489 | AutoComplete, CascadeSelect, DataView | Open |
| #8490 | Carousel, Galleria, Timeline | Open |
| #8491 | OrderList, PickList | Open |
| #8493 | VirtualScroller, SelectButton, InputChips | Open |
