### PR TITLE
fix(confirmpopup): prevent duplicate callback on rapid accept/reject clicks

### DIFF
--- a/packages/primevue/src/confirmdialog/ConfirmDialog.vue
+++ b/packages/primevue/src/confirmdialog/ConfirmDialog.vue
@@ -70,7 +70,8 @@ export default {
     data() {
         return {
             visible: false,
-            confirmation: null
+            confirmation: null,
+            closing: false
         };
     },
     mounted() {
@@ -81,6 +82,7 @@ export default {
 
             if (options.group === this.group) {
                 this.confirmation = options;
+                this.closing = false;
 
                 if (this.confirmation.onShow) {
                     this.confirmation.onShow();
@@ -104,6 +106,12 @@ export default {
     },
     methods: {
         accept() {
+            if (this.closing) {
+                return;
+            }
+
+            this.closing = true;
+
             if (this.confirmation.accept) {
                 this.confirmation.accept();
             }
@@ -111,6 +119,12 @@ export default {
             this.visible = false;
         },
         reject() {
+            if (this.closing) {
+                return;
+            }
+
+            this.closing = true;
+
             if (this.confirmation.reject) {
                 this.confirmation.reject();
             }

--- a/packages/primevue/src/confirmpopup/ConfirmPopup.vue
+++ b/packages/primevue/src/confirmpopup/ConfirmPopup.vue
@@ -79,7 +79,8 @@ export default {
             confirmation: null,
             autoFocusAccept: null,
             autoFocusReject: null,
-            target: null
+            target: null,
+            closing: false
         };
     },
     target: null,
@@ -98,6 +99,7 @@ export default {
             if (options.group === this.group) {
                 this.confirmation = options;
                 this.target = options.target;
+                this.closing = false;
 
                 if (this.confirmation.onShow) {
                     this.confirmation.onShow();
@@ -138,6 +140,12 @@ export default {
     },
     methods: {
         accept() {
+            if (this.closing) {
+                return;
+            }
+
+            this.closing = true;
+
             if (this.confirmation.accept) {
                 this.confirmation.accept();
             }
@@ -145,6 +153,12 @@ export default {
             this.visible = false;
         },
         reject() {
+            if (this.closing) {
+                return;
+            }
+
+            this.closing = true;
+
             if (this.confirmation.reject) {
                 this.confirmation.reject();
             }


### PR DESCRIPTION
Fixes #8557

## Problem

ConfirmDialog and ConfirmPopup fire accept/reject callbacks multiple times when buttons are rapidly clicked (double-click). This is because there is no debounce mechanism to prevent duplicate invocations.

## Solution

Added a `closing` flag to both ConfirmDialog and ConfirmPopup components that:
1. Is initialized to `false` and reset to `false` when a new confirmation is shown
2. Is set to `true` on the first accept/reject click
3. Prevents subsequent calls to accept/reject from executing the callback

This ensures the accept/reject callback is only fired once, even if the user double-clicks the button.