### PR TITLE
fix(treeselect): reset selfClick after overlay click to prevent doubl…

### DIFF
--- a/packages/primevue/src/treeselect/TreeSelect.vue
+++ b/packages/primevue/src/treeselect/TreeSelect.vue
@@ -448,6 +448,10 @@ export default {
             });
 
             this.selfClick = true;
+
+            setTimeout(() => {
+                this.selfClick = false;
+            }, 0);
         },
         onOverlayKeydown(event) {
             if (event.code === 'Escape') this.hide();


### PR DESCRIPTION
## Description
Fixes #7966

When clicking on the header slot of a TreeSelect, the click-outside-to-close 
functionality required two outside clicks to close the panel instead of one.

## Root Cause
`onOverlayClick` sets `selfClick = true` when the overlay is clicked, which 
is correct for preventing the panel from closing. However it was never reset 
after the interaction completed, causing the next outside click to be 
incorrectly treated as a self-click and ignored.

## Fix
Added a `setTimeout(() => { this.selfClick = false }, 0)` at the end of 
`onOverlayClick` to reset the flag after all click events from that 
interaction have fired.

## How to Test
1. Go to /treeselect/#template
2. Open the TreeSelect panel
3. Click the header area ("Available Files")
4. Click outside — panel should close on first click ✅

## Closes
Closes #7966