### PR TITLE
fix(KeyFilter): restore invalid IME input to last valid value

### DIFF
--- a/packages/primevue/src/keyfilter/KeyFilter.js
+++ b/packages/primevue/src/keyfilter/KeyFilter.js
@@ -67,7 +67,9 @@ const KeyFilter = BaseKeyFilter.extend('keyfilter', {
             el.$_keyfilterKeydownEvent = (event) => this.onKeydown(event, el);
             el.$_keyfilterBeforeInputEvent = (event) => this.onBeforeInput(event, el);
             el.$_keyfilterPasteEvent = (event) => this.onPaste(event, el);
+            // Keep Vue's model in sync by restoring invalid IME text before bubble-phase listeners run.
             el.$_keyfilterInputEvent = () => this.syncValue(el);
+            // IME composition can bypass beforeinput cancellation, so validate again when composition finishes.
             el.$_keyfilterCompositionEndEvent = () => this.syncValue(el);
 
             el.addEventListener('keypress', el.$_keyfilterKeydownEvent);
@@ -101,6 +103,7 @@ const KeyFilter = BaseKeyFilter.extend('keyfilter', {
                 return;
             }
 
+            // Block cancelable direct insertions early; non-cancelable IME paths are handled by syncValue.
             const regex = this.getRegex(target);
 
             if (regex === '') {


### PR DESCRIPTION
Fix #6724 

## Background

The existing `KeyFilter` primarily relied on blocking individual key inputs. Because of this, in IME environments such as Korean composition input, disallowed characters could bypass the filter and remain in the input value.

As a result, even when using numeric presets such as `v-keyfilter.int` or `v-keyfilter.num`, Korean jamo or composed Korean characters could still end up in the final value.

## Changes

This update changes the behavior so that disallowed IME input cannot remain in the final value.

The logic now works in two stages:

1. For cancelable browser input paths such as direct typing, invalid input is blocked early in `beforeinput`.
2. For input paths where pre-blocking is unreliable, such as IME composition, the value is restored to the last valid value during `input` and `compositionend`.

In practice, characters may briefly appear during composition, but invalid Korean input will no longer persist in the final DOM value or the `v-model` value.

## Implementation Details

- Added state on the input element to store the last valid value.
- Added `beforeinput` handling to proactively block cancelable direct insertions such as `insertText`.
- Moved `input` validation to the capture phase so restoration happens before Vue updates `v-model`.
- Applied the same restoration logic on `compositionend` to ensure invalid values do not remain after IME composition finishes.
- When `validateOnly` is enabled, the entire input value is validated against the provided regular expression.
- When `validateOnly` is disabled, validation now checks that every character in the input string matches the allowed pattern. This prevents invalid values from passing simply because they contain at least one allowed character.

## Expected Impact

- Preset filters such as numeric and alphabetic filters will no longer allow Korean characters to remain in the final value.
- Input value and model value stay consistent even when browser or IME behavior makes `beforeinput` blocking unreliable.
- Existing key-based and paste-based filtering behavior remains intact, with IME-safe fallback handling added on top.
- the implementation is based on generic IME/composition event handling and should also benefit other composition-based input methods.