### PR TITLE
docs: add Chinese (zh-CN) translation of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # PrimeVue MonoRepo
 
+English | [中文](./README.zh-CN.md)
+
 PrimeVue is a rich set of open source UI Components for Vue. See [PrimeVue homepage](https://primevue.org/) for live showcase and documentation.
 
 ## Packages

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,29 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Discord Chat](https://img.shields.io/discord/557940238991753223.svg?color=7289da&label=chat&logo=discord)](https://discord.gg/gzKFYnpmCY)
+[![Prime Discussions](https://img.shields.io/github/discussions-search?query=org%3Aprimefaces&logo=github&label=Prime%20Discussions&link=https%3A%2F%2Fgithub.com%2Forgs%2Fprimefaces%2Fdiscussions)](https://github.com/orgs/primefaces/discussions)
+
+[![PrimeVue Hero](https://www.primefaces.org/static/social/primevue-preview.jpg)](https://primevue.org/)
+
+# PrimeVue 仓库
+
+[English](./README.md) | 中文
+
+PrimeVue 是一套丰富的开源 Vue UI 组件库。访问 [PrimeVue 官网](https://primevue.org/) 查看在线演示和文档。
+
+## 包列表
+
+| 名称                                                                                                               | 版本                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| [primevue](https://github.com/primefaces/primevue/tree/master/packages/primevue)                                   | [![npm version](https://badge.fury.io/js/primevue.svg)](https://badge.fury.io/js/primevue)                                                 |
+| [@primevue/core](https://github.com/primefaces/primevue/tree/master/packages/core)                                 | [![npm version](https://badge.fury.io/js/@primevue%2Fcore.svg)](https://badge.fury.io/js/@primevue%2Fcore)                                 |
+| [@primevue/icons](https://github.com/primefaces/primevue/tree/master/packages/icons)                               | [![npm version](https://badge.fury.io/js/@primevue%2Ficons.svg)](https://badge.fury.io/js/@primevue%2Ficons)                               |
+| [@primevue/themes](https://github.com/primefaces/primevue/tree/master/packages/themes)                             | [![npm version](https://badge.fury.io/js/@primevue%2Fthemes.svg)](https://badge.fury.io/js/@primevue%2Fthemes)                             |
+| [@primevue/nuxt-module](https://github.com/primefaces/primevue/tree/master/packages/nuxt-module)                   | [![npm version](https://badge.fury.io/js/@primevue%2Fnuxt-module.svg)](https://badge.fury.io/js/@primevue%2Fnuxt-module)                   |
+| [@primevue/auto-import-resolver](https://github.com/primefaces/primevue/tree/master/packages/auto-import-resolver) | [![npm version](https://badge.fury.io/js/@primevue%2Fauto-import-resolver.svg)](https://badge.fury.io/js/@primevue%2Fauto-import-resolver) |
+| [@primevue/metadata](https://github.com/primefaces/primevue/tree/master/packages/metadata)                         | [![npm version](https://badge.fury.io/js/@primevue%2Fmetadata.svg)](https://badge.fury.io/js/@primevue%2Fmetadata)                         |
+
+## 贡献者
+
+<a href="https://github.com/primefaces/primevue/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=primefaces/primevue" />
+</a>


### PR DESCRIPTION
## Description

Add a Chinese (Simplified) translation of the README to help Chinese-speaking developers understand and use PrimeVue.

### Changes
- Added `README.zh-CN.md` with Chinese translation
- Updated `README.md` with language switch link (English | 中文)

### Motivation
PrimeVue is widely used by Chinese developers. Having a Chinese README will:
- Lower the barrier to entry for Chinese-speaking developers
- Improve accessibility and inclusivity
- Help grow the Chinese community