### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/apps/showcase/doc/vite/DownloadDoc.vue
+++ b/apps/showcase/doc/vite/DownloadDoc.vue
@@ -19,6 +19,9 @@ yarn add primevue @primeuix/themes
 
 # Using pnpm
 pnpm add primevue @primeuix/themes
+
+# Using deno
+deno add primevue @primeuix/themes
 `
             }
         };


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, yarn, and pnpm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno add primevue @primeuix/themes
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install primevue`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
