### PR TITLE
Fix/stepper a11y issues

### DIFF
--- a/packages/primevue/src/divider/Divider.vue
+++ b/packages/primevue/src/divider/Divider.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="cx('root')" :style="sx('root')" role="separator" :aria-orientation="layout" :data-p="dataP" v-bind="ptmi('root')">
+    <div :class="cx('root')" :style="sx('root')" :aria-orientation="layout" :data-p="dataP" v-bind="ptmi('root')">
         <div v-if="$slots.default" :class="cx('content')" :data-p="dataP" v-bind="ptm('content')">
             <slot></slot>
         </div>

--- a/packages/primevue/src/step/Step.vue
+++ b/packages/primevue/src/step/Step.vue
@@ -1,6 +1,6 @@
 <template>
     <component v-if="!asChild" :is="as" :class="cx('root')" role="presentation" :data-p-active="active" :data-p-disabled="isStepDisabled" :data-p="dataP" v-bind="getPTOptions('root')">
-        <button :id="id" :class="cx('header')" role="tab" type="button" :tabindex="isStepDisabled ? -1 : undefined" :aria-controls="ariaControls" :disabled="isStepDisabled" @click="onStepClick" :data-p="dataP" v-bind="getPTOptions('header')">
+        <button :id="id" :class="cx('header')" role="tab" type="button" :tabindex="isStepDisabled ? -1 : undefined" :disabled="isStepDisabled" @click="onStepClick" :data-p="dataP" v-bind="getPTOptions('header')">
             <span :class="cx('number')" :data-p="dataP" v-bind="getPTOptions('number')">{{ activeValue }}</span>
             <span :class="cx('title')" :data-p="dataP" v-bind="getPTOptions('title')">
                 <slot />
@@ -95,7 +95,6 @@ export default {
                     'aria-selected': this.active,
                     role: 'tab',
                     tabindex: this.disabled ? -1 : undefined,
-                    'aria-controls': this.ariaControls,
                     'data-pc-section': 'header',
                     disabled: this.isStepDisabled,
                     onClick: this.onStepClick

--- a/packages/primevue/src/step/Step.vue
+++ b/packages/primevue/src/step/Step.vue
@@ -1,5 +1,5 @@
 <template>
-    <component v-if="!asChild" :is="as" :class="cx('root')" :aria-current="active ? 'step' : undefined" role="presentation" :data-p-active="active" :data-p-disabled="isStepDisabled" :data-p="dataP" v-bind="getPTOptions('root')">
+    <component v-if="!asChild" :is="as" :class="cx('root')" role="presentation" :data-p-active="active" :data-p-disabled="isStepDisabled" :data-p="dataP" v-bind="getPTOptions('root')">
         <button :id="id" :class="cx('header')" role="tab" type="button" :tabindex="isStepDisabled ? -1 : undefined" :aria-controls="ariaControls" :disabled="isStepDisabled" @click="onStepClick" :data-p="dataP" v-bind="getPTOptions('header')">
             <span :class="cx('number')" :data-p="dataP" v-bind="getPTOptions('number')">{{ activeValue }}</span>
             <span :class="cx('title')" :data-p="dataP" v-bind="getPTOptions('title')">
@@ -84,7 +84,6 @@ export default {
             return {
                 root: {
                     role: 'presentation',
-                    'aria-current': this.active ? 'step' : undefined,
                     'data-pc-name': 'step',
                     'data-pc-section': 'root',
                     'data-p-disabled': this.isStepDisabled,
@@ -92,8 +91,10 @@ export default {
                 },
                 header: {
                     id: this.id,
+                    'aria-current': this.active ? 'step' : undefined,
+                    'aria-selected': this.active,
                     role: 'tab',
-                    taindex: this.disabled ? -1 : undefined,
+                    tabindex: this.disabled ? -1 : undefined,
                     'aria-controls': this.ariaControls,
                     'data-pc-section': 'header',
                     disabled: this.isStepDisabled,

--- a/packages/primevue/src/steplist/StepList.vue
+++ b/packages/primevue/src/steplist/StepList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="cx('root')" v-bind="ptmi('root')">
+    <div :class="cx('root')" v-bind="ptmi('root')" role="tablist">
         <slot />
     </div>
 </template>

--- a/packages/primevue/src/steppanel/StepPanel.vue
+++ b/packages/primevue/src/steppanel/StepPanel.vue
@@ -96,7 +96,7 @@ export default {
             return {
                 id: this.id,
                 role: 'tabpanel',
-                'aria-controls': this.ariaControls,
+                'aria-labelledby': this.ariaControls,
                 'data-pc-name': 'steppanel',
                 'data-p-active': this.active
             };

--- a/packages/primevue/src/stepper/Stepper.vue
+++ b/packages/primevue/src/stepper/Stepper.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="cx('root')" role="tablist" v-bind="ptmi('root')">
+    <div :class="cx('root')" v-bind="ptmi('root')">
         <slot v-if="$slots.start" name="start" />
         <slot />
         <slot v-if="$slots.end" name="end" />


### PR DESCRIPTION
### Defect Fixes

Fixed several a11y accessibility violations inside the Stepper component.

Axe Dev tools issues count went from 25 to 21 as a result of these changes.

A11y issues fixed:

- Certain ARIA roles must contain particular children
- ARIA attributes must conform to valid values

Related issue fixes: https://github.com/primefaces/primeng/issues/17669

### Feature Requests

Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
