### PR TITLE
Fixed #8534 - DatePicker: manual input reverts to previous value in t…

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1969,7 +1969,7 @@ export default {
                 throw 'Invalid Time';
             }
 
-            this.pm = ampm.toLowerCase() === this.$primevue.config.locale.pm.toLowerCase() || ampm.toLowerCase() === 'pm';
+            this.pm = !!ampm && (ampm.toLowerCase() === this.$primevue.config.locale.pm.toLowerCase() || ampm.toLowerCase() === 'pm');
             let time = this.parseTime(timeString);
 
             value.setHours(time.hour);


### PR DESCRIPTION
…imeOnly (24h) mode

When typing a time in a DatePicker configured with `timeOnly` and the default 24-hour format, the parsing regex in `parseDateTime` does not capture an am/pm group, so `populateTime` is called with `ampm === undefined`. The subsequent `ampm.toLowerCase()` call then throws a TypeError, which is silently swallowed by the try/catch in `onInput`, leaving the model unchanged. On blur the input is reset from `rawValue`, so the typed value visibly reverts to the previous one.

Guard the `pm` assignment so it only inspects `ampm` when defined.

### Defect Fixes

When submitting a PR, please also create an issue documenting the error.

### Feature Requests

Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.

Closes #8534