### PR TITLE
fix(select): ignore option select when overlay is hidden

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -498,6 +498,7 @@ export default {
             focus(focusableEl);
         },
         onOptionSelect(event, option, isHide = true) {
+            if(!this.overlayVisible) return;
             const value = this.getOptionValue(option);
             this.updateModel(event, value);
             isHide && this.hide(true);


### PR DESCRIPTION
## Summary

Prevents `onOptionSelect` from updating the model when the dropdown overlay is not visible, avoiding incorrect commits due to event timing (e.g. `mousedown` after the panel has started closing).

**Closes** #8508

## Changes

- Early return in `onOptionSelect` when `!overlayVisible` before `updateModel` / `hide`.

## Testing

- [ ] Manual: open `Select`, choose an option — value updates and panel closes as before.
- [ ] Manual: regression check for keyboard (Enter with overlay open, arrow navigation).