### PR TITLE
fix(select): remove aria-controls when overlay is closed

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -41,7 +41,7 @@
             :aria-labelledby="ariaLabelledby"
             aria-haspopup="listbox"
             :aria-expanded="overlayVisible"
-            :aria-controls="$id + '_list'"
+            :aria-controls="overlayVisible ? $id + '_list' : undefined"
             :aria-activedescendant="focused ? focusedOptionId : undefined"
             :aria-invalid="invalid || undefined"
             :aria-disabled="disabled"


### PR DESCRIPTION
`aria-controls` should only reference the listbox when it exists in the DOM. Setting it unconditionally causes accessibility violations when the overlay is hidden — the referenced element is not present.

Follows the same pattern applied to other overlay components in #8162, where non editable `Select` was missed.

### Defect Fix
Closes #8586

<video src="https://github.com/user-attachments/assets/d60369b8-6ac6-47b7-98ca-2997a4af1832" alt="devtools showing aria-controls only present when opening the select dropdown"></video>