### PR TITLE
fix(drawer): correct modal prop JSDoc typo

### DIFF
--- a/apps/showcase/doc/common/apidoc/index.json
+++ b/apps/showcase/doc/common/apidoc/index.json
@@ -28267,7 +28267,7 @@
                             "readonly": false,
                             "type": "boolean",
                             "default": "true",
-                            "description": "Whether to a modal layer behind the drawer."
+                            "description": "Whether to display a modal layer behind the drawer."
                         },
                         {
                             "name": "blockScroll",

--- a/apps/showcase/server/assets/llms/components.json
+++ b/apps/showcase/server/assets/llms/components.json
@@ -12475,7 +12475,7 @@
                         "name": "modal",
                         "type": "boolean",
                         "default": "true",
-                        "description": "Whether to a modal layer behind the drawer."
+                        "description": "Whether to display a modal layer behind the drawer."
                     },
                     {
                         "name": "blockScroll",

--- a/apps/showcase/server/assets/llms/components/drawer.md
+++ b/apps/showcase/server/assets/llms/components/drawer.md
@@ -636,7 +636,7 @@ const visible = ref(false);
 | showCloseIcon    | boolean                                                        | true    | Whether to display a close icon inside the panel.                          |
 | closeButtonProps | object                                                         | -       | Used to pass the custom value to read for the button inside the component. |
 | closeIcon        | string                                                         | -       | Icon to display in the drawer close button.                                |
-| modal            | boolean                                                        | true    | Whether to a modal layer behind the drawer.                                |
+| modal            | boolean                                                        | true    | Whether to display a modal layer behind the drawer.                                |
 | blockScroll      | boolean                                                        | false   | Whether background scroll should be blocked when drawer is visible.        |
 | dt               | any                                                            | -       | It generates scoped CSS variables using design tokens for the component.   |
 | pt               | PassThrough<DrawerPassThroughOptions>                          | -       | Used to pass attributes to DOM elements inside the component.              |

--- a/apps/showcase/server/assets/llms/llms-full.txt
+++ b/apps/showcase/server/assets/llms/llms-full.txt
@@ -17317,7 +17317,7 @@ const visible = ref(false);
 | showCloseIcon | boolean | true | Whether to display a close icon inside the panel. |
 | closeButtonProps | object | - | Used to pass the custom value to read for the button inside the component. |
 | closeIcon | string | - | Icon to display in the drawer close button. |
-| modal | boolean | true | Whether to a modal layer behind the drawer. |
+| modal | boolean | true | Whether to display a modal layer behind the drawer. |
 | blockScroll | boolean | false | Whether background scroll should be blocked when drawer is visible. |
 | dt | any | - | It generates scoped CSS variables using design tokens for the component. |
 | pt | PassThrough<DrawerPassThroughOptions> | - | Used to pass attributes to DOM elements inside the component. |

--- a/packages/mcp/data/components.json
+++ b/packages/mcp/data/components.json
@@ -12475,7 +12475,7 @@
                         "name": "modal",
                         "type": "boolean",
                         "default": "true",
-                        "description": "Whether to a modal layer behind the drawer."
+                        "description": "Whether to display a modal layer behind the drawer."
                     },
                     {
                         "name": "blockScroll",

--- a/packages/primevue/scripts/components/drawer.js
+++ b/packages/primevue/scripts/components/drawer.js
@@ -39,7 +39,7 @@ const DrawerProps = [
         name: 'modal',
         type: 'boolean',
         default: 'true',
-        description: 'Whether to a modal layer behind the sidebar.'
+        description: 'Whether to display a modal layer behind the drawer.'
     },
     {
         name: 'ariaCloseLabel',

--- a/packages/primevue/scripts/components/sidebar.js
+++ b/packages/primevue/scripts/components/sidebar.js
@@ -39,7 +39,7 @@ const SidebarProps = [
         name: 'modal',
         type: 'boolean',
         default: 'true',
-        description: 'Whether to a modal layer behind the sidebar.'
+        description: 'Whether to display a modal layer behind the sidebar.'
     },
     {
         name: 'ariaCloseLabel',

--- a/packages/primevue/src/drawer/Drawer.d.ts
+++ b/packages/primevue/src/drawer/Drawer.d.ts
@@ -172,7 +172,7 @@ export interface DrawerProps {
      */
     closeIcon?: string | undefined;
     /**
-     * Whether to a modal layer behind the drawer.
+     * Whether to display a modal layer behind the drawer.
      * @defaultValue true
      */
     modal?: boolean | undefined;


### PR DESCRIPTION
## Summary

Fixes a typo in the `modal` prop documentation for the Drawer component (and related generated docs).

**Before:** `Whether to a modal layer behind the drawer.`  
**After:** `Whether to display a modal layer behind the drawer.`

Also fixes `packages/primevue/scripts/components/drawer.js`, which incorrectly referred to "sidebar" instead of "drawer", and applies the same JSDoc fix to the legacy `sidebar.js`.