### PR TITLE
fix(treetable): respect selectable property in checkbox selection

### DIFF
--- a/packages/primevue/src/treetable/TreeTableRow.vue
+++ b/packages/primevue/src/treetable/TreeTableRow.vue
@@ -355,6 +355,8 @@ export default {
             });
         },
         propagateDown(node, check, selectionKeys) {
+            if (node.selectable === false) return;
+
             if (check) selectionKeys[this.nodeKey(node)] = { checked: true, partialChecked: false };
             else delete selectionKeys[this.nodeKey(node)];
 
@@ -369,20 +371,21 @@ export default {
             let _selectionKeys = { ...event.selectionKeys };
             let checkedChildCount = 0;
             let childPartialSelected = false;
+            let selectableChildren = this.node.children.filter((child) => child.selectable !== false);
 
-            for (let child of this.node.children) {
+            for (let child of selectableChildren) {
                 if (_selectionKeys[this.nodeKey(child)] && _selectionKeys[this.nodeKey(child)].checked) checkedChildCount++;
                 else if (_selectionKeys[this.nodeKey(child)] && _selectionKeys[this.nodeKey(child)].partialChecked) childPartialSelected = true;
             }
 
-            if (check && checkedChildCount === this.node.children.length) {
+            if (check && checkedChildCount === selectableChildren.length && selectableChildren.length > 0) {
                 _selectionKeys[this.nodeKey(this.node)] = { checked: true, partialChecked: false };
             } else {
                 if (!check) {
                     delete _selectionKeys[this.nodeKey(this.node)];
                 }
 
-                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== this.node.children.length)) _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: true };
+                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== selectableChildren.length)) _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: true };
                 else _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: false };
             }
 
@@ -397,20 +400,21 @@ export default {
             let _selectionKeys = { ...event.selectionKeys };
             let checkedChildCount = 0;
             let childPartialSelected = false;
+            let selectableChildren = this.node.children.filter((child) => child.selectable !== false);
 
-            for (let child of this.node.children) {
+            for (let child of selectableChildren) {
                 if (_selectionKeys[this.nodeKey(child)] && _selectionKeys[this.nodeKey(child)].checked) checkedChildCount++;
                 else if (_selectionKeys[this.nodeKey(child)] && _selectionKeys[this.nodeKey(child)].partialChecked) childPartialSelected = true;
             }
 
-            if (check && checkedChildCount === this.node.children.length) {
+            if (check && checkedChildCount === selectableChildren.length && selectableChildren.length > 0) {
                 _selectionKeys[this.nodeKey(this.node)] = { checked: true, partialChecked: false };
             } else {
                 if (!check) {
                     delete _selectionKeys[this.nodeKey(this.node)];
                 }
 
-                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== this.node.children.length)) _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: true };
+                if (childPartialSelected || (checkedChildCount > 0 && checkedChildCount !== selectableChildren.length)) _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: true };
                 else _selectionKeys[this.nodeKey(this.node)] = { checked: false, partialChecked: false };
             }
 


### PR DESCRIPTION
## Problem

When using `TreeTable` with `selectionMode="checkbox"`, if some children have `selectable: false`, clicking the parent node still selects all children including non-selectable ones. The parent is marked as `checked` instead of `partialChecked`.

## Root Cause

The `propagateDown()` method recursively selects all children without checking the `selectable` property. The `propagateUp()` and `onCheckboxChange()` methods count all children when determining the parent's checked state.

## Solution

1. **`propagateDown()`**: Skip nodes with `selectable: false` to prevent them from being selected
2. **`propagateUp()`**: Filter to count only selectable children when calculating parent state
3. **`onCheckboxChange()`**: Same filtering for consistent behavior

## Testing

1. Create a TreeTable with `selectionMode="checkbox"`
2. Add nodes with `selectable: false` property
3. Click parent checkbox → non-selectable children should not be selected
4. Parent should show `partialChecked` state when some children are not selectable

Fixes #8282