### PR TITLE
fix(galleria): zindex clear throws error when container is unmounted in fullscreen

### DIFF
--- a/packages/primevue/src/galleria/Galleria.vue
+++ b/packages/primevue/src/galleria/Galleria.vue
@@ -46,7 +46,8 @@ export default {
         this.mask = null;
 
         if (this.container) {
-            ZIndex.clear(this.container);
+            const el = typeof this.container.nodeType === 'number' ? this.container : this.container.$el;
+            if (el) ZIndex.clear(el);
             this.container = null;
         }
     },


### PR DESCRIPTION
### Defect fixes
Fixes #8519

In fullscreen mode, `Galleria` sets `containerRef` to the **GalleriaContent component instance** (a Vue ref to a child component), not to a DOM node.

In `beforeUnmount`, the code called `ZIndex.clear(this.container)`. `@primeuix/utils` `ZIndex.clear` expects an `HTMLElement` and uses `parseInt(element.style.zIndex, 10)`. A component proxy has no `style`, so this throws:
`TypeError: Cannot read properties of undefined (reading 'zIndex')`

This often appears when navigating away while a fullscreen Galleria was open (e.g. product create page with an image gallery). Stack traces can land in unrelated chunks (e.g. Toast / `useToast`) because of bundling, but the failing call is `ZIndex.clear` with a non-element `container`.

**Root cause:** In the fullscreen branch, `:ref="containerRef"` is bound to `GalleriaContent`, so `this.container` is a component instance, not an `Element`.

**Reproducer:** Mount `Galleria` with `fullScreen` and `visible` true, then unmount the parent (e.g. route change) while the overlay is still mounted — `beforeUnmount` runs and `ZIndex.clear` receives the component instance.

https://stackblitz.com/edit/primevue-4-galleria-zindex-issue (I used hotreload invalidate to simulate a route change, to make this simple, check error in console)

## Problem
```vue
<!-- Simplified: fullscreen Galleria with visible content -->
<Galleria :value="items" full-screen v-model:visible="visible" />