### PR TITLE
FIX: sync rawValue and input display for DatePicker when d_value changes via Form initialValues

### DIFF
--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -1,136 +1,173 @@
 <script>
-import { isNotEmpty } from '@primeuix/utils';
-import BaseComponent from '@primevue/core/basecomponent';
-
+import { isNotEmpty } from "@primeuix/utils";
+import BaseComponent from "@primevue/core/basecomponent";
 export default {
-    name: 'BaseEditableHolder',
-    extends: BaseComponent,
-    emits: ['update:modelValue', 'value-change'],
-    props: {
-        modelValue: {
-            type: null,
-            default: undefined
-        },
-        defaultValue: {
-            type: null,
-            default: undefined
-        },
-        name: {
-            type: String,
-            default: undefined
-        },
-        invalid: {
-            type: Boolean,
-            default: undefined
-        },
-        disabled: {
-            type: Boolean,
-            default: false
-        },
-        formControl: {
-            type: Object,
-            default: undefined
-        }
+  name: "BaseEditableHolder",
+  extends: BaseComponent,
+  emits: ["update:modelValue", "value-change"],
+  props: {
+    modelValue: {
+      type: null,
+      default: undefined,
     },
-    inject: {
-        $parentInstance: {
-            default: undefined
-        },
-        $pcForm: {
-            default: undefined
-        },
-        $pcFormField: {
-            default: undefined
-        }
+    defaultValue: {
+      type: null,
+      default: undefined,
     },
-    data() {
-        return {
-            d_value: this.defaultValue !== undefined ? this.defaultValue : this.modelValue
-        };
+    name: {
+      type: String,
+      default: undefined,
     },
-    watch: {
-        modelValue: {
-            deep: true,
-            handler(newValue) {
-                this.d_value = newValue;
-            }
-        },
-        defaultValue(newValue) {
-            this.d_value = newValue;
-        },
-        $formName: {
-            immediate: true,
-            handler(newValue) {
-                this.formField = this.$pcForm?.register?.(newValue, this.$formControl) || {};
-            }
-        },
-        $formControl: {
-            immediate: true,
-            handler(newValue) {
-                this.formField = this.$pcForm?.register?.(this.$formName, newValue) || {};
-            }
-        },
-        $formDefaultValue: {
-            immediate: true,
-            handler(newValue) {
-                this.d_value !== newValue && (this.d_value = newValue);
-            }
-        },
-        $formValue: {
-            immediate: false,
-            handler(newValue) {
-                if (this.$pcForm?.getFieldState(this.$formName) && newValue !== this.d_value) {
-                    this.d_value = newValue;
-                }
-            }
-        }
+    invalid: {
+      type: Boolean,
+      default: undefined,
     },
-    formField: {},
-    methods: {
-        writeValue(value, event) {
-            if (this.controlled) {
-                this.d_value = value;
-                this.$emit('update:modelValue', value);
-            }
-
-            this.$emit('value-change', value);
-
-            this.formField.onChange?.({ originalEvent: event, value });
-        },
-        // @todo move to @primeuix/utils
-        findNonEmpty(...values) {
-            return values.find(isNotEmpty);
-        }
+    disabled: {
+      type: Boolean,
+      default: false,
     },
-    computed: {
-        $filled() {
-            return isNotEmpty(this.d_value);
-        },
-        $invalid() {
-            return !this.$formNovalidate && this.findNonEmpty(this.invalid, this.$pcFormField?.$field?.invalid, this.$pcForm?.getFieldState(this.$formName)?.invalid);
-        },
-        $formName() {
-            return !this.$formNovalidate ? this.name || this.$formControl?.name : undefined;
-        },
-        $formControl() {
-            return this.formControl || this.$pcFormField?.formControl;
-        },
-        $formNovalidate() {
-            return this.$formControl?.novalidate;
-        },
-        $formDefaultValue() {
-            return this.findNonEmpty(this.d_value, this.$pcFormField?.initialValue, this.$pcForm?.initialValues?.[this.$formName]);
-        },
-        $formValue() {
-            return this.findNonEmpty(this.$pcFormField?.$field?.value, this.$pcForm?.getFieldState(this.$formName)?.value);
-        },
-        controlled() {
-            return this.$inProps.hasOwnProperty('modelValue') || (!this.$inProps.hasOwnProperty('modelValue') && !this.$inProps.hasOwnProperty('defaultValue'));
-        },
-        // @deprecated use $filled instead
-        filled() {
-            return this.$filled;
+    formControl: {
+      type: Object,
+      default: undefined,
+    },
+  },
+  inject: {
+    $parentInstance: {
+      default: undefined,
+    },
+    $pcForm: {
+      default: undefined,
+    },
+    $pcFormField: {
+      default: undefined,
+    },
+  },
+  data() {
+    return {
+      d_value:
+        this.defaultValue !== undefined ? this.defaultValue : this.modelValue,
+    };
+  },
+  watch: {
+    modelValue: {
+      deep: true,
+      handler(newValue) {
+        this.d_value = newValue;
+      },
+    },
+    defaultValue(newValue) {
+      this.d_value = newValue;
+    },
+    $formName: {
+      immediate: true,
+      handler(newValue) {
+        this.formField =
+          this.$pcForm?.register?.(newValue, this.$formControl) || {};
+      },
+    },
+    $formControl: {
+      immediate: true,
+      handler(newValue) {
+        this.formField =
+          this.$pcForm?.register?.(this.$formName, newValue) || {};
+      },
+    },
+    $formDefaultValue: {
+      immediate: true,
+      handler(newValue) {
+        if (this.d_value !== newValue) {
+          this.d_value = newValue;
+          // FIX: déclenche la mise à jour visuelle de l'input
+          // pour les composants comme DatePicker qui ont updateInputfield()
+          this.$nextTick(() => {
+            this.updateInputfield?.();
+          });
         }
-    }
+      },
+    },
+    $formValue: {
+      immediate: false,
+      handler(newValue) {
+        if (
+          this.$pcForm?.getFieldState(this.$formName) &&
+          newValue !== this.d_value
+        ) {
+          this.d_value = newValue;
+          // FIX: idem for programatic update via setFieldValue
+          this.$nextTick(() => {
+            this.updateInputfield?.(); // updated DatePicker value
+          });
+        }
+      },
+    },
+  },
+  formField: {},
+  methods: {
+    writeValue(value, event) {
+      if (this.controlled) {
+        this.d_value = value;
+        this.$emit("update:modelValue", value);
+      }
+      this.$nextTick(() => {
+        this.updateInputfield?.();
+      });
+      this.$emit("value-change", value);
+      this.formField.onChange?.({ originalEvent: event, value });
+    },
+    // @todo move to @primeuix/utils
+    findNonEmpty(...values) {
+      return values.find(isNotEmpty);
+    },
+  },
+  computed: {
+    $filled() {
+      return isNotEmpty(this.d_value);
+    },
+    $invalid() {
+      return (
+        !this.$formNovalidate &&
+        this.findNonEmpty(
+          this.invalid,
+          this.$pcFormField?.$field?.invalid,
+          this.$pcForm?.getFieldState(this.$formName)?.invalid,
+        )
+      );
+    },
+    $formName() {
+      return !this.$formNovalidate
+        ? this.name || this.$formControl?.name
+        : undefined;
+    },
+    $formControl() {
+      return this.formControl || this.$pcFormField?.formControl;
+    },
+    $formNovalidate() {
+      return this.$formControl?.novalidate;
+    },
+    $formDefaultValue() {
+      return this.findNonEmpty(
+        this.d_value,
+        this.$pcFormField?.initialValue,
+        this.$pcForm?.initialValues?.[this.$formName],
+      );
+    },
+    $formValue() {
+      return this.findNonEmpty(
+        this.$pcFormField?.$field?.value,
+        this.$pcForm?.getFieldState(this.$formName)?.value,
+      );
+    },
+    controlled() {
+      return (
+        this.$inProps.hasOwnProperty("modelValue") ||
+        (!this.$inProps.hasOwnProperty("modelValue") &&
+          !this.$inProps.hasOwnProperty("defaultValue"))
+      );
+    },
+    // @deprecated use $filled instead
+    filled() {
+      return this.$filled;
+    },
+  },
 };
 </script>

--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -642,6 +642,21 @@ export default {
                 }
             }
         },
+        // FIX: sync rawValue and input display when d_value changes via Form initialValues
+        d_value: {
+            immediate: true,
+            handler(newValue) {
+                if (newValue === this.modelValue) return;
+                this.rawValue = typeof newValue === 'string' ? this.safeParse(newValue) : newValue;
+                this.updateCurrentMetaData();
+                if (!this.inline && this.input) {
+                    this.input.value = this.formatValue(this.rawValue);
+                }
+                if (this.$refs.clearIcon?.$el?.style) {
+                    this.$refs.clearIcon.$el.style.display = isEmpty(newValue) ? 'none' : 'block';
+                }
+            }
+        },
         showTime() {
             this.updateCurrentMetaData();
         },


### PR DESCRIPTION
When using a `DatePicker` component inside a PrimeVue `Form` component with `initialValues`, the input field remains visually empty even though the form state internally holds the correct value. The value is correctly passed, and other field types (e.g. `InputText`) populate as expected.

This is a regression: the same setup works correctly in version **4.3.1** but fails in **4.5.0** and above (confirmed on **4.5.5**).

Root cause (identified via source analysis): `DatePicker` maintains its own internal `rawValue` state that drives the visible input. When `BaseEditableHolder` sets `d_value` via the `$formDefaultValue` watcher, it does not trigger the `modelValue` watcher in `DatePicker`, so `rawValue` is never updated and the `<input>` element retains an empty display value.