### PR TITLE
feat: add dateEqualsAndAfter and dateEqualsAndBefore to FilterService

### DIFF
--- a/packages/core/src/api/Api.d.ts
+++ b/packages/core/src/api/Api.d.ts
@@ -16,6 +16,8 @@ export interface FilterMatchModeOptions {
     readonly DATE_IS_NOT: string;
     readonly DATE_BEFORE: string;
     readonly DATE_AFTER: string;
+    readonly DATE_EQUALS_AND_AFTER: string;
+    readonly DATE_EQUALS_AND_BEFORE: string;
 }
 
 export declare const FilterMatchMode: FilterMatchModeOptions;
@@ -46,6 +48,8 @@ export declare namespace FilterService {
         dateIsNot(value: any, filter: string): boolean;
         dateBefore(value: any, filter: string): boolean;
         dateAfter(value: any, filter: string): boolean;
+        dateEqualsAndAfter(value: any, filter: string): boolean;
+        dateEqualsAndBefore(value: any, filter: string): boolean;
     }
     export function register(rule: string, fn: (...arg: any[]) => boolean): void;
 }

--- a/packages/core/src/api/FilterMatchMode.js
+++ b/packages/core/src/api/FilterMatchMode.js
@@ -14,7 +14,9 @@ const FilterMatchMode = {
     DATE_IS: 'dateIs',
     DATE_IS_NOT: 'dateIsNot',
     DATE_BEFORE: 'dateBefore',
-    DATE_AFTER: 'dateAfter'
+    DATE_AFTER: 'dateAfter',
+    DATE_EQUALS_AND_AFTER : 'dateEqualsAndAfter',
+    DATE_EQUALS_AND_BEFORE : 'dateEqualsAndBefore'
 };
 
 export default FilterMatchMode;

--- a/packages/core/src/api/FilterService.js
+++ b/packages/core/src/api/FilterService.js
@@ -257,7 +257,29 @@ const FilterService = {
             }
 
             return value.getTime() > filter.getTime();
-        }
+        },
+        dateEqualsAndAfter: function dateEqualsAndAfter(value, filter) {
+            if (filter === undefined || filter === null) {
+                return true;
+            }
+
+            if (value === undefined || value === null) {
+                return false;
+            }
+
+            return value.getTime() >= filter.getTime();
+        },
+        dateEqualsAndBefore: function dateEqualsAndBefore(value, filter) {
+            if (filter === undefined || filter === null) {
+                return true;
+            }
+
+            if (value === undefined || value === null) {
+                return false;
+            }
+
+            return value.getTime() <= filter.getTime();
+        },
     },
     register(rule, fn) {
         this.filters[rule] = fn;


### PR DESCRIPTION
### Description
This PR adds `dateEqualsAndAfter` and `dateEqualsAndBefore` match modes to the FilterService. 

### Why is this needed?
Currently, PrimeVue has `dateBefore` and `dateAfter`, but in many real-world scenarios (like selecting a date range in a calendar), we need to include the selected date itself in the filter results. These new modes provide a cleaner way to handle "less than or equal to" and "greater than or equal to" logic for dates.

### Changes
- Added `DATE_EQUALS_AND_AFTER` and `DATE_EQUALS_AND_BEFORE` to `FilterMatchModeOptions`.
- Implemented `dateEqualsAndAfter` and `dateEqualsAndBefore` logic in `FilterService`.