### PR TITLE
fix(Dialog): provide headerId to header slot

### DIFF
--- a/packages/primevue/src/dialog/Dialog.spec.js
+++ b/packages/primevue/src/dialog/Dialog.spec.js
@@ -122,3 +122,96 @@ describe('maximizable', () => {
         expect(icon.classes()).toContain('pi-facebook');
     });
 });
+
+describe('ariaLabelledById', () => {
+    it('should not set aria-labelledby when showHeader is false', async () => {
+        const wrapper = mount(Dialog, {
+            global: {
+                plugins: [PrimeVue],
+                stubs: {
+                    teleport: true
+                }
+            },
+            props: {
+                visible: false,
+                showHeader: false,
+                header: 'Test Header'
+            },
+            data() {
+                return {
+                    containerVisible: true
+                };
+            }
+        });
+
+        await wrapper.setProps({ visible: true });
+
+        const dialog = wrapper.find('[role="dialog"]');
+
+        expect(dialog.attributes('aria-labelledby')).toBeUndefined();
+    });
+
+    it('should set aria-labelledby when showHeader is true and header prop is provided', async () => {
+        const wrapper = mount(Dialog, {
+            global: {
+                plugins: [PrimeVue],
+                stubs: {
+                    teleport: true
+                }
+            },
+            props: {
+                visible: false,
+                showHeader: true,
+                header: 'Test Header'
+            },
+            data() {
+                return {
+                    containerVisible: true
+                };
+            }
+        });
+
+        await wrapper.setProps({ visible: true });
+
+        const dialog = wrapper.find('[role="dialog"]');
+
+        const ariaLabelledBy = dialog.attributes('aria-labelledby');
+
+        expect(ariaLabelledBy).toContain('_header');
+
+        const headerSpan = wrapper.find(`#${ariaLabelledBy}`);
+
+        expect(headerSpan.text()).toBe('Test Header');
+    });
+
+    it('should provide id to custom header slot', async () => {
+        const wrapper = mount(Dialog, {
+            global: {
+                plugins: [PrimeVue],
+                stubs: {
+                    teleport: true
+                }
+            },
+            props: {
+                visible: false
+            },
+            slots: {
+                header: `<template #header="{ headerId }"><h2 :id="headerId">Custom Header</h2></template>`
+            },
+            data() {
+                return {
+                    containerVisible: true
+                };
+            }
+        });
+
+        await wrapper.setProps({ visible: true });
+
+        const dialog = wrapper.find('[role="dialog"]');
+        const ariaLabelledBy = dialog.attributes('aria-labelledby');
+        const headerSpan = wrapper.find(`#${ariaLabelledBy}`);
+
+        expect(ariaLabelledBy).toContain('_header');
+        expect(headerSpan.attributes('id')).toBe(ariaLabelledBy);
+    });
+});

--- a/packages/primevue/src/dialog/Dialog.vue
+++ b/packages/primevue/src/dialog/Dialog.vue
@@ -6,7 +6,7 @@
                     <slot v-if="$slots.container" name="container" :closeCallback="close" :maximizeCallback="(event) => maximize(event)" :initDragCallback="initDrag"></slot>
                     <template v-else>
                         <div v-if="showHeader" :ref="headerContainerRef" :class="cx('header')" @mousedown="initDrag" v-bind="ptm('header')">
-                            <slot name="header" :class="cx('title')">
+                            <slot name="header" :class="cx('title')" :headerId="ariaLabelledById">
                                 <span v-if="header" :id="ariaLabelledById" :class="cx('title')" v-bind="ptm('title')">{{ header }}</span>
                             </slot>
                             <div :class="cx('headerActions')" v-bind="ptm('headerActions')">
@@ -404,7 +404,7 @@ export default {
             return this.maximized ? (this.minimizeIcon ? 'span' : 'WindowMinimizeIcon') : this.maximizeIcon ? 'span' : 'WindowMaximizeIcon';
         },
         ariaLabelledById() {
-            return this.header != null || this.$attrs['aria-labelledby'] !== null ? this.$id + '_header' : null;
+            return this.showHeader && (this.header != null || this.$slots.header || this.$attrs['aria-labelledby'] !== null) ? this.$id + '_header' : null;
         },
         closeAriaLabel() {
             return this.$primevue.config.locale.aria ? this.$primevue.config.locale.aria.close : undefined;


### PR DESCRIPTION
- Providing headerId to header slot to make sure ariaLabelledById can be referenced in customer header slot
- Extend condition for the ariaLabelledById. We won't generate ariaLabelledById  if showHeader is false
- Add unit tests for ariaLabelledById test cases

### Defect Fixes

Closes [Issue](https://github.com/primefaces/primevue/issues/8547)

### Feature Requests

Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
