### PR TITLE
fix(Select): guard filterInput ref in onOverlayEnter focus

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -724,7 +724,7 @@ export default {
             this.$attrSelector && el.setAttribute(this.$attrSelector, '');
 
             setTimeout(() => {
-                this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
+                this.autoFilterFocus && this.filter && this.$refs.filterInput && focus(this.$refs.filterInput.$el);
                 this.autoUpdateModel();
             }, 1);
         },


### PR DESCRIPTION
### Defect Fixes

Fixes https://github.com/primefaces/primevue/issues/8601

`Select`'s `onOverlayEnter` focuses the filter input on a 1ms `setTimeout`
without checking the ref still exists:

```js
setTimeout(() => {
    this.autoFilterFocus && this.filter && focus(this.$refs.filterInput.$el);
    this.autoUpdateModel();
}, 1);
```

This adds the same null guard already used by onOverlayLeave.