### PR TITLE
fix(tree,treeselect,organizationchart): enable generic type inference for value/options and slots

### DIFF
--- a/packages/primevue/src/organizationchart/OrganizationChart.d.ts
+++ b/packages/primevue/src/organizationchart/OrganizationChart.d.ts
@@ -10,7 +10,7 @@
 import type { DefineComponent, DesignToken, EmitFn, HintedString, PassThrough } from '@primevue/core';
 import type { ComponentHooks } from '@primevue/core/basecomponent';
 import type { PassThroughOptions } from 'primevue/passthrough';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type OrganizationChartPassThroughOptionType = OrganizationChartPassThroughAttributes | ((options: OrganizationChartPassThroughMethodOptions) => OrganizationChartPassThroughAttributes | string) | string | null | undefined;
 
@@ -231,11 +231,11 @@ export interface OrganizationChartContext {
 /**
  * Defines valid properties in OrganizationChart component.
  */
-export interface OrganizationChartProps {
+export interface OrganizationChartProps<T extends OrganizationChartNode = OrganizationChartNode> {
     /**
      * Value of the component.
      */
-    value?: OrganizationChartNode;
+    value?: T;
     /**
      * A map instance of key-value pairs to represented the selected nodes.
      */
@@ -277,7 +277,7 @@ export interface OrganizationChartProps {
 /**
  * Defines valid slots in OrganizationChart component.
  */
-export interface OrganizationChartSlots {
+export interface OrganizationChartSlots<T extends OrganizationChartNode = OrganizationChartNode> {
     /**
      * Custom content template.
      */
@@ -285,13 +285,13 @@ export interface OrganizationChartSlots {
         /**
          * Current node
          */
-        node: any;
+        node: T;
     }): VNode[];
     /**
      * Dynamic content template.
      * @todo
      */
-    [key: string]: (node: any) => VNode[];
+    [key: string]: (node: T) => VNode[];
     /**
      * @deprecated since v4.0. Use 'toggleicon' slot instead.
      * Custom toggler icon template.
@@ -365,11 +365,19 @@ export declare type OrganizationChartEmits = EmitFn<OrganizationChartEmitsOption
  * @group Component
  *
  */
-declare const OrganizationChart: DefineComponent<OrganizationChartProps, OrganizationChartSlots, OrganizationChartEmits>;
+declare const OrganizationChart: {
+    new <T extends OrganizationChartNode = OrganizationChartNode>(
+        props: OrganizationChartProps<T>
+    ): {
+        $props: OrganizationChartProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: OrganizationChartSlots<T>;
+        $emit: EmitFn<OrganizationChartEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        OrganizationChart: DefineComponent<OrganizationChartProps, OrganizationChartSlots, OrganizationChartEmits>;
+        OrganizationChart: typeof OrganizationChart;
     }
 }
 

--- a/packages/primevue/src/tree/Tree.d.ts
+++ b/packages/primevue/src/tree/Tree.d.ts
@@ -14,7 +14,7 @@ import type { InputIconPassThroughOptions } from 'primevue/inputicon';
 import type { InputTextPassThroughOptions } from 'primevue/inputtext';
 import type { PassThroughOptions } from 'primevue/passthrough';
 import type { TreeNode } from 'primevue/treenode';
-import { VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, VNode, VNodeProps } from 'vue';
 
 export declare type TreePassThroughOptionType<T = any> = TreePassThroughAttributes | ((options: TreePassThroughMethodOptions<T>) => TreePassThroughAttributes | string) | string | null | undefined;
 
@@ -324,11 +324,11 @@ export interface TreeContext {
 /**
  * Defines valid properties in Tree component.
  */
-export interface TreeProps {
+export interface TreeProps<T extends TreeNode = TreeNode> {
     /**
      * An array of treenodes.
      */
-    value?: TreeNode[] | undefined;
+    value?: T[] | undefined;
     /**
      * A map of keys to represent the expansion state in controlled mode.
      */
@@ -370,7 +370,7 @@ export interface TreeProps {
      * When filtering is enabled, filterBy decides which field or fields (comma separated) to search against. A callable taking a TreeNode can be provided instead of a list of field names.
      * @defaultValue label
      */
-    filterBy?: string | ((node: TreeNode) => string) | undefined;
+    filterBy?: string | ((node: T) => string) | undefined;
     /**
      * Mode for filtering.
      * @defaultValue lenient
@@ -450,7 +450,7 @@ export interface TreeProps {
 /**
  * Defines valid slots in Tree component.
  */
-export interface TreeSlots {
+export interface TreeSlots<T extends TreeNode = TreeNode> {
     /**
      * Default content slot.
      */
@@ -458,7 +458,7 @@ export interface TreeSlots {
         /**
          * Tree node instance
          */
-        node: TreeNode;
+        node: T;
         /**
          * Selection state
          */
@@ -508,7 +508,7 @@ export interface TreeSlots {
         /**
          * Tree node instance
          */
-        node: TreeNode;
+        node: T;
         /**
          * Expanded state of the node
          */
@@ -523,7 +523,7 @@ export interface TreeSlots {
         /**
          * Tree node instance
          */
-        node: TreeNode;
+        node: T;
         /**
          * Expanded state of the node
          */
@@ -537,7 +537,7 @@ export interface TreeSlots {
         /**
          * Tree node instance
          */
-        node: TreeNode;
+        node: T;
         /**
          * Expanded state of the node
          */
@@ -551,7 +551,7 @@ export interface TreeSlots {
         /**
          * Tree node instance
          */
-        node: TreeNode;
+        node: T;
         /**
          * Style class of the icon.
          */
@@ -615,7 +615,7 @@ export interface TreeSlots {
      * Optional slots.
      * @todo
      */
-    [key: string]: (node: any) => VNode[];
+    [key: string]: (node: T) => VNode[];
 }
 
 /**
@@ -703,11 +703,19 @@ export declare type TreeEmits = EmitFn<TreeEmitsOptions>;
  * @group Component
  *
  */
-declare const Tree: DefineComponent<TreeProps, TreeSlots, TreeEmits>;
+declare const Tree: {
+    new <T extends TreeNode = TreeNode>(
+        props: TreeProps<T>
+    ): {
+        $props: TreeProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: TreeSlots<T>;
+        $emit: EmitFn<TreeEmitsOptions>;
+    };
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        Tree: DefineComponent<TreeProps, TreeSlots, TreeEmits>;
+        Tree: typeof Tree;
     }
 }
 

--- a/packages/primevue/src/treeselect/TreeSelect.d.ts
+++ b/packages/primevue/src/treeselect/TreeSelect.d.ts
@@ -13,7 +13,7 @@ import type { ChipPassThroughOptions } from 'primevue/chip';
 import type { PassThroughOptions } from 'primevue/passthrough';
 import type { TreeExpandedKeys, TreePassThroughOptions } from 'primevue/tree';
 import type { TreeNode } from 'primevue/treenode';
-import { InputHTMLAttributes, TransitionProps, VNode } from 'vue';
+import { AllowedComponentProps, ComponentCustomProps, InputHTMLAttributes, TransitionProps, VNode, VNodeProps } from 'vue';
 
 export declare type TreeSelectPassThroughOptionType = TreeSelectPassThroughAttributes | ((options: TreeSelectPassThroughMethodOptions) => TreeSelectPassThroughAttributes | string) | string | null | undefined;
 
@@ -172,15 +172,15 @@ export interface TreeSelectState {
 /**
  * Defines valid properties in TreeSelect component.
  */
-export interface TreeSelectProps {
+export interface TreeSelectProps<T extends TreeNode = TreeNode> {
     /**
      * Value of the component.
      */
-    modelValue?: TreeNode | any;
+    modelValue?: T | any;
     /**
      * The default value for the input when not controlled by `modelValue`.
      */
-    defaultValue?: TreeNode | any;
+    defaultValue?: T | any;
     /**
      * The name attribute for the element, typically used in form submissions.
      */
@@ -188,7 +188,7 @@ export interface TreeSelectProps {
     /**
      * An array of treenodes.
      */
-    options?: TreeNode[] | undefined;
+    options?: T[] | undefined;
     /**
      * A map of keys to represent the expansion state in controlled mode.
      */
@@ -264,7 +264,7 @@ export interface TreeSelectProps {
      * When filtering is enabled, filterBy decides which field or fields (comma separated) to search against. A callable taking a TreeNode can be provided instead of a list of field names.
      * @defaultValue label
      */
-    filterBy?: string | ((node: TreeNode) => string) | undefined;
+    filterBy?: string | ((node: T) => string) | undefined;
     /**
      * Mode for filtering.
      * @defaultValue lenient
@@ -366,7 +366,7 @@ export interface TreeSelectProps {
 /**
  * Defines valid slots in TreeSelect component.
  */
-export interface TreeSelectSlots {
+export interface TreeSelectSlots<T extends TreeNode = TreeNode> {
     /**
      * Custom value template.
      * @param {Object} scope - value slot's params.
@@ -375,7 +375,7 @@ export interface TreeSelectSlots {
         /**
          * Selected value
          */
-        value: TreeNode | any;
+        value: T | any;
         /**
          * Placeholder
          */
@@ -389,7 +389,7 @@ export interface TreeSelectSlots {
         /**
          * Current node
          */
-        node: TreeNode | any;
+        node: T;
         /**
          * Selection state
          */
@@ -407,11 +407,11 @@ export interface TreeSelectSlots {
         /**
          * Selected value
          */
-        value: TreeNode | any;
+        value: T | any;
         /**
          * An array of treenodes.
          */
-        options: TreeNode[];
+        options: T[];
     }): VNode[];
     /**
      * Custom footer template.
@@ -421,11 +421,11 @@ export interface TreeSelectSlots {
         /**
          * Selected value
          */
-        value: TreeNode | any;
+        value: T | any;
         /**
          * An array of treenodes.
          */
-        options: TreeNode[];
+        options: T[];
     }): VNode[];
     /**
      * Custom empty template.
@@ -461,11 +461,11 @@ export interface TreeSelectSlots {
         /**
          * Node instance
          */
-        node: TreeNode | any;
+        node: T;
         /**
          * Expanded state of the node
          */
-        expanded: TreeNode[];
+        expanded: T[];
     }): VNode[];
     /**
      * Custom item toggle icon template.
@@ -475,11 +475,11 @@ export interface TreeSelectSlots {
         /**
          * Node instance
          */
-        node: TreeNode | any;
+        node: T;
         /**
          * Expanded state of the node
          */
-        expanded: TreeNode[];
+        expanded: T[];
     }): VNode[];
     /**
      * Custom item checkbox icon template.
@@ -599,11 +599,19 @@ export interface TreeSelectMethods {
  * @group Component
  *
  */
-declare const TreeSelect: DefineComponent<TreeSelectProps, TreeSelectSlots, TreeSelectEmits, TreeSelectMethods>;
+declare const TreeSelect: {
+    new <T extends TreeNode = TreeNode>(
+        props: TreeSelectProps<T>
+    ): {
+        $props: TreeSelectProps<T> & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        $slots: TreeSelectSlots<T>;
+        $emit: EmitFn<TreeSelectEmitsOptions>;
+    } & TreeSelectMethods;
+};
 
 declare module 'vue' {
     export interface GlobalComponents {
-        TreeSelect: DefineComponent<TreeSelectProps, TreeSelectSlots, TreeSelectEmits, TreeSelectMethods>;
+        TreeSelect: typeof TreeSelect;
     }
 }
 


### PR DESCRIPTION
### Defect Fixes

Fixes #8496

Tree, TreeSelect, and OrganizationChart use `TreeNode` / `OrganizationChartNode` for their data props and all slot scoped data. Both interfaces have a `[key: string]: any` index signature. Developers who extend these interfaces with custom properties get no type safety — custom properties resolve to `any` via the index signature instead of their declared types.

Same root cause as #8442 — `DefineComponent`'s no-arg constructor prevents generic inference. Same fix pattern as #8444 (DataTable/DatePicker).

Related: #7426, #6041

**Reproducer:** [StackBlitz](https://stackblitz.com/github/YevheniiKotyrlo/primevue-generic-type-repro?file=src%2FApp.vue) — `bun run type-check` (0 errors, typo undetected) → `bun run patch && bun run type-check` (TS2339 catches it)

## Problem

```typescript
interface MyTreeNode extends TreeNode {
  customLabel: string;
  customIcon?: string;
}

const nodes: MyTreeNode[] = [
  { key: '1', customLabel: 'Root', children: [] }
];
```

```vue
<Tree :value="nodes">
  <template #default="{ node }">
    {{ node.customLabel }}
    <!-- No error — `node.customLabel` is `any` (from index signature), typo ships to production -->
  </template>
</Tree>
```

After this fix, TypeScript infers `T = MyTreeNode` from the `:value` binding and flows it to all slots:

```vue
<Tree :value="nodes">
  <template #default="{ node }">
    {{ node.customLabel }}
    <!-- node.customLabel is `string` — proper type from MyTreeNode -->
  </template>
</Tree>
```

## Changes

**Tree:**
- `TreeProps<T extends TreeNode = TreeNode>` — `value: T[]`, `filterBy` callback `(node: T) => string`
- `TreeSlots<T extends TreeNode = TreeNode>` — all 5+ slots with `node: T`, catch-all `[key: string]: (node: T) => VNode[]`
- Generic constructor replaces `DefineComponent`

**TreeSelect:**
- `TreeSelectProps<T extends TreeNode = TreeNode>` — `options: T[]`, `modelValue: T | any`, `filterBy` callback `(node: T) => string`
- `TreeSelectSlots<T extends TreeNode = TreeNode>` — `node: T` in option/toggle slots (removes incorrect `| any`), `options: T[]` in header/footer
- Generic constructor with `& TreeSelectMethods`

**OrganizationChart:**
- `OrganizationChartProps<T extends OrganizationChartNode = OrganizationChartNode>` — `value: T`
- `OrganizationChartSlots<T extends OrganizationChartNode = OrganizationChartNode>` — `node: T` in default slot, catch-all `[key: string]: (node: T) => VNode[]`
- Generic constructor replaces `DefineComponent`

## What gets typed

| Slot / Prop | Before | After |
|---|---|---|
| Tree `#default` `node` | `TreeNode` | `T` |
| Tree `#nodeicon` / `#nodetoggleicon` `node` | `TreeNode` | `T` |
| Tree catch-all `[key: string]` `node` | `any` | `T` |
| TreeSelect `#option` `node` | `TreeNode \| any` | `T` |
| TreeSelect `#header` / `#footer` `options` | `TreeNode[]` | `T[]` |
| OrganizationChart `#default` `node` | `any` | `T` |
| OrganizationChart catch-all `[key: string]` `node` | `any` | `T` |

## Scope / Impact

- **No breaking changes** — backward compatible, `T` defaults to `TreeNode` / `OrganizationChartNode`
- **No runtime changes** — types only (.d.ts files)
- **3 components**: Tree, TreeSelect, OrganizationChart

## Verification

| Gate | Result |
|---|---|
| `pnpm run format:check` | PASS |
| `pnpm run lint` | PASS |
| `pnpm run test:unit` | Pre-existing failures only, 0 new |
| `pnpm run build:packages` | Pre-existing Windows build issue (`NODE_ENV=` syntax), 0 new |

## Series

This is part of a series bringing generic type inference to all PrimeVue data components:

| PR | Components | Status |
|---|---|---|
| #8444 | DataTable, DatePicker | Open |
| #8484 | Select, MultiSelect, Listbox | Open |
| #8485 | Column (phantom `of` prop) | Open |
| #8489 | AutoComplete, CascadeSelect, DataView | Open |
| #8490 | Carousel, Galleria, Timeline | Open |
| #8491 | OrderList, PickList | Open |
| #8493 | VirtualScroller, SelectButton, InputChips | Open |
| #8495 | Menubar, Menu, TieredMenu, MegaMenu, ContextMenu, PanelMenu, Breadcrumb, Steps, TabMenu, SplitButton, Dock, SpeedDial | Open |
| **#8497** | **Tree, TreeSelect, OrganizationChart** | **This PR** |

After this series, every PrimeVue component with a collection prop will infer `T` from the binding and flow it to slots — giving developers full IDE autocomplete and compile-time type safety in templates.
