### PR TITLE
fix(inputmask): sync input on modelValue clear with unmask

### DIFF
--- a/packages/primevue/src/inputmask/InputMask.vue
+++ b/packages/primevue/src/inputmask/InputMask.vue
@@ -52,6 +52,9 @@ export default {
             if (newValue !== oldValue) {
                 this.updateValue();
             }
+        },
+        d_value(newValue) {
+            this.updateValue(false);
         }
     },
     mounted() {


### PR DESCRIPTION
## Summary

- Add a watch on \`d_value\` in InputMask that calls \`updateValue(false)\` to sync the input element when \`modelValue\` is programmatically changed
- Fixes the issue where clearing \`modelValue\` with \`unmask\` enabled left the displayed value out of sync

## Problem

When \`unmask\` is enabled and the parent programmatically clears \`modelValue\` (e.g. sets it to \`''\` or \`null\`):

1. The watch in \`BaseEditableHolder\` updates \`d_value\` to the new value
2. But InputMask does not react to \`d_value\` changes
3. The input element still displays the old masked value
4. The component emits \`update:modelValue\` with the stale unmasked value

## Fix

Add a watch on \`d_value\` in InputMask that calls \`this.updateValue(false)\`:

\`\`\`js
d_value(newValue) {
    this.updateValue(false);
}
\`\`\`

The \`updateValue(false)\` method:
- When \`d_value\` is empty: clears the input element and buffer
- When \`d_value\` has a value: formats and displays it correctly
- The \`false\` parameter prevents emitting back to the parent (avoiding loops)

Fixes #8570
