### PR TITLE
fix(datatable): fix filter overlay closing when interacting with nested overlay components

### DIFF
--- a/packages/primevue/src/datatable/ColumnFilter.vue
+++ b/packages/primevue/src/datatable/ColumnFilter.vue
@@ -539,9 +539,7 @@ export default {
             this.bindResizeListener();
 
             this.overlayEventListener = (e) => {
-                if (!this.isOutsideClicked(e.target)) {
-                    this.selfClick = true;
-                }
+                this.selfClick = true;
             };
 
             OverlayEventBus.on('overlay-click', this.overlayEventListener);
@@ -567,7 +565,8 @@ export default {
             this.overlay = el;
         },
         isOutsideClicked(target) {
-            return !this.isTargetClicked(target) && this.overlay && !(this.overlay.isSameNode(target) || this.overlay.contains(target));
+            const insideAnyOverlay = target.closest('[data-pc-section="panel"], [data-pc-section="overlay"]');
+            return !this.isTargetClicked(target) && this.overlay && !(this.overlay.isSameNode(target) || this.overlay.contains(target)) && !insideAnyOverlay;
         },
         isTargetClicked(target) {
             return this.$refs.icon && (this.$refs.icon.$el.isSameNode(target) || this.$refs.icon.$el.contains(target));
@@ -578,8 +577,9 @@ export default {
                     if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(event.target)) {
                         this.overlayVisible = false;
                     }
-
-                    this.selfClick = false;
+                    setTimeout(() => {
+                        this.selfClick = false;
+                    }, 0);
                 };
 
                 document.addEventListener('click', this.outsideClickListener, true);


### PR DESCRIPTION
## Description
When using components like MultiSelect, Select, or TreeSelect as custom 
filters inside a DataTable column, the filter overlay panel closed 
immediately upon interacting with any option.

## Root Cause
The `isOutsideClicked` method in `ColumnFilter` only checked if the 
clicked target was inside `this.overlay`. However, nested overlay panels 
(like MultiSelect dropdown) are appended to the body by default, so they 
exist outside `this.overlay` in the DOM, causing them to be incorrectly 
treated as outside clicks.

Additionally, the `overlayEventListener` had a condition that prevented 
`selfClick` from being set correctly for nested overlays.

## Fix
- Simplified `overlayEventListener` to always set `selfClick = true` 
  when any overlay-click event is received
- Updated `isOutsideClicked` to check if the target is inside any active 
  overlay panel using `closest('[data-pc-section="panel"], 
  [data-pc-section="overlay"]')`

## How to Test
1. Go to /datatable/#advanced_filter
2. Click the filter icon on the "Agent" column
3. Click any option in the MultiSelect, checkbox should toggle and 
   panel should stay open
4. Also verify clicking outside still correctly closes the panel

## Closes
Closes #8537
Closes #8213