### PR TITLE
fix(docs): corrected typo "CND" to "CDN"

### DIFF
--- a/apps/showcase/pages/cdn/index.vue
+++ b/apps/showcase/pages/cdn/index.vue
@@ -8,7 +8,7 @@
             <div class="doc-intro">
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
                     <div class="flex-1">
-                        <h1>Install PrimeVue with CND</h1>
+                        <h1>Install PrimeVue with CDN</h1>
                         <p>Setting up PrimeVue in a project using CDN.</p>
                     </div>
                     <DocCopyMarkdown docType="page" class="flex-shrink-0" />


### PR DESCRIPTION
Corrected a typo where "CDN" was mistakenly written as "CND" in the documentation.
Updated the source file (apps/showcase/pages/cdn/index.vue). 

Some generated files such as component.json, llms-full.txt, llms.txt, cdn.md were not included to avoid unnecessary changes. If required, I would be happy to generate them.