### PR TITLE
fix(core): prevent useStyle from retaining the mounting component

### DIFF
--- a/packages/core/src/usestyle/UseStyle.js
+++ b/packages/core/src/usestyle/UseStyle.js
@@ -3,7 +3,7 @@
  * https://github.com/vueuse
  */
 import { isClient, isExist, setAttribute, setAttributes } from '@primeuix/utils/dom';
-import { getCurrentInstance, nextTick, onMounted, readonly, ref, watch } from 'vue';
+import { getCurrentInstance, isRef, nextTick, onMounted, readonly, ref, watch } from 'vue';
 
 function tryOnMounted(fn, sync = true) {
     if (getCurrentInstance() && getCurrentInstance().components) onMounted(fn);
@@ -57,20 +57,28 @@ export function useStyle(css, options = {}) {
             first ? document.head.prepend(styleRef.value) : document.head.appendChild(styleRef.value);
             setAttribute(styleRef.value, 'data-primevue-style-id', _name);
             setAttributes(styleRef.value, _styleProps);
-            styleRef.value.onload = (event) => onStyleLoaded?.(event, { name: _name });
+            if (onStyleLoaded) {
+                styleRef.value.onload = (event) => onStyleLoaded(event, { name: _name });
+            }
+
             onStyleMounted?.(_name);
         }
 
         if (isLoaded.value) return;
 
-        stop = watch(
-            cssRef,
-            (value) => {
-                styleRef.value.textContent = value;
-                onStyleUpdated?.(_name);
-            },
-            { immediate: true }
-        );
+        if (isRef(css)) {
+            stop = watch(
+                cssRef,
+                (value) => {
+                    styleRef.value.textContent = value;
+                    onStyleUpdated?.(_name);
+                },
+                { immediate: true }
+            );
+        } else {
+            styleRef.value.textContent = cssRef.value;
+            onStyleUpdated?.(_name);
+        }
 
         isLoaded.value = true;
     };


### PR DESCRIPTION
## Summary
  
  `useStyle` appends a `<style>` element to `document.head` and never removes it. Two
  things attached during `load()` stay alive for as long as that element does, i.e. the
  lifetime of the page:
  
  - `styleRef.value.onload` is assigned on every load, even when no `onLoad` callback
    was passed. Every caller inside the library passes none.
  - `watch(cssRef, ..., { immediate: true })` registers a reactive effect, even when
    `css` is a plain string that can never change after the immediate run.
  
  For the common path (a static CSS string and no `onLoad` callback) neither does
  anything useful. Both keep the `useStyle` closure reachable after the owning component
  has unmounted, along with everything it transitively references, including the
  component instance the watch captures.

  ## Approach

  Both retentions are removed without changing existing behavior:

  - Assign `onload` only when an `onLoad` callback was actually provided.
  - When `css` is not a ref, write the element's `textContent` once instead of
    registering a watcher. When `css` is a ref, keep the `watch` so reactive input
    still updates the element.

  ## Changes

  `packages/core/src/usestyle/UseStyle.js`

  - Import `isRef` from `vue`.
  - `onload` is assigned only when an `onLoad` callback is passed.
  - `load()` writes `textContent` once for a non-reactive `css`. The `watch` path is
    unchanged for `isRef(css)`.

  ## Note

  One minor behavior change: passing a plain string as `css` and then mutating the
  returned `css` ref to update the stylesheet no longer takes effect. Pass a ref if you
  need live updates. The public signature types `css` as `string` and nothing in the
  library does this, so existing usage is unaffected.