### PR TITLE
docs(floatlabel): fix syntax error in composition api example

### DIFF
--- a/apps/showcase/doc/floatlabel/VariantsDoc.vue
+++ b/apps/showcase/doc/floatlabel/VariantsDoc.vue
@@ -61,8 +61,8 @@ export default {
 <\/script>
 `,
                 composition: `
-<div class="card flex flex-wrap justify-center items-end gap-4">
-    <div class="card flex flex-wrap justify-center gap-4">
+<template>
+    <div class="card flex flex-wrap justify-center items-end gap-4">
         <FloatLabel variant="in">
             <InputText id="in_label" v-model="value1" autocomplete="off" />
             <label for="in_label">In Label</label>


### PR DESCRIPTION
Fixed a missing <template> tag and an unclosed <div> in the FloatLabel Variant documentation's composition API snippet.

And I also create an issue documenting the error.


<img width="1920" height="860" alt="1" src="https://github.com/user-attachments/assets/57098f23-939d-4155-ac5b-124bd0fa65f5" />
<img width="1920" height="880" alt="2" src="https://github.com/user-attachments/assets/506c409a-1322-414a-88e0-556909823a1c" />
