### PR TITLE
fix(carousel,galleria,timeline): enable generic type inference for value and slots

### DIFF
--- a/packages/primevue/src/carousel/Carousel.d.ts
+++ b/packages/primevue/src/carousel/Carousel.d.ts
@@ -11,7 +11,7 @@ import type { DefineComponent, DesignToken, EmitFn, PassThrough } from '@primevu
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ButtonPassThroughOptions } from 'primevue/button';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type CarouselPassThroughOptionType = CarouselPassThroughAttributes | ((options: CarouselPassThroughMethodOptions) => CarouselPassThroughAttributes | string) | string | null | undefined;
 
@@ -248,11 +248,11 @@ export interface CarouselResponsiveOptions {
 /**
  * Defines valid properties in Carousel component.
  */
-export interface CarouselProps {
+export interface CarouselProps<T = any> {
     /**
      * An array of objects to display.
      */
-    value?: any | undefined;
+    value?: T[] | undefined;
     /**
      * Index of the first item.
      * @defaultValue 0
@@ -349,7 +349,7 @@ export interface CarouselProps {
 /**
  * Defines valid slots in Carousel slots.
  */
-export interface CarouselSlots {
+export interface CarouselSlots<T = any> {
     /**
      * Custom content for each item.
      * @param {Object} scope - item slot's params.
@@ -358,7 +358,7 @@ export interface CarouselSlots {
         /**
          * Data of the component
          */
-        data: any;
+        data: T;
         /**
          * Index of the item
          */
@@ -411,11 +411,19 @@ export declare type CarouselEmits = EmitFn<CarouselEmitsOptions>;
  * @group Component
  *
  */
-declare const Carousel: DefineComponent<CarouselProps, CarouselSlots, CarouselEmits>;
+declare const Carousel: {
+    new <T = any>(
+        props: CarouselProps<T>
+    ): {
+        $props: CarouselProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: CarouselSlots<T>;
+        $emit: EmitFn<CarouselEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Carousel: DefineComponent<CarouselProps, CarouselSlots, CarouselEmits>;
+        Carousel: typeof Carousel;
     }
 }
 

--- a/packages/primevue/src/galleria/Galleria.d.ts
+++ b/packages/primevue/src/galleria/Galleria.d.ts
@@ -10,7 +10,7 @@
 import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { ButtonHTMLAttributes, HTMLAttributes, TransitionProps, VNode } from 'vue';
+import { AllowedComponentProps, ButtonHTMLAttributes, ComponentCustomProps, HTMLAttributes, TransitionProps, VNode, VNodeProps } from 'vue';
 
 export declare type GalleriaPassThroughOptionType = GalleriaPassThroughAttributes | ((options: GalleriaPassThroughMethodOptions) => GalleriaPassThroughAttributes | string) | string | null | undefined;
 
@@ -270,7 +270,7 @@ export interface GalleriaContext {
 /**
  * Defines valid properties in Galleria component.
  */
-export interface GalleriaProps {
+export interface GalleriaProps<T = any> {
     /**
      * Unique identifier of the element.
      */
@@ -278,7 +278,7 @@ export interface GalleriaProps {
     /**
      * An array of objects to display.
      */
-    value?: any[];
+    value?: T[];
     /**
      * Index of the first item.
      * @defaultValue 0
@@ -429,7 +429,7 @@ export interface GalleriaProps {
 /**
  * Defines valid slots in Galleria slots.
  */
-export interface GalleriaSlots {
+export interface GalleriaSlots<T = any> {
     /**
      * Custom header template.
      */
@@ -446,7 +446,7 @@ export interface GalleriaSlots {
         /**
          * Item instance
          */
-        item: any;
+        item: T;
     }): VNode[];
     /**
      * Custom caption template.
@@ -456,7 +456,7 @@ export interface GalleriaSlots {
         /**
          * Item instance
          */
-        item: any;
+        item: T;
     }): VNode[];
     /**
      * Custom indicator template.
@@ -484,7 +484,7 @@ export interface GalleriaSlots {
         /**
          * Item instance
          */
-        item: any;
+        item: T;
     }): VNode[];
     /**
      * Custom close icon template.
@@ -538,11 +538,19 @@ export declare type GalleriaEmits = EmitFn<GalleriaEmitsOptions>;
  * @group Component
  *
  */
-declare const Galleria: DefineComponent<GalleriaProps, GalleriaSlots, GalleriaEmits>;
+declare const Galleria: {
+    new <T = any>(
+        props: GalleriaProps<T>
+    ): {
+        $props: GalleriaProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: GalleriaSlots<T>;
+        $emit: EmitFn<GalleriaEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Galleria: DefineComponent<GalleriaProps, GalleriaSlots, GalleriaEmits>;
+        Galleria: typeof Galleria;
     }
 }
 

--- a/packages/primevue/src/timeline/Timeline.d.ts
+++ b/packages/primevue/src/timeline/Timeline.d.ts
@@ -10,7 +10,7 @@
 import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type TimelinePassThroughOptionType = TimelinePassThroughAttributes | ((options: TimelinePassThroughMethodOptions) => TimelinePassThroughAttributes | string) | string | null | undefined;
 
@@ -108,11 +108,11 @@ export interface TimelineContext {
 /**
  * Defines valid properties in Timeline component.
  */
-export interface TimelineProps {
+export interface TimelineProps<T = any> {
     /**
      * An array of events to display.
      */
-    value?: any[] | undefined;
+    value?: T[] | undefined;
     /**
      * Position of the timeline bar relative to the content.
      * @defaultValue left
@@ -151,7 +151,7 @@ export interface TimelineProps {
 /**
  * Defines valid slots in Timeline component.
  */
-export interface TimelineSlots {
+export interface TimelineSlots<T = any> {
     /**
      * Custom content template
      * @param {Object} scope - content slot's params.
@@ -160,7 +160,7 @@ export interface TimelineSlots {
         /**
          * Item data
          */
-        item: any;
+        item: T;
         /**
          * Index of item
          */
@@ -174,7 +174,7 @@ export interface TimelineSlots {
         /**
          * Item data
          */
-        item: any;
+        item: T;
         /**
          * Index of item
          */
@@ -188,7 +188,7 @@ export interface TimelineSlots {
         /**
          * Item data
          */
-        item: any;
+        item: T;
         /**
          * Index of item
          */
@@ -201,7 +201,7 @@ export interface TimelineSlots {
         /**
          * Item data
          */
-        item: any;
+        item: T;
         /**
          * Index of item
          */
@@ -228,11 +228,19 @@ export declare type TimelineEmits = EmitFn<TimelineEmitsOptions>;
  * @group Component
  *
  */
-declare const Timeline: DefineComponent<TimelineProps, TimelineSlots, TimelineEmits>;
+declare const Timeline: {
+    new <T = any>(
+        props: TimelineProps<T>
+    ): {
+        $props: TimelineProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: TimelineSlots<T>;
+        $emit: EmitFn<TimelineEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Timeline: DefineComponent<TimelineProps, TimelineSlots, TimelineEmits>;
+        Timeline: typeof Timeline;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8487

Carousel, Galleria, and Timeline use `any` for their value arrays and slot scoped data. Developers get no IDE autocomplete and no compile-time safety when rendering items in these data-display components.

Same root cause as #8442 — `DefineComponent`'s no-arg constructor prevents generic inference. Same fix pattern as #8444 (DataTable/DatePicker).

Related: #7426, #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-generic-type-repro?file=src%2FApp.vue) — `bun run type-check` (0 errors, typo undetected) → `bun run patch && bun run type-check` (TS2339 catches it)

## Problem

```vue
<Carousel :value="products">
  <template #item="{ data }">
    {{ data.naem }}
    <!-- No error — `data` is `any`, typo ships to production -->
  </template>
</Carousel>
```

After this fix, TypeScript infers `T` from the `:value` binding and flows it to all slots:

```vue
<Carousel :value="products">
  <template #item="{ data }">
    {{ data.naem }}
    <!-- TS2339: Property 'naem' does not exist on type 'Product' -->
  </template>
</Carousel>
```

## Changes

For each component:

- `[Component]Props<T = any>` — `value: T[]`
- `[Component]Slots<T = any>` — all data-bearing slot parameters become `T`
- Generic constructor: `new <T = any>(props: [Component]Props<T>)` with `$slots: [Component]Slots<T>`

## What gets typed

| Slot | Before | After |
|---|---|---|
| Carousel `#item` `data` | `any` | `T` |
| Galleria `#item` / `#caption` / `#thumbnail` `item` | `any` | `T` |
| Timeline `#content` / `#opposite` / `#marker` / `#connector` `item` | `any` | `T` |

## Scope / Impact

- **No breaking changes** — backward compatible, `T` defaults to `any`
- **No runtime changes** — types only (.d.ts files)
- **3 components**: Carousel, Galleria, Timeline

## Verification

| Gate | Result |
|---|---|
| `pnpm run format:check` | PASS |
| `pnpm run lint` | PASS |
| `pnpm run test:unit` | Pre-existing failures only, 0 new |
| `pnpm run build:packages` | PASS |

## Series

This is part of a series bringing generic type inference to all PrimeVue data components:

| PR | Components | Status |
|---|---|---|
| #8444 | DataTable, DatePicker | Open |
| #8484 | Select, MultiSelect, Listbox | Open |
| #8485 | Column (phantom `of` prop) | Open |
| #8489 | AutoComplete, CascadeSelect, DataView | Open |
| **#8490** | **Carousel, Galleria, Timeline** | **This PR** |
| #8491 | OrderList, PickList | Open |
| #8493 | VirtualScroller, SelectButton, InputChips | Open |

After this series, every PrimeVue component with a collection prop will infer `T` from the binding and flow it to slots — giving developers full IDE autocomplete and compile-time type safety in templates.
