### PR TITLE
fix: Chip aria-label on role-less root element

### DIFF
--- a/packages/primevue/src/chip/Chip.spec.js
+++ b/packages/primevue/src/chip/Chip.spec.js
@@ -25,6 +25,10 @@ describe('Chip.vue', () => {
         expect(wrapper.find('.p-chip-remove-icon').exists()).toBe(true);
     });
 
+    it('should not set aria-label on root when label is visible', () => {
+        expect(wrapper.find('.p-chip.p-component').attributes('aria-label')).toBeUndefined();
+    });
+
     it('should close icon work', async () => {
         await wrapper.find('.p-chip-remove-icon').trigger('click');
 

--- a/packages/primevue/src/chip/Chip.vue
+++ b/packages/primevue/src/chip/Chip.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="visible" :class="cx('root')" :aria-label="label" v-bind="ptmi('root')" :data-p="dataP">
+    <div v-if="visible" :class="cx('root')" v-bind="ptmi('root')" :data-p="dataP">
         <slot>
             <img v-if="image" :src="image" v-bind="ptm('image')" :class="cx('image')" />
             <component v-else-if="$slots.icon" :is="$slots.icon" :class="cx('icon')" v-bind="ptm('icon')" />


### PR DESCRIPTION
Fixes #8593

**Describe the bug**

`Chip` sets `aria-label` on its root `div`, even when the same text is already rendered visibly in `.p-chip-label`. This triggers an `aria-prohibited-attr` violation because `aria-label` is not allowed on a `div` without a valid role.

**Fix**

Remove `aria-label` from the Chip root. Visible label text remains in `.p-chip-label`. Consumers can still pass accessibility attributes through `pt` when needed.