### PR TITLE
fix(orderlist,picklist): enable generic type inference for items and slots

### DIFF
--- a/packages/primevue/src/orderlist/OrderList.d.ts
+++ b/packages/primevue/src/orderlist/OrderList.d.ts
@@ -12,7 +12,7 @@ import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ButtonPassThroughOptions, ButtonProps } from 'primevue/button';
 import type { ListboxPassThroughOptions } from 'primevue/listbox';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { TransitionProps, VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, TransitionProps, VNode, VNodeProps } from 'vue';
 
 export declare type OrderListPassThroughOptionType = OrderListPassThroughAttributes | ((options: OrderListPassThroughMethodOptions) => OrderListPassThroughAttributes | string) | string | null | undefined;
 
@@ -169,11 +169,11 @@ export interface OrderListState {
 /**
  * Defines valid properties in OrderList component.
  */
-export interface OrderListProps {
+export interface OrderListProps<T = any> {
     /**
      * Value of the component.
      */
-    modelValue?: any[];
+    modelValue?: T[];
     /**
      * Name of the field that uniquely identifies the a record in the data.
      */
@@ -181,7 +181,7 @@ export interface OrderListProps {
     /**
      * Selected items in the list.
      */
-    selection?: any[];
+    selection?: T[];
     /**
      * Defines whether metaKey is required or not for the selection.
      * When true metaKey needs to be pressed to select or unselect an item and
@@ -281,7 +281,7 @@ export interface OrderListProps {
 /**
  * Defines valid slots in OrderList component.
  */
-export interface OrderListSlots {
+export interface OrderListSlots<T = any> {
     /**
      * Custom header template.
      */
@@ -295,7 +295,7 @@ export interface OrderListSlots {
         /**
          * Item of the component
          */
-        item: any;
+        item: T;
         /**
          * Selection state
          */
@@ -313,7 +313,7 @@ export interface OrderListSlots {
         /**
          * Option of the component
          */
-        option: any;
+        option: T;
         /**
          * Selection state
          */
@@ -389,11 +389,19 @@ export declare type OrderListEmits = EmitFn<OrderListEmitsOptions>;
  * @group Component
  *
  */
-declare const OrderList: DefineComponent<OrderListProps, OrderListSlots, OrderListEmits>;
+declare const OrderList: {
+    new <T = any>(
+        props: OrderListProps<T>
+    ): {
+        $props: OrderListProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: OrderListSlots<T>;
+        $emit: EmitFn<OrderListEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        OrderList: DefineComponent<OrderListProps, OrderListSlots, OrderListEmits>;
+        OrderList: typeof OrderList;
     }
 }
 

--- a/packages/primevue/src/picklist/PickList.d.ts
+++ b/packages/primevue/src/picklist/PickList.d.ts
@@ -12,7 +12,7 @@ import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ButtonPassThroughOptions } from 'primevue/button';
 import type { ListboxPassThroughOptions } from 'primevue/listbox';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { TransitionProps, VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, TransitionProps, VNode, VNodeProps } from 'vue';
 
 export declare type PickListPassThroughOptionType = PickListPassThroughAttributes | ((options: PickListPassThroughMethodOptions) => PickListPassThroughAttributes | string) | string | null | undefined;
 
@@ -290,15 +290,15 @@ export interface PickListContext {
 /**
  * Defines valid properties in PickList component.
  */
-export interface PickListProps {
+export interface PickListProps<T = any> {
     /**
      * Value of the component as a multidimensional array.
      */
-    modelValue?: any[][] | undefined;
+    modelValue?: T[][] | undefined;
     /**
      * Selected items in the list as a multidimensional array.
      */
-    selection?: any[][] | undefined;
+    selection?: T[][] | undefined;
     /**
      * Name of the field that uniquely identifies the a record in the data.
      */
@@ -420,7 +420,7 @@ export interface PickListProps {
 /**
  * Defines valid slots in PickList component.
  */
-export interface PickListSlots {
+export interface PickListSlots<T = any> {
     /**
      * Custom header template.
      */
@@ -434,7 +434,7 @@ export interface PickListSlots {
         /**
          * Item of the component
          */
-        item: any;
+        item: T;
         /**
          * Selection state
          */
@@ -452,7 +452,7 @@ export interface PickListSlots {
         /**
          * Option of the component
          */
-        option: any;
+        option: T;
         /**
          * Selection state
          */
@@ -612,11 +612,19 @@ export declare type PickListEmits = EmitFn<PickListEmitsOptions>;
  * @group Component
  *
  */
-declare const PickList: DefineComponent<PickListProps, PickListSlots, PickListEmits>;
+declare const PickList: {
+    new <T = any>(
+        props: PickListProps<T>
+    ): {
+        $props: PickListProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: PickListSlots<T>;
+        $emit: EmitFn<PickListEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        PickList: DefineComponent<PickListProps, PickListSlots, PickListEmits>;
+        PickList: typeof PickList;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8488

OrderList and PickList use `any` for their modelValue and slot scoped data. Unlike the Select family (#8484), these components' `modelValue` IS the full item array — there is no `optionValue` extraction. This means `modelValue` itself becomes `T[]` / `T[][]`, providing end-to-end type safety from binding to slot.

Same root cause as #8442 — `DefineComponent`'s no-arg constructor prevents generic inference. Same fix pattern as #8444 (DataTable/DatePicker).

Related: #7426, #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-generic-type-repro?file=src%2FApp.vue) — `bun run type-check` (0 errors, typo undetected) → `bun run patch && bun run type-check` (TS2339 catches it)

## Problem

```vue
<OrderList v-model="products">
  <template #option="{ option }">
    {{ option.naem }}
    <!-- No error — `option` is `any`, typo ships to production -->
  </template>
</OrderList>
```

After this fix, TypeScript infers `T` from the `v-model` binding and flows it to all slots:

```vue
<OrderList v-model="products">
  <template #option="{ option }">
    {{ option.naem }}
    <!-- TS2339: Property 'naem' does not exist on type 'Product' -->
  </template>
</OrderList>
```

## Changes

- `OrderListProps<T = any>` — `modelValue: T[]`, `selection: T[]`
- `OrderListSlots<T = any>` — `item: T`, `option: T`
- `PickListProps<T = any>` — `modelValue: T[][]`, `selection: T[][]`
- `PickListSlots<T = any>` — `item: T`, `option: T`
- Both: generic constructor replaces `DefineComponent`

### Why `modelValue` becomes `T[]` here

In Select/MultiSelect (#8484), `modelValue` stays `any` because `optionValue` extracts a scalar — the value type differs from the option type. OrderList and PickList have no `optionValue` extraction. The items in `modelValue` ARE the option objects, so `modelValue: T[]` is correct and gives full round-trip type safety.

## What gets typed

| Slot/Prop | Before | After |
|---|---|---|
| OrderList `modelValue` | `any[]` | `T[]` |
| OrderList `selection` | `any[]` | `T[]` |
| OrderList `#option` / `#item` data | `any` | `T` |
| PickList `modelValue` | `any[][]` | `T[][]` |
| PickList `selection` | `any[][]` | `T[][]` |
| PickList `#option` / `#item` data | `any` | `T` |

## Scope / Impact

- **No breaking changes** — backward compatible, `T` defaults to `any`
- **No runtime changes** — types only (.d.ts files)
- **2 components**: OrderList, PickList

## Verification

| Gate | Result |
|---|---|
| `pnpm run format:check` | PASS |
| `pnpm run lint` | PASS |
| `pnpm run test:unit` | Pre-existing failures only, 0 new |
| `pnpm run build:packages` | PASS |

## Series

This is part of a series bringing generic type inference to all PrimeVue data components:

| PR | Components | Status |
|---|---|---|
| #8444 | DataTable, DatePicker | Open |
| #8484 | Select, MultiSelect, Listbox | Open |
| #8485 | Column (phantom `of` prop) | Open |
| #8489 | AutoComplete, CascadeSelect, DataView | Open |
| #8490 | Carousel, Galleria, Timeline | Open |
| **#8491** | **OrderList, PickList** | **This PR** |
| #8493 | VirtualScroller, SelectButton, InputChips | Open |

After this series, every PrimeVue component with a collection prop will infer `T` from the binding and flow it to slots — giving developers full IDE autocomplete and compile-time type safety in templates.
