### PR TITLE
fix: prevent scroll listener binding when appendTo is set to 'self'

### DIFF
--- a/packages/primevue/src/datepicker/DatePicker.vue
+++ b/packages/primevue/src/datepicker/DatePicker.vue
@@ -1082,6 +1082,10 @@ export default {
             }
         },
         bindScrollListener() {
+            if (this.appendTo === 'self') {
+                return;
+            }
+
             if (!this.scrollHandler) {
                 this.scrollHandler = new ConnectedOverlayScrollHandler(this.$refs.container, () => {
                     if (this.overlayVisible) {


### PR DESCRIPTION
### Defect Fixes

Fixes https://github.com/primefaces/primevue/issues/8597

When `appendTo="self"`, the overlay panel is part of the component's DOM and scrolls naturally with its container. The `ConnectedOverlayScrollHandler` was firing on intermediate scrollable ancestors (e.g. a Dialog), closing the panel even though it stays aligned with the input.

Skip binding the scroll handler entirely when `appendTo="self"`.