### PR TITLE
DatePicker: improve accessibility semantics, correct SR announcements and keyboard focus behavior

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -37,7 +37,9 @@
             :pt="ptm('pcInputText')"
         />
         <slot v-if="showClear && !inline" name="clearicon" :class="cx('clearIcon')" :clearCallback="onClearClick">
-            <TimesIcon ref="clearIcon" :class="[cx('clearIcon')]" @click="onClearClick" v-bind="ptm('clearIcon')" />
+            <button ref="clearIcon" type="button" :class="cx('clearIcon')" :aria-label="$primevue.config.locale.clear" @click="onClearClick" v-bind="ptm('clearIcon')">
+                <TimesIcon aria-hidden="true" />
+            </button>
         </slot>
         <slot v-if="showIcon && iconDisplay === 'button' && !inline" name="dropdownbutton" :toggleCallback="onButtonClick">
             <button
@@ -57,11 +59,23 @@
             </button>
         </slot>
         <template v-else-if="showIcon && iconDisplay === 'input' && !inline">
-            <span v-if="$slots.inputicon || showIcon" :class="cx('inputIconContainer')" :data-p="inputIconDataP" v-bind="ptm('inputIconContainer')">
+            <button
+                v-if="$slots.inputicon || showIcon"
+                :class="cx('inputIconContainer')"
+                :data-p="inputIconDataP"
+                :disabled="disabled"
+                type="button"
+                :aria-label="$primevue.config.locale.chooseDate"
+                aria-haspopup="dialog"
+                :aria-expanded="overlayVisible"
+                :aria-controls="overlayVisible ? panelId : undefined"
+                @click="onButtonClick"
+                v-bind="ptm('inputIconContainer')"
+            >
                 <slot name="inputicon" :class="cx('inputIcon')" :clickCallback="onButtonClick">
-                    <component :is="icon ? 'i' : 'CalendarIcon'" :class="[icon, cx('inputIcon')]" @click="onButtonClick" v-bind="ptm('inputicon')" />
+                    <component :is="icon ? 'i' : 'CalendarIcon'" :class="[icon, cx('inputIcon')]" v-bind="ptm('inputicon')" />
                 </slot>
-            </span>
+            </button>
         </template>
         <Portal :appendTo="appendTo" :disabled="inline">
             <transition name="p-anchored-overlay" @enter="onOverlayEnter($event)" @after-enter="onOverlayEnterComplete" @after-leave="onOverlayAfterLeave" @leave="onOverlayLeave" v-bind="ptm('transition')">
@@ -72,7 +86,6 @@
                     :class="[cx('panel'), panelClass]"
                     :style="panelStyle"
                     :role="inline ? null : 'dialog'"
-                    :aria-modal="inline ? null : 'true'"
                     :aria-label="$primevue.config.locale.chooseDate"
                     @click="onOverlayClick"
                     @keydown="onOverlayKeyDown"
@@ -115,7 +128,7 @@
                                                 @keydown="onContainerButtonKeydown"
                                                 :class="cx('selectYear')"
                                                 :disabled="switchViewButtonDisabled"
-                                                :aria-label="$primevue.config.locale.chooseYear"
+                                                :aria-label="getYearButtonAriaLabel(month)"
                                                 v-bind="ptm('selectYear')"
                                                 data-pc-group-section="view"
                                             >
@@ -128,7 +141,7 @@
                                                 @keydown="onContainerButtonKeydown"
                                                 :class="cx('selectMonth')"
                                                 :disabled="switchViewButtonDisabled"
-                                                :aria-label="$primevue.config.locale.chooseMonth"
+                                                :aria-label="getMonthButtonAriaLabel(month)"
                                                 v-bind="ptm('selectMonth')"
                                                 data-pc-group-section="view"
                                             >
@@ -143,7 +156,7 @@
                                                 @keydown="onContainerButtonKeydown"
                                                 :class="cx('selectMonth')"
                                                 :disabled="switchViewButtonDisabled"
-                                                :aria-label="$primevue.config.locale.chooseMonth"
+                                                :aria-label="getMonthButtonAriaLabel(month)"
                                                 v-bind="ptm('selectMonth')"
                                                 data-pc-group-section="view"
                                             >
@@ -156,7 +169,7 @@
                                                 @keydown="onContainerButtonKeydown"
                                                 :class="cx('selectYear')"
                                                 :disabled="switchViewButtonDisabled"
-                                                :aria-label="$primevue.config.locale.chooseYear"
+                                                :aria-label="getYearButtonAriaLabel(month)"
                                                 v-bind="ptm('selectYear')"
                                                 data-pc-group-section="view"
                                             >
@@ -189,7 +202,7 @@
                                         </Button>
                                     </slot>
                                 </div>
-                                <table v-if="currentView === 'date'" :class="cx('dayView')" role="grid" v-bind="ptm('dayView')">
+                                <table v-if="currentView === 'date'" :class="cx('dayView')" role="grid" :aria-label="getCalendarAriaLabel(month)" v-bind="ptm('dayView')">
                                     <thead v-bind="ptm('tableHeader')">
                                         <tr v-bind="ptm('tableHeaderRow')">
                                             <th v-if="showWeek" scope="col" :class="cx('weekHeader')" v-bind="ptm('weekHeader', { context: { disabled: showWeek } })" :data-p-disabled="showWeek" data-pc-group-section="tableheadercell">
@@ -217,8 +230,15 @@
                                             <td
                                                 v-for="date of week"
                                                 :key="date.day + '' + date.month"
-                                                :aria-label="date.day"
+                                                :aria-label="getDateAriaLabel(date)"
+                                                role="gridcell"
                                                 :class="cx('dayCell', { date })"
+                                                :aria-selected="isSelected(date)"
+                                                :aria-disabled="!date.selectable"
+                                                :data-p-disabled="!date.selectable"
+                                                :data-p-selected="isSelected(date)"
+                                                @click="onDateSelect($event, date)"
+                                                @keydown="onDateCellKeydown($event, date, groupIndex)"
                                                 v-bind="
                                                     ptm('dayCell', {
                                                         context: {
@@ -238,11 +258,7 @@
                                                     v-if="showOtherMonths || !date.otherMonth"
                                                     v-ripple
                                                     :class="cx('day', { date })"
-                                                    @click="onDateSelect($event, date)"
                                                     draggable="false"
-                                                    @keydown="onDateCellKeydown($event, date, groupIndex)"
-                                                    :aria-selected="isSelected(date)"
-                                                    :aria-disabled="!date.selectable"
                                                     v-bind="
                                                         ptm('day', {
                                                             context: {
@@ -269,9 +285,10 @@
                             </div>
                         </div>
                         <div v-if="currentView === 'month'" :class="cx('monthView')" v-bind="ptm('monthView')">
-                            <span
+                            <button
                                 v-for="(m, i) of monthPickerValues"
                                 :key="m"
+                                type="button"
                                 v-ripple
                                 @click="onMonthSelect($event, { month: m, index: i })"
                                 @keydown="onMonthCellKeydown($event, { month: m, index: i })"
@@ -293,12 +310,13 @@
                                 <div v-if="isMonthSelected(i)" class="p-hidden-accessible" aria-live="polite" v-bind="ptm('hiddenMonth')" :data-p-hidden-accessible="true">
                                     {{ m.value }}
                                 </div>
-                            </span>
+                            </button>
                         </div>
                         <div v-if="currentView === 'year'" :class="cx('yearView')" v-bind="ptm('yearView')">
-                            <span
+                            <button
                                 v-for="y of yearPickerValues"
                                 :key="y.value"
+                                type="button"
                                 v-ripple
                                 @click="onYearSelect($event, y)"
                                 @keydown="onYearCellKeydown($event, y)"
@@ -319,7 +337,7 @@
                                 <div v-if="isYearSelected(y.value)" class="p-hidden-accessible" aria-live="polite" v-bind="ptm('hiddenYear')" :data-p-hidden-accessible="true">
                                     {{ y.value }}
                                 </div>
-                            </span>
+                            </button>
                         </div>
                     </template>
                     <div v-if="(showTime || timeOnly) && currentView === 'date'" :class="cx('timePicker')" :data-p="timePickerDataP" v-bind="ptm('timePicker')">
@@ -621,15 +639,17 @@ export default {
             queryMatches: false,
             queryOrientation: null,
             focusedDateIndex: 0,
-            rawValue: null
+            rawValue: null,
+            suppressFocusOpen: false
         };
     },
     watch: {
         modelValue: {
             immediate: true,
             handler(newValue) {
-                this.updateCurrentMetaData();
                 this.rawValue = typeof newValue === 'string' ? this.parseValue(newValue) : newValue;
+
+                this.updateCurrentMetaData();
 
                 if (!this.typeUpdate && !this.inline && this.input) {
                     this.input.value = this.formatValue(this.rawValue);
@@ -637,9 +657,7 @@ export default {
 
                 this.typeUpdate = false;
 
-                if (this.$refs.clearIcon?.$el?.style) {
-                    this.$refs.clearIcon.$el.style.display = isEmpty(newValue) ? 'none' : 'block';
-                }
+                this.updateClearIconVisibility(!isEmpty(newValue));
             }
         },
         showTime() {
@@ -693,9 +711,7 @@ export default {
         } else {
             this.input.value = this.inputFieldValue;
 
-            if (this.$refs.clearIcon?.$el?.style) {
-                this.$refs.clearIcon.$el.style.display = !this.$filled ? 'none' : 'block';
-            }
+            this.updateClearIconVisibility(this.$filled);
         }
     },
     updated() {
@@ -1222,7 +1238,7 @@ export default {
                 return;
             }
 
-            find(this.overlay, 'table td span:not([data-p-disabled="true"])').forEach((cell) => (cell.tabIndex = -1));
+            find(this.overlay, 'table td[role="gridcell"]:not([data-p-disabled="true"])').forEach((cell) => (cell.tabIndex = -1));
 
             if (event) {
                 event.currentTarget.focus();
@@ -1245,12 +1261,14 @@ export default {
             }
 
             if (this.isSingleSelection() && (!this.showTime || this.hideOnDateTimeSelect)) {
-                if (this.input) {
-                    this.input.focus();
-                }
-
                 setTimeout(() => {
                     this.overlayVisible = false;
+
+                    // Return keyboard focus to the trigger input after panel closes.
+                    if (this.input) {
+                        this.suppressFocusOpen = true;
+                        setTimeout(() => this.input?.focus(), 0);
+                    }
                 }, 150);
             }
         },
@@ -2186,14 +2204,13 @@ export default {
         },
         onDateCellKeydown(event, date, groupIndex) {
             event.preventDefault();
-            const cellContent = event.currentTarget;
-            const cell = cellContent.parentElement;
+            const cell = event.currentTarget;
 
             const cellIndex = getIndex(cell);
 
             switch (event.code) {
                 case 'ArrowDown': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
 
                     let nextRow = cell.parentElement.nextElementSibling;
 
@@ -2203,13 +2220,13 @@ export default {
                         const nextTableRows = tableRows.slice(tableRowIndex + 1);
 
                         let hasNextFocusableDate = nextTableRows.find((el) => {
-                            let focusCell = el.children[cellIndex].children[0];
+                            let focusCell = el.children[cellIndex];
 
                             return !getAttribute(focusCell, 'data-p-disabled');
                         });
 
                         if (hasNextFocusableDate) {
-                            let focusCell = hasNextFocusableDate.children[cellIndex].children[0];
+                            let focusCell = hasNextFocusableDate.children[cellIndex];
 
                             focusCell.tabIndex = '0';
                             focusCell.focus();
@@ -2227,7 +2244,7 @@ export default {
                 }
 
                 case 'ArrowUp': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
 
                     if (event.altKey) {
                         this.overlayVisible = false;
@@ -2241,13 +2258,13 @@ export default {
                             const prevTableRows = tableRows.slice(0, tableRowIndex).reverse();
 
                             let hasNextFocusableDate = prevTableRows.find((el) => {
-                                let focusCell = el.children[cellIndex].children[0];
+                                let focusCell = el.children[cellIndex];
 
                                 return !getAttribute(focusCell, 'data-p-disabled');
                             });
 
                             if (hasNextFocusableDate) {
-                                let focusCell = hasNextFocusableDate.children[cellIndex].children[0];
+                                let focusCell = hasNextFocusableDate.children[cellIndex];
 
                                 focusCell.tabIndex = '0';
                                 focusCell.focus();
@@ -2266,7 +2283,7 @@ export default {
                 }
 
                 case 'ArrowLeft': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     let prevCell = cell.previousElementSibling;
 
                     if (prevCell) {
@@ -2274,13 +2291,13 @@ export default {
                         const prevCells = cells.slice(0, cellIndex).reverse();
 
                         let hasNextFocusableDate = prevCells.find((el) => {
-                            let focusCell = el.children[0];
+                            let focusCell = el;
 
                             return !getAttribute(focusCell, 'data-p-disabled');
                         });
 
                         if (hasNextFocusableDate) {
-                            let focusCell = hasNextFocusableDate.children[0];
+                            let focusCell = hasNextFocusableDate;
 
                             focusCell.tabIndex = '0';
                             focusCell.focus();
@@ -2296,20 +2313,20 @@ export default {
                 }
 
                 case 'ArrowRight': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     let nextCell = cell.nextElementSibling;
 
                     if (nextCell) {
                         const cells = Array.from(cell.parentElement.children);
                         const nextCells = cells.slice(cellIndex + 1);
                         let hasNextFocusableDate = nextCells.find((el) => {
-                            let focusCell = el.children[0];
+                            let focusCell = el;
 
                             return !getAttribute(focusCell, 'data-p-disabled');
                         });
 
                         if (hasNextFocusableDate) {
-                            let focusCell = hasNextFocusableDate.children[0];
+                            let focusCell = hasNextFocusableDate;
 
                             focusCell.tabIndex = '0';
                             focusCell.focus();
@@ -2348,9 +2365,9 @@ export default {
                 }
 
                 case 'Home': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     let currentRow = cell.parentElement;
-                    let focusCell = currentRow.children[0].children[0];
+                    let focusCell = currentRow.children[0];
 
                     if (getAttribute(focusCell, 'data-p-disabled')) {
                         this.navigateToMonth(event, true, groupIndex);
@@ -2364,9 +2381,9 @@ export default {
                 }
 
                 case 'End': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     let currentRow = cell.parentElement;
-                    let focusCell = currentRow.children[currentRow.children.length - 1].children[0];
+                    let focusCell = currentRow.children[currentRow.children.length - 1];
 
                     if (getAttribute(focusCell, 'data-p-disabled')) {
                         this.navigateToMonth(event, false, groupIndex);
@@ -2380,7 +2397,7 @@ export default {
                 }
 
                 case 'PageUp': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     if (event.shiftKey) {
                         this.navigationState = { backward: true };
                         this.navBackward(event);
@@ -2391,7 +2408,7 @@ export default {
                 }
 
                 case 'PageDown': {
-                    cellContent.tabIndex = '-1';
+                    cell.tabIndex = '-1';
                     if (event.shiftKey) {
                         this.navigationState = { backward: false };
                         this.navForward(event);
@@ -2413,7 +2430,7 @@ export default {
                     this.navBackward(event);
                 } else {
                     let prevMonthContainer = this.overlay.children[groupIndex - 1];
-                    let cells = find(prevMonthContainer, 'table td span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                    let cells = find(prevMonthContainer, 'table td[role="gridcell"]:not([data-p-disabled="true"])');
                     let focusCell = cells[cells.length - 1];
 
                     focusCell.tabIndex = '0';
@@ -2425,7 +2442,7 @@ export default {
                     this.navForward(event);
                 } else {
                     let nextMonthContainer = this.overlay.children[groupIndex + 1];
-                    let focusCell = findSingle(nextMonthContainer, 'table td span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                    let focusCell = findSingle(nextMonthContainer, 'table td[role="gridcell"]:not([data-p-disabled="true"])');
 
                     focusCell.tabIndex = '0';
                     focusCell.focus();
@@ -2641,7 +2658,7 @@ export default {
                         } else if (this.currentView === 'year') {
                             cells = find(this.overlay, '[data-pc-section="yearview"] [data-pc-section="year"]:not([data-p-disabled="true"])');
                         } else {
-                            cells = find(this.overlay, 'table td span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                            cells = find(this.overlay, 'table td[role="gridcell"]:not([data-p-disabled="true"])');
                         }
 
                         if (cells && cells.length > 0) {
@@ -2653,7 +2670,7 @@ export default {
                         } else if (this.currentView === 'year') {
                             cell = findSingle(this.overlay, '[data-pc-section="yearview"] [data-pc-section="year"]:not([data-p-disabled="true"])');
                         } else {
-                            cell = findSingle(this.overlay, 'table td span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                            cell = findSingle(this.overlay, 'table td[role="gridcell"]:not([data-p-disabled="true"])');
                         }
                     }
 
@@ -2684,19 +2701,21 @@ export default {
                 cells.forEach((cell) => (cell.tabIndex = -1));
                 cell = selectedCell || cells[0];
             } else {
-                cell = findSingle(this.overlay, 'span[data-p-selected="true"]');
+                let cells = find(this.overlay, 'table td[role="gridcell"]');
+
+                cells.forEach((gridCell) => (gridCell.tabIndex = -1));
+                cell = findSingle(this.overlay, 'td[role="gridcell"][data-p-selected="true"]');
 
                 if (!cell) {
-                    let todayCell = findSingle(this.overlay, 'td[data-p-today="true"] span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                    let todayCell = findSingle(this.overlay, 'td[role="gridcell"][data-p-today="true"]:not([data-p-disabled="true"])');
 
                     if (todayCell) cell = todayCell;
-                    else cell = findSingle(this.overlay, '.p-datepicker-calendar td span:not([data-p-disabled="true"]):not([data-p-ink="true"])');
+                    else cell = findSingle(this.overlay, 'table td[role="gridcell"]:not([data-p-disabled="true"])');
                 }
             }
 
             if (cell) {
                 cell.tabIndex = '0';
-
                 this.preventFocus = false;
             }
         },
@@ -2718,10 +2737,14 @@ export default {
                             if (this.timeOnly) {
                                 focusableElements[0].focus();
                             } else {
-                                let elementIndex = focusableElements.findIndex((el) => el.tagName === 'SPAN');
+                                let elementIndex = focusableElements.findIndex((el) => el.tagName === 'TD');
 
                                 if (elementIndex === -1) {
                                     elementIndex = focusableElements.findIndex((el) => el.tagName === 'BUTTON');
+                                }
+
+                                if (elementIndex === -1) {
+                                    elementIndex = focusableElements.findIndex((el) => el.tagName === 'SPAN');
                                 }
 
                                 if (elementIndex !== -1) {
@@ -2757,14 +2780,22 @@ export default {
 
             this.$emit('keydown', event);
         },
+        getClearIconElement() {
+            return this.$refs.clearIcon?.$el || this.$refs.clearIcon;
+        },
+        updateClearIconVisibility(visible) {
+            const clearIconEl = this.getClearIconElement();
+
+            if (clearIconEl?.style) {
+                clearIconEl.style.display = visible ? 'block' : 'none';
+            }
+        },
         onInput(event) {
             try {
                 this.selectionStart = this.input.selectionStart;
                 this.selectionEnd = this.input.selectionEnd;
 
-                if (this.$refs.clearIcon?.$el?.style) {
-                    this.$refs.clearIcon.$el.style.display = isEmpty(event.target.value) ? 'none' : 'block';
-                }
+                this.updateClearIconVisibility(!isEmpty(event.target.value));
 
                 let value = this.parseValue(event.target.value);
 
@@ -2785,7 +2816,9 @@ export default {
             }
         },
         onFocus(event) {
-            if (this.showOnFocus && this.isEnabled()) {
+            if (this.suppressFocusOpen) {
+                this.suppressFocusOpen = false;
+            } else if (this.showOnFocus && this.isEnabled()) {
                 this.overlayVisible = true;
             }
 
@@ -2799,9 +2832,7 @@ export default {
             this.focused = false;
             event.target.value = this.formatValue(this.rawValue);
 
-            if (this.$refs.clearIcon?.$el?.style) {
-                this.$refs.clearIcon.$el.style.display = isEmpty(event.target.value) ? 'none' : 'block';
-            }
+            this.updateClearIconVisibility(!isEmpty(event.target.value));
         },
         onKeyDown(event) {
             if (event.code === 'ArrowDown' && this.overlay) {
@@ -2823,16 +2854,23 @@ export default {
                     this.overlayVisible = false;
                 }
             } else if (event.code === 'Enter') {
+                let handled = false;
+
                 if (this.manualInput && event.target.value !== null && event.target.value?.trim() !== '') {
                     try {
                         let value = this.parseValue(event.target.value);
 
                         if (this.isValidSelection(value)) {
                             this.overlayVisible = false;
+                            handled = true;
                         }
                     } catch (err) {
                         /* NoOp */
                     }
+                }
+
+                if (handled) {
+                    event.preventDefault();
                 }
 
                 this.$emit('keydown', event);
@@ -2853,12 +2891,33 @@ export default {
         getMonthName(index) {
             return this.$primevue.config.locale.monthNames[index];
         },
+        getCalendarAriaLabel(month) {
+            return `${this.getMonthName(month.month)} ${month.year} calendar`;
+        },
+        getDateAriaLabel(dateMeta) {
+            const date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
+            const dayName = this.$primevue.config.locale.dayNames[date.getDay()];
+            const monthName = this.$primevue.config.locale.monthNames[dateMeta.month];
+
+            return `${dayName}, ${monthName} ${dateMeta.day}, ${dateMeta.year}`;
+        },
+        getMonthButtonAriaLabel(month) {
+            return `${this.$primevue.config.locale.chooseMonth}: ${this.getMonthName(month.month)} ${month.year}`;
+        },
+        getYearButtonAriaLabel(month) {
+            return `${this.$primevue.config.locale.chooseYear}: ${this.getYear(month)}`;
+        },
         getYear(month) {
             return this.currentView === 'month' ? this.currentYear : month.year;
         },
         onClearClick() {
             this.updateModel(null);
             this.overlayVisible = false;
+
+            if (this.input) {
+                this.suppressFocusOpen = true;
+                setTimeout(() => this.input?.focus(), 0);
+            }
         },
         onOverlayClick(event) {
             event.stopPropagation();
@@ -2957,14 +3016,18 @@ export default {
                         propValue = propValue[0];
                     } else {
                         const start = this.parseValueForComparison(propValue[0]);
-                        let lastVisibleMonth = new Date(start.getFullYear(), start.getMonth() + this.numberOfMonths, 1);
+                        const end = this.parseValueForComparison(propValue[1]);
 
-                        if (propValue[1] < lastVisibleMonth) {
-                            propValue = propValue[0];
+                        if (this.showTime) {
+                            propValue = end;
                         } else {
-                            const end = this.parseValueForComparison(propValue[1]);
+                            let lastVisibleMonth = new Date(start.getFullYear(), start.getMonth() + this.numberOfMonths, 1);
 
-                            propValue = new Date(end.getFullYear(), end.getMonth() - this.numberOfMonths + 1, 1);
+                            if (propValue[1] < lastVisibleMonth) {
+                                propValue = propValue[0];
+                            } else {
+                                propValue = new Date(end.getFullYear(), end.getMonth() - this.numberOfMonths + 1, 1);
+                            }
                         }
                     }
                 } else if (this.isMultipleSelection()) {

--- a/packages/primevue/src/datepicker/style/DatePickerStyle.js
+++ b/packages/primevue/src/datepicker/style/DatePickerStyle.js
@@ -5,6 +5,21 @@ const inlineStyles = {
     root: ({ props }) => ({ position: props.appendTo === 'self' || props.showClear ? 'relative' : undefined })
 };
 
+const css = () => `
+.p-datepicker-day-cell:focus,
+.p-datepicker-day-cell:focus-visible {
+    outline: none;
+}
+
+.p-datepicker-day-cell:focus-visible .p-datepicker-day {
+    outline-width: var(--p-datepicker-date-focus-ring-width);
+    outline-style: var(--p-datepicker-date-focus-ring-style);
+    outline-color: var(--p-datepicker-date-focus-ring-color);
+    outline-offset: var(--p-datepicker-date-focus-ring-offset);
+    box-shadow: var(--p-datepicker-date-focus-ring-shadow);
+}
+`;
+
 const classes = {
     root: ({ instance, state }) => [
         'p-datepicker p-component p-inputwrapper',
@@ -101,6 +116,7 @@ const classes = {
 
 export default BaseStyle.extend({
     name: 'datepicker',
+    css,
     style,
     classes,
     inlineStyles


### PR DESCRIPTION

This PR improves DatePicker accessibility semantics, screen reader announcement, and keyboard/focus behavior.

### What changed

- Added/updated ARIA semantics for DatePicker triggers (dialog relationship and expanded state).
- Improved input-icon trigger accessibility parity.
- Refined keyboard handling for `Enter` to avoid unnecessary `preventDefault`.
- Improved calendar grid focus behavior (gridcell-focused navigation flow).
- Updated clear action behavior to:
  - clear model value,
  - close overlay,
  - restore focus to input safely without reopening the panel immediately.
 - Correct screen reader announcements

### Why

These changes improve screen reader and keyboard UX while preserving existing component behavior as much as possible.

## Validation

- Ran DatePicker unit tests:
  - `src/datepicker/DatePicker.spec.js` passes.

- Ran a11y automated tool (used axe DevTools)
  - Before:
  
<img width="1346" height="632" alt="Screenshot 2026-03-27 at 1 55 53 PM" src="https://github.com/user-attachments/assets/523f7a39-71dc-4657-a3a1-2934d28f1f06" />

 - After:
 
 
<img width="1344" height="427" alt="Screenshot 2026-03-27 at 2 01 34 PM" src="https://github.com/user-attachments/assets/c3397a68-b495-42d0-968d-133af9cd8520" />


- Tested with screen reader (used Voiceover)
 

## Notes

- Scope intentionally kept narrow to DatePicker behavior/accessibility.
- No intended functional changes outside DatePicker.