### PR TITLE
fix(tablist): fix tablist timer not cleared on unmount

### DIFF
--- a/packages/primevue/src/tablist/TabList.vue
+++ b/packages/primevue/src/tablist/TabList.vue
@@ -58,6 +58,7 @@ export default {
     },
     resizeObserver: undefined,
     inkBarObserver: undefined,
+    mountTimer: undefined,
     watch: {
         showNavigators(newValue) {
             newValue ? this.bindResizeObserver() : this.unbindResizeObserver();
@@ -71,7 +72,8 @@ export default {
         }
     },
     mounted() {
-        setTimeout(() => {
+        this.mountTimer = setTimeout(() => {
+            this.mountTimer = undefined;
             this.updateInkBar();
             this.bindInkBarObserver();
         }, 150);
@@ -85,6 +87,7 @@ export default {
         this.showNavigators && this.updateButtonState();
     },
     beforeUnmount() {
+        clearTimeout(this.mountTimer);
         this.unbindResizeObserver();
         this.unbindInkBarObserver();
     },


### PR DESCRIPTION
The mounted hook in TabList schedules a setTimeout to update the ink bar after 150ms.
If the component unmounts before that timer fires, the callback runs against a destroyed instance, causing errors.

This fix stores the timer ID in this.mountTimer and calls clearTimeout in beforeUnmount.