### PR TITLE
fix datepicker to not show clear icon when disabled

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -36,7 +36,7 @@
             :data-p-has-e-icon="showIcon && iconDisplay === 'input' && !inline"
             :pt="ptm('pcInputText')"
         />
-        <slot v-if="showClear && !inline" name="clearicon" :class="cx('clearIcon')" :clearCallback="onClearClick">
+        <slot v-if="isClearIconVisible && !inline" name="clearicon" :class="cx('clearIcon')" :clearCallback="onClearClick">
             <TimesIcon ref="clearIcon" :class="[cx('clearIcon')]" @click="onClearClick" v-bind="ptm('clearIcon')" />
         </slot>
         <slot v-if="showIcon && iconDisplay === 'button' && !inline" name="dropdownbutton" :toggleCallback="onButtonClick">


### PR DESCRIPTION
When a DatePicker is disabled, it should not show a 'clear' icon even when the 'showClear' attribute is present:

<DatePicker :disabled="true" showClear />

This fix uses the isClearIconVisible function in the same way it is also used in other components like Password or Select

