### PR TITLE
fix(forms): cleanup dynamically removed form fields

### DIFF
--- a/packages/core/src/baseeditableholder/BaseEditableHolder.vue
+++ b/packages/core/src/baseeditableholder/BaseEditableHolder.vue
@@ -86,6 +86,12 @@ export default {
         }
     },
     formField: {},
+    beforeUnmount() {
+        // PATCHED: unregister field and clear form state on unmount
+        if (this.$formName) {
+            this.$pcForm?.unregister?.(this.$formName)
+        }
+    },
     methods: {
         writeValue(value, event) {
             if (this.controlled) {

--- a/packages/forms/src/form/Form.vue
+++ b/packages/forms/src/form/Form.vue
@@ -46,6 +46,7 @@ export default {
             submit,
             register,
             onSubmit,
+            unregister: $form.unregister, // PATCHED: expose unregister method to child form components
             onReset,
             ...omit($form, ['handleSubmit', 'handleReset'])
         };

--- a/packages/forms/src/useform/index.js
+++ b/packages/forms/src/useform/index.js
@@ -240,6 +240,15 @@ export const useForm = (options = {}) => {
         if (_states[field] !== undefined) _states[field].value = value;
     };
 
+    const unregister = (field)  => {
+        // PATCHED: remove field state and stop reactive watchers
+        if (fields[field]) {
+            fields[field]._watcher.stop();
+            delete fields[field];
+        }
+        delete _states[field];
+    };
+
     const getFieldState = (field) => {
         return fields[field]?.states;
     };
@@ -257,6 +266,7 @@ export const useForm = (options = {}) => {
     return {
         defineField,
         setFieldValue,
+        unregister,
         getFieldState,
         handleSubmit,
         handleReset,


### PR DESCRIPTION
# Fix dynamic field cleanup in forms

Related issue: https://github.com/primefaces/primevue/issues/8408

## Problem

When dynamically removing form fields using `v-if`, `v-for`, or custom dynamic arrays, the field state was not properly cleaned up from the internal form store.

Although the component was destroyed, the following data remained registered internally:

* field state (`_states`)
* validation errors
* dirty/touched flags
* field watchers

This caused several issues:

* stale validation errors
* invalid form state after field removal
* orphan reactive watchers
* memory leaks
* removed fields still appearing in submit state

---

## Example

```vue id="pfy8z3"
<MyField v-if="visible" name="email" />
```

When `visible` becomes `false`, the component is unmounted visually, but the internal form state still contains:

```js id="u0j6lh"
_states.email
```

As a result:

* the form may still be invalid
* validation errors may still exist
* watchers continue reacting to changes

The same issue also affects dynamic arrays:

```vue id="m5j4cb"
<MyField
  v-for="(item, index) in items"
  :key="item.id"
  :name="`contacts.${index}.email`"
/>
```

Removing an item from the array leaves stale field states and watchers behind.

---

## Root Cause

`defineField()` registers field state and watchers internally, but there was no cleanup mechanism when a field component was unmounted.

As a result, dynamically removed fields remained inside:

```js id="z6x7ke"
fields
_states
```

---

## Solution

This PR introduces a new `unregister(field)` cleanup method in `useForm`.

The method now:

* stops the field watcher
* removes the field definition
* clears the internal field state

Field components automatically call `unregister()` during `beforeUnmount`.

---

## Result

Dynamic form fields are now properly cleaned up when removed.

This fixes:

* stale validation states
* lingering errors
* orphan watchers
* invalid form validity after field removal

and significantly improves dynamic form reliability.

---

## Test Reproduction

https://stackblitz.com/edit/vitejs-vite-pub96hsp
