### PR TITLE
fix(virtualscroller,selectbutton,inputchips): enable generic type inference for items and slots

### DIFF
--- a/packages/primevue/src/inputchips/InputChips.d.ts
+++ b/packages/primevue/src/inputchips/InputChips.d.ts
@@ -11,7 +11,7 @@ import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } 
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { ChipPassThroughOptions } from 'primevue/chip';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { InputHTMLAttributes, VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, InputHTMLAttributes, VNode, VNodeProps } from 'vue';
 
 export declare type InputChipsPassThroughOptionType = InputChipsPassThroughAttributes | ((options: InputChipsPassThroughMethodOptions) => InputChipsPassThroughAttributes | string) | string | null | undefined;
 
@@ -155,11 +155,11 @@ export interface InputChipsState {
 /**
  * Defines valid properties in InputChips component.
  */
-export interface InputChipsProps {
+export interface InputChipsProps<T = any> {
     /**
      * Value of the component.
      */
-    modelValue?: any[];
+    modelValue?: T[];
     /**
      * Maximum number of entries allowed.
      */
@@ -252,7 +252,7 @@ export interface InputChipsProps {
 /**
  * Defines valid slots in InputChips slots.
  */
-export interface InputChipsSlots {
+export interface InputChipsSlots<T = any> {
     /**
      * Custom chip template.
      * @param {Object} scope - chip slot's params.
@@ -261,7 +261,7 @@ export interface InputChipsSlots {
         /**
          * Value of the component
          */
-        value: any;
+        value: T;
     }): VNode[];
     /**
      * @deprecated since v4.0. Use 'chipicon' slot.
@@ -338,11 +338,19 @@ export declare type InputChipsEmits = EmitFn<InputChipsEmitsOptions>;
  * @group Component
  *
  */
-declare const InputChips: DefineComponent<InputChipsProps, InputChipsSlots, InputChipsEmits>;
+declare const InputChips: {
+    new <T = any>(
+        props: InputChipsProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps
+    ): {
+        $props: InputChipsProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: InputChipsSlots<T>;
+        $emit: InputChipsEmits;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        InputChips: DefineComponent<InputChipsProps, InputChipsSlots, InputChipsEmits>;
+        InputChips: typeof InputChips;
     }
 }
 

--- a/packages/primevue/src/selectbutton/SelectButton.d.ts
+++ b/packages/primevue/src/selectbutton/SelectButton.d.ts
@@ -9,7 +9,7 @@
  */
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 // import { ToggleButtonPassThroughOptions } from 'primevue/togglebutton';
 import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 
@@ -120,7 +120,7 @@ export interface SelectButtonState {
 /**
  * Defines valid properties in SelectButton component.
  */
-export interface SelectButtonProps {
+export interface SelectButtonProps<T = any> {
     /**
      * Value of the component.
      */
@@ -136,19 +136,19 @@ export interface SelectButtonProps {
     /**
      * An array of selectitems to display as the available options.
      */
-    options?: any[] | undefined;
+    options?: T[] | undefined;
     /**
      * Property name or getter function to use as the label of an option.
      */
-    optionLabel?: string | ((data: any) => string) | undefined;
+    optionLabel?: string | ((data: T) => string) | undefined;
     /**
      * Property name or getter function to use as the value of an option, defaults to the option itself when not defined.
      */
-    optionValue?: string | ((data: any) => any) | undefined;
+    optionValue?: string | ((data: T) => any) | undefined;
     /**
      * Property name or getter function to use as the disabled flag of an option, defaults to false when not defined.
      */
-    optionDisabled?: string | ((data: any) => boolean) | undefined;
+    optionDisabled?: string | ((data: T) => boolean) | undefined;
     /**
      * When specified, allows selecting multiple values.
      * @defaultValue false
@@ -214,7 +214,7 @@ export interface SelectButtonProps {
 /**
  * Defines valid slots in SelectButton component.
  */
-export interface SelectButtonSlots {
+export interface SelectButtonSlots<T = any> {
     /**
      * Custom content for each option.
      * @param {Object} scope - option slot's params.
@@ -223,7 +223,7 @@ export interface SelectButtonSlots {
         /**
          * Option instance
          */
-        option: any;
+        option: T;
         /**
          * Index of the option
          */
@@ -275,11 +275,19 @@ export declare type SelectButtonEmits = EmitFn<SelectButtonEmitsOptions>;
  * @group Component
  *
  */
-declare const SelectButton: DefineComponent<SelectButtonProps, SelectButtonSlots, SelectButtonEmits>;
+declare const SelectButton: {
+    new <T = any>(
+        props: SelectButtonProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps
+    ): {
+        $props: SelectButtonProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: SelectButtonSlots<T>;
+        $emit: SelectButtonEmits;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        SelectButton: DefineComponent<SelectButtonProps, SelectButtonSlots, SelectButtonEmits>;
+        SelectButton: typeof SelectButton;
     }
 }
 

--- a/packages/primevue/src/virtualscroller/VirtualScroller.d.ts
+++ b/packages/primevue/src/virtualscroller/VirtualScroller.d.ts
@@ -10,7 +10,7 @@
 import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type VirtualScrollerPassThroughOptionType = VirtualScrollerPassThroughAttributes | ((options: VirtualScrollerPassThroughMethodOptions) => VirtualScrollerPassThroughAttributes | string) | string | null | undefined;
 
@@ -222,7 +222,7 @@ export interface VirtualScrollerLoaderOptions extends VirtualScrollerItemOptions
 /**
  * Defines valid properties in VirtualScroller component.
  */
-export interface VirtualScrollerProps {
+export interface VirtualScrollerProps<T = any> {
     /**
      * Unique identifier of the element.
      */
@@ -238,7 +238,7 @@ export interface VirtualScrollerProps {
     /**
      * An array of objects to display.
      */
-    items?: any[] | any[][] | undefined | null;
+    items?: T[] | T[][] | undefined | null;
     /**
      * The height/width of item according to orientation.
      */
@@ -356,7 +356,7 @@ export interface VirtualScrollerProps {
 /**
  * Defines valid slots in VirtualScroller component.
  */
-export interface VirtualScrollerSlots {
+export interface VirtualScrollerSlots<T = any> {
     /**
      * Custom content template.
      * @param {Object} scope - content slot's params.
@@ -365,7 +365,7 @@ export interface VirtualScrollerSlots {
         /**
          * An array of objects to display for virtualscroller
          */
-        items: any;
+        items: T[];
         /**
          * Style class of the content
          */
@@ -433,7 +433,7 @@ export interface VirtualScrollerSlots {
         /**
          * Item data.
          */
-        item: any;
+        item: T;
         /**
          * Item options.
          */
@@ -526,11 +526,19 @@ export interface VirtualScrollerMethods {
  * @group Component
  *
  */
-declare const VirtualScroller: DefineComponent<VirtualScrollerProps, VirtualScrollerSlots, VirtualScrollerEmits, VirtualScrollerMethods>;
+declare const VirtualScroller: {
+    new <T = any>(
+        props: VirtualScrollerProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps
+    ): {
+        $props: VirtualScrollerProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: VirtualScrollerSlots<T>;
+        $emit: VirtualScrollerEmits;
+    } & VirtualScrollerMethods;
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        VirtualScroller: DefineComponent<VirtualScrollerProps, VirtualScrollerSlots, VirtualScrollerEmits, VirtualScrollerMethods>;
+        VirtualScroller: typeof VirtualScroller;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8492

VirtualScroller, SelectButton, and InputChips use `any` for their collection props and slot scoped data. These are the last three PrimeVue components where collection props flow to slots without generic type inference.

Same root cause as #8442 — `DefineComponent`'s no-arg constructor prevents generic inference. Same fix pattern as #8444 (DataTable/DatePicker).

Related: #7426, #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-generic-type-repro?file=src%2FApp.vue) — `bun run type-check` (0 errors, typo undetected) → `bun run patch && bun run type-check` (TS2339 catches it)

## Problem

```vue
<SelectButton :options="cities" :optionLabel="(city) => city.name">
  <template #option="{ option }">
    {{ option.naem }}
    <!-- No error — `option` is `any`, typo ships to production -->
  </template>
</SelectButton>
```

After this fix, TypeScript infers `T` from the collection prop and flows it to all slots:

```vue
<SelectButton :options="cities" :optionLabel="(city) => city.name">
  <template #option="{ option }">
    {{ option.naem }}
    <!-- TS2339: Property 'naem' does not exist on type 'City' -->
  </template>
</SelectButton>
```

## Changes

**VirtualScroller:**
- `VirtualScrollerProps<T = any>`: `items?: T[] | T[][]`
- `VirtualScrollerSlots<T = any>`: item slot `item: T`, content slot `items: T[]`

**SelectButton:**
- `SelectButtonProps<T = any>`: `options?: T[]`, callbacks `(data: T) => ...`
- `SelectButtonSlots<T = any>`: option slot `option: T`
- `modelValue` stays `any` — `optionValue` extracts a scalar, same reasoning as Select (#8484)

**InputChips:**
- `InputChipsProps<T = any>`: `modelValue?: T[]`
- `InputChipsSlots<T = any>`: chip slot `value: T`
- `modelValue` becomes `T[]` — items ARE the value (no `optionValue`), same reasoning as OrderList (#8491)

Each component uses the generic constructor pattern (`new <T>(props)`) so TypeScript infers `T` automatically.

## What gets typed

| Slot/Callback | Before | After |
|---|---|---|
| VirtualScroller `#item` slot `item` | `any` | `T` |
| VirtualScroller `#content` slot `items` | `any` | `T[]` |
| SelectButton `#option` slot `option` | `any` | `T` |
| SelectButton `optionLabel` callback param | `any` | `T` |
| SelectButton `optionValue` callback param | `any` | `T` |
| SelectButton `optionDisabled` callback param | `any` | `T` |
| InputChips `#chip` slot `value` | `any` | `T` |
| InputChips `modelValue` | `any[]` | `T[]` |

## Scope / Impact

- **No breaking changes** — backward compatible, `T` defaults to `any`
- **No runtime changes** — types only (.d.ts files)
- **3 components**: VirtualScroller, SelectButton, InputChips

## Verification

| Gate | Result |
|---|---|
| `pnpm run format:check` | PASS |
| `pnpm run lint` | PASS |
| `pnpm run test:unit` | Pre-existing failures only, 0 new |
| `pnpm run build:packages` (primevue) | PASS |
| Type pressure test (4 `@ts-expect-error` checks) | PASS |

## Series

This is the final PR in a series bringing generic type inference to all PrimeVue data components:

| PR | Components | Status |
|---|---|---|
| #8444 | DataTable, DatePicker | Open |
| #8484 | Select, MultiSelect, Listbox | Open |
| #8485 | Column (phantom `of` prop) | Open |
| #8489 | AutoComplete, CascadeSelect, DataView | Open |
| #8490 | Carousel, Galleria, Timeline | Open |
| #8491 | OrderList, PickList | Open |
| **#8493** | **VirtualScroller, SelectButton, InputChips** | **This PR** |

After this series, every PrimeVue component with a collection prop infers `T` from the binding and flows it to slots — giving developers full IDE autocomplete and compile-time type safety in templates.