### PR TITLE
fix(DataTable, Column): convert date inputs to Date object before comparing their strings

### DIFF
--- a/packages/core/src/api/FilterService.js
+++ b/packages/core/src/api/FilterService.js
@@ -190,8 +190,10 @@ const FilterService = {
             if (value === undefined || value === null) {
                 return false;
             }
-
-            return value.toDateString() === filter.toDateString();
+            
+            const valueAsDate = new Date(value);
+            const filterAsDate = new Date(filter);
+            return valueAsDate.toDateString() === filterAsDate.toDateString();
         },
         dateIsNot(value, filter) {
             if (filter === undefined || filter === null) {
@@ -202,7 +204,9 @@ const FilterService = {
                 return false;
             }
 
-            return value.toDateString() !== filter.toDateString();
+            const valueAsDate = new Date(value);
+            const filterAsDate = new Date(filter);
+            return valueAsDate.toDateString() !== filterAsDate.toDateString();
         },
         dateBefore(value, filter) {
             if (filter === undefined || filter === null) {
@@ -213,7 +217,9 @@ const FilterService = {
                 return false;
             }
 
-            return value.getTime() < filter.getTime();
+            const valueAsDate = new Date(value);
+            const filterAsDate = new Date(filter);
+            return valueAsDate.getTime() < filterAsDate.getTime();
         },
         dateAfter(value, filter) {
             if (filter === undefined || filter === null) {
@@ -224,7 +230,9 @@ const FilterService = {
                 return false;
             }
 
-            return value.getTime() > filter.getTime();
+            const valueAsDate = new Date(value);
+            const filterAsDate = new Date(filter);
+            return valueAsDate.getTime() > filterAsDate.getTime();
         }
     },
     register(rule, fn) {


### PR DESCRIPTION
DataTable Date column filters break if a) the column data are strings, which is common when collecting data from an API that transmits as JSON; or b) the filters use some input type other than DatePicker that does not return a Date object, such as a native `<input type="date">` element.

This PR adds guardrails to `FilterService.js` that converts the inputs to `Date` objects before comparing them.

This PR resolves https://github.com/primefaces/primevue/issues/8506
