### PR TITLE
fix(inputnumber): form does not submit on enter

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.spec.js
+++ b/packages/primevue/src/inputnumber/InputNumber.spec.js
@@ -41,6 +41,13 @@ describe('InputNumber.vue', () => {
         expect(wrapper.find('input.p-inputnumber-input').attributes()['aria-valuenow']).toBe('12');
     });
 
+    it('is keydown called when enter key pressed on virtual keyboard', async () => {
+        await wrapper.vm.onInputKeyDown({ code: '', key: 'Enter', target: { value: '12' }, preventDefault: () => {} });
+
+        expect(wrapper.emitted()['update:modelValue'][0]).toEqual([12]);
+        expect(wrapper.find('input.p-inputnumber-input').attributes()['aria-valuenow']).toBe('12');
+    });
+
     it('is keypress called when pressed a number', async () => {
         wrapper.find('input.p-inputnumber-input').element.setSelectionRange(2, 2);
 

--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -379,7 +379,7 @@ export default {
             }
         },
         onUpButtonKeyDown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === 'Space' || event.key === 'Enter' || event.code === 'NumpadEnter') {
                 this.repeat(event, null, 1);
             }
         },
@@ -406,7 +406,7 @@ export default {
             }
         },
         onDownButtonKeyDown(event) {
-            if (event.code === 'Space' || event.code === 'Enter' || event.code === 'NumpadEnter') {
+            if (event.key === 'Space' || event.key === 'Enter' || event.code === 'NumpadEnter') {
                 this.repeat(event, null, -1);
             }
         },
@@ -441,7 +441,9 @@ export default {
             let selectionRange = selectionEnd - selectionStart;
             let inputValue = event.target.value;
             let newValueStr = null;
-            const code = event.code || event.key;
+
+            // Will be empty string on Android and some ChromeOS devices
+            const code = event.code === '' ? event.key : (event.code ?? event.key);
 
             switch (code) {
                 case 'ArrowUp':
@@ -604,7 +606,7 @@ export default {
             let isDecimalSign = this.isDecimalSign(char);
             const isMinusSign = this.isMinusSign(char);
 
-            if (event.code !== 'Enter') {
+            if (event.key !== 'Enter') {
                 event.preventDefault();
             }
 


### PR DESCRIPTION
### Summary

Updates InputNumber to use the [key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) property on keyboard events. On some virtual keyboards (Android, ChromeOS) the [code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) property on keyboard events is set to an empty string.  

### Defect Fixes

Fixes #4199
