### PR TITLE
fix: inconsistent baseZIndex handling

### DIFF
--- a/packages/primevue/src/blockui/BlockUI.vue
+++ b/packages/primevue/src/blockui/BlockUI.vue
@@ -70,7 +70,7 @@ export default {
             }
 
             if (this.autoZIndex) {
-                ZIndex.set('modal', this.mask, this.baseZIndex + this.$primevue.config.zIndex.modal);
+                ZIndex.set('modal', this.mask, this.baseZIndex || this.$primevue.config.zIndex.modal);
             }
 
             this.isBlocked = true;

--- a/packages/primevue/src/colorpicker/ColorPicker.vue
+++ b/packages/primevue/src/colorpicker/ColorPicker.vue
@@ -358,7 +358,7 @@ export default {
             this.bindResizeListener();
 
             if (this.autoZIndex) {
-                ZIndex.set('overlay', el, this.baseZIndex + this.$primevue.config.zIndex.overlay);
+                ZIndex.set('overlay', el, this.baseZIndex || this.$primevue.config.zIndex.overlay);
             }
 
             // Issue: #7508

--- a/packages/primevue/src/contextmenu/ContextMenu.vue
+++ b/packages/primevue/src/contextmenu/ContextMenu.vue
@@ -363,7 +363,7 @@ export default {
             this.position();
 
             if (this.autoZIndex) {
-                ZIndex.set('menu', el, this.baseZIndex + this.$primevue.config.zIndex.menu);
+                ZIndex.set('menu', el, this.baseZIndex || this.$primevue.config.zIndex.menu);
             }
         },
         onAfterEnter() {

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -129,7 +129,7 @@ export default {
             this.bindGlobalListeners();
 
             if (this.autoZIndex) {
-                ZIndex.set('modal', this.mask, this.baseZIndex + this.$primevue.config.zIndex.modal);
+                ZIndex.set('modal', this.mask, this.baseZIndex || this.$primevue.config.zIndex.modal);
             }
         },
         onAfterEnter() {

--- a/packages/primevue/src/menu/Menu.vue
+++ b/packages/primevue/src/menu/Menu.vue
@@ -267,7 +267,7 @@ export default {
             this.bindScrollListener();
 
             if (this.autoZIndex) {
-                ZIndex.set('menu', el, this.baseZIndex + this.$primevue.config.zIndex.menu);
+                ZIndex.set('menu', el, this.baseZIndex || this.$primevue.config.zIndex.menu);
             }
 
             if (this.popup) {

--- a/packages/primevue/src/popover/Popover.d.ts
+++ b/packages/primevue/src/popover/Popover.d.ts
@@ -128,7 +128,7 @@ export interface PopoverProps {
      * Base zIndex value to use in layering.
      * @defaultValue 0
      */
-    baseZIndex?: number;
+    baseZIndex?: number | undefined;
     /**
      * Whether to automatically manage layering.
      * @defaultValue true

--- a/packages/primevue/src/popover/Popover.vue
+++ b/packages/primevue/src/popover/Popover.vue
@@ -116,7 +116,7 @@ export default {
             this.bindResizeListener();
 
             if (this.autoZIndex) {
-                ZIndex.set('overlay', el, this.baseZIndex + this.$primevue.config.zIndex.overlay);
+                ZIndex.set('overlay', el, this.baseZIndex || this.$primevue.config.zIndex.overlay);
             }
 
             this.overlayEventListener = (e) => {

--- a/packages/primevue/src/tieredmenu/TieredMenu.vue
+++ b/packages/primevue/src/tieredmenu/TieredMenu.vue
@@ -416,7 +416,7 @@ export default {
         },
         onEnter(el) {
             if (this.autoZIndex) {
-                ZIndex.set('menu', el, this.baseZIndex + this.$primevue.config.zIndex.menu);
+                ZIndex.set('menu', el, this.baseZIndex || this.$primevue.config.zIndex.menu);
             }
 
             addStyle(el, { position: 'absolute', top: '0' });


### PR DESCRIPTION
Fixes #8523

`ZIndex.set` fully breaks (never sets `z-index` anymore until page reload) after being called with `NaN` (e.g., 0 + undefined).  `this.$primevue.config.zIndex.<zIndexGroup>` can be undefined by setting `app.config.globalProperties.$primevue.config.zIndex = {}`.

Regardless, it doesn't really make sense to have only a few `ZIndex.set()` with `+` instead of `||`. Before https://github.com/primefaces/primevue/commit/b910825a84b635414ab847a16f0a8fc4a2ec416f, all `ZIndex.set()` were using just baseZIndex with the autogenerated zIndex or just the autogenerated zIndex, but somehow some of them were changed to the version with `+` and some of them with `||`. To keep the previous behavior and make baseZIndex work as expected (it is THE base zIndex for this component, which means it should overwrite the global zIndex config value), I suggest using `||` everywhere.
