### PR TITLE
Fix nuxt module published types path

### DIFF
--- a/packages/nuxt-module/package.json
+++ b/packages/nuxt-module/package.json
@@ -44,10 +44,10 @@
     },
     "publishConfig": {
         "main": "./dist/module.cjs",
-        "types": "./dist/types.d.ts",
+        "types": "./dist/module.d.ts",
         "exports": {
             ".": {
-                "types": "./dist/types.d.ts",
+                "types": "./dist/module.d.ts",
                 "import": "./dist/module.mjs",
                 "require": "./dist/module.cjs"
             }


### PR DESCRIPTION
## Summary

Updates the published type entry for `@primevue/nuxt-module` to point at `./dist/module.d.ts`, which is the declaration file currently included in the published package.

The package metadata currently points `publishConfig.types` and the export-map `types` condition at `./dist/types.d.ts`, but the npm package contains `dist/module.d.ts` instead.

## Verification

I verified this in a clean temporary consumer install with `@primevue/nuxt-module@4.5.5`, `typescript@5.9.3`, and `@types/node@24`.

Before the metadata change:

```text
index.ts(1,22): error TS7016: Could not find a declaration file for module '@primevue/nuxt-module'. .../node_modules/@primevue/nuxt-module/dist/module.cjs implicitly has an 'any' type.
```

After changing the package metadata to `./dist/module.d.ts`, the same `npx tsc --noEmit` check exits successfully.

Also verified the source metadata and ran `git diff --check` locally.