### PR TITLE
fix(inputnumber): allow negative value input with prefix prop

### DIFF
--- a/packages/primevue/src/inputnumber/InputNumber.vue
+++ b/packages/primevue/src/inputnumber/InputNumber.vue
@@ -704,11 +704,18 @@ export default {
 
             if (sign.isMinusSign) {
                 const isNewMinusSign = minusCharIndex === -1;
+                const prefixLength = (this.prefixChar || '').length;
 
-                if (selectionStart === 0 || selectionStart === currencyCharIndex + 1) {
+                if (selectionStart === 0 || selectionStart === currencyCharIndex + 1 || (isNewMinusSign && prefixLength > 0 && selectionStart === prefixLength)) {
                     newValueStr = inputValue;
 
-                    if (isNewMinusSign || selectionEnd !== 0) {
+                    if (isNewMinusSign) {
+                        if (prefixLength > 0 && selectionStart === prefixLength) {
+                            newValueStr = '-' + inputValue;
+                        } else {
+                            newValueStr = this.insertText(inputValue, text, 0, selectionEnd);
+                        }
+                    } else if (selectionEnd !== 0) {
                         newValueStr = this.insertText(inputValue, text, 0, selectionEnd);
                     }
 


### PR DESCRIPTION
Fixes #8560

## Problem

When using InputNumber with the `prefix` prop (e.g., `$`), entering negative values becomes impossible once the input already contains a number. The component correctly renders negative values if set programmatically, but user keyboard input for `-` is blocked.

The issue is in the `insert()` method's `isMinusSign` handling: it only checks for caret position at `0` or `currencyCharIndex + 1`, but doesn't account for custom prefix length.

## Fix

- Added `selectionStart === prefixLength` check to allow minus sign insertion right after the prefix
- When inserting minus at the prefix position, correctly prepends `-` before the entire string (including prefix)

## Reproduction

1. Create `<InputNumber prefix="$" />`
2. Enter a number (e.g., 123 → shows `$123`)
3. Place caret between `$` and `1` (position 1)
4. Type `-`
5. Before fix: nothing happens
6. After fix: value becomes `-$123`