### PR TITLE
fix(select): pass select context via getPTOptions to all inner sections

### DIFF
--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -296,7 +296,7 @@ export default {
         getPTOptions(key) {
             return this.ptm(key, {
                 context: {
-                    option: this.visibleOptions.findIndex((option) => this.isValidSelectedOption(option)),
+                    option: this.visibleOptions.find((option) => this.isValidSelectedOption(option)),
                     index: this.findSelectedOptionIndex(),
                     selected: true,
                     focused: false,

--- a/packages/primevue/src/select/Select.vue
+++ b/packages/primevue/src/select/Select.vue
@@ -1,5 +1,5 @@
 <template>
-    <div ref="container" :id="$id" :class="cx('root')" @click="onContainerClick" :data-p="containerDataP" v-bind="ptmi('root')">
+    <div ref="container" :id="$id" :class="cx('root')" @click="onContainerClick" :data-p="containerDataP" v-bind="getPTOptions('root')">
         <input
             v-if="editable"
             ref="focusInput"
@@ -26,7 +26,7 @@
             @keydown="onKeyDown"
             @input="onEditableInput"
             :data-p="labelDataP"
-            v-bind="ptm('label')"
+            v-bind="getPTOptions('label')"
         />
         <span
             v-else
@@ -49,25 +49,25 @@
             @blur="onBlur"
             @keydown="onKeyDown"
             :data-p="labelDataP"
-            v-bind="ptm('label')"
+            v-bind="getPTOptions('label')"
         >
             <slot name="value" :value="d_value" :placeholder="placeholder">{{ label === 'p-emptylabel' ? '&nbsp;' : (label ?? 'empty') }}</slot>
         </span>
         <slot v-if="isClearIconVisible" name="clearicon" :class="cx('clearIcon')" :clearCallback="onClearClick">
-            <component :is="clearIcon ? 'i' : 'TimesIcon'" ref="clearIcon" :class="[cx('clearIcon'), clearIcon]" @click="onClearClick" v-bind="ptm('clearIcon')" data-pc-section="clearicon" />
+            <component :is="clearIcon ? 'i' : 'TimesIcon'" ref="clearIcon" :class="[cx('clearIcon'), clearIcon]" @click="onClearClick" v-bind="getPTOptions('clearIcon')" data-pc-section="clearicon" />
         </slot>
-        <div :class="cx('dropdown')" v-bind="ptm('dropdown')">
+        <div :class="cx('dropdown')" v-bind="getPTOptions('dropdown')">
             <slot v-if="loading" name="loadingicon" :class="cx('loadingIcon')">
-                <span v-if="loadingIcon" :class="[cx('loadingIcon'), 'pi-spin', loadingIcon]" aria-hidden="true" v-bind="ptm('loadingIcon')" />
-                <SpinnerIcon v-else :class="cx('loadingIcon')" spin aria-hidden="true" v-bind="ptm('loadingIcon')" />
+                <span v-if="loadingIcon" :class="[cx('loadingIcon'), 'pi-spin', loadingIcon]" aria-hidden="true" v-bind="getPTOptions('loadingIcon')" />
+                <SpinnerIcon v-else :class="cx('loadingIcon')" spin aria-hidden="true" v-bind="getPTOptions('loadingIcon')" />
             </slot>
             <slot v-else name="dropdownicon" :class="cx('dropdownIcon')">
-                <component :is="dropdownIcon ? 'span' : 'ChevronDownIcon'" :class="[cx('dropdownIcon'), dropdownIcon]" aria-hidden="true" :data-p="dropdownIconDataP" v-bind="ptm('dropdownIcon')" />
+                <component :is="dropdownIcon ? 'span' : 'ChevronDownIcon'" :class="[cx('dropdownIcon'), dropdownIcon]" aria-hidden="true" :data-p="dropdownIconDataP" v-bind="getPTOptions('dropdownIcon')" />
             </slot>
         </div>
         <Portal :appendTo="appendTo">
-            <transition name="p-anchored-overlay" @enter="onOverlayEnter" @after-enter="onOverlayAfterEnter" @leave="onOverlayLeave" @after-leave="onOverlayAfterLeave" v-bind="ptm('transition')">
-                <div v-if="overlayVisible" :ref="overlayRef" :class="[cx('overlay'), panelClass, overlayClass]" :style="[panelStyle, overlayStyle]" @click="onOverlayClick" @keydown="onOverlayKeyDown" :data-p="overlayDataP" v-bind="ptm('overlay')">
+            <transition name="p-anchored-overlay" @enter="onOverlayEnter" @after-enter="onOverlayAfterEnter" @leave="onOverlayLeave" @after-leave="onOverlayAfterLeave" v-bind="getPTOptions('transition')">
+                <div v-if="overlayVisible" :ref="overlayRef" :class="[cx('overlay'), panelClass, overlayClass]" :style="[panelStyle, overlayStyle]" @click="onOverlayClick" @keydown="onOverlayKeyDown" :data-p="overlayDataP" v-bind="getPTOptions('overlay')">
                     <span
                         ref="firstHiddenFocusableElementOnOverlay"
                         role="presentation"
@@ -75,13 +75,13 @@
                         class="p-hidden-accessible p-hidden-focusable"
                         :tabindex="0"
                         @focus="onFirstHiddenFocus"
-                        v-bind="ptm('hiddenFirstFocusableEl')"
+                        v-bind="getPTOptions('hiddenFirstFocusableEl')"
                         :data-p-hidden-accessible="true"
                         :data-p-hidden-focusable="true"
                     ></span>
                     <slot name="header" :value="d_value" :options="visibleOptions"></slot>
-                    <div v-if="filter" :class="cx('header')" v-bind="ptm('header')">
-                        <IconField :unstyled="unstyled" :pt="ptm('pcFilterContainer')">
+                    <div v-if="filter" :class="cx('header')" v-bind="getPTOptions('header')">
+                        <IconField :unstyled="unstyled" :pt="getPTOptions('pcFilterContainer')">
                             <InputText
                                 ref="filterInput"
                                 type="text"
@@ -99,24 +99,24 @@
                                 @keydown="onFilterKeyDown"
                                 @blur="onFilterBlur"
                                 @input="onFilterChange"
-                                :pt="ptm('pcFilter')"
+                                :pt="getPTOptions('pcFilter')"
                                 :formControl="{ novalidate: true }"
                             />
-                            <InputIcon :unstyled="unstyled" :pt="ptm('pcFilterIconContainer')">
+                            <InputIcon :unstyled="unstyled" :pt="getPTOptions('pcFilterIconContainer')">
                                 <slot name="filtericon">
-                                    <span v-if="filterIcon" :class="filterIcon" v-bind="ptm('filterIcon')" />
-                                    <SearchIcon v-else v-bind="ptm('filterIcon')" />
+                                    <span v-if="filterIcon" :class="filterIcon" v-bind="getPTOptions('filterIcon')" />
+                                    <SearchIcon v-else v-bind="getPTOptions('filterIcon')" />
                                 </slot>
                             </InputIcon>
                         </IconField>
-                        <span role="status" aria-live="polite" class="p-hidden-accessible" v-bind="ptm('hiddenFilterResult')" :data-p-hidden-accessible="true">
+                        <span role="status" aria-live="polite" class="p-hidden-accessible" v-bind="getPTOptions('hiddenFilterResult')" :data-p-hidden-accessible="true">
                             {{ filterResultMessageText }}
                         </span>
                     </div>
-                    <div :class="cx('listContainer')" :style="{ 'max-height': virtualScrollerDisabled ? scrollHeight : '' }" v-bind="ptm('listContainer')">
-                        <VirtualScroller :ref="virtualScrollerRef" v-bind="virtualScrollerOptions" :items="visibleOptions" :style="{ height: scrollHeight }" :tabindex="-1" :disabled="virtualScrollerDisabled" :pt="ptm('virtualScroller')">
+                    <div :class="cx('listContainer')" :style="{ 'max-height': virtualScrollerDisabled ? scrollHeight : '' }" v-bind="getPTOptions('listContainer')">
+                        <VirtualScroller :ref="virtualScrollerRef" v-bind="virtualScrollerOptions" :items="visibleOptions" :style="{ height: scrollHeight }" :tabindex="-1" :disabled="virtualScrollerDisabled" :pt="getPTOptions('virtualScroller')">
                             <template v-slot:content="{ styleClass, contentRef, items, getItemOptions, contentStyle, itemSize }">
-                                <ul :ref="(el) => listRef(el, contentRef)" :id="$id + '_list'" :class="[cx('list'), styleClass]" :style="contentStyle" role="listbox" v-bind="ptm('list')">
+                                <ul :ref="(el) => listRef(el, contentRef)" :id="$id + '_list'" :class="[cx('list'), styleClass]" :style="contentStyle" role="listbox" v-bind="getPTOptions('list')">
                                     <template v-for="(option, i) of items" :key="getOptionRenderKey(option, getOptionIndex(i, getItemOptions))">
                                         <li
                                             v-if="isOptionGroup(option)"
@@ -124,10 +124,10 @@
                                             :style="{ height: itemSize ? itemSize + 'px' : undefined }"
                                             :class="cx('optionGroup')"
                                             role="option"
-                                            v-bind="ptm('optionGroup')"
+                                            v-bind="getPTItemOptions(option, getItemOptions, i, 'optionGroup')"
                                         >
                                             <slot name="optiongroup" :option="option.optionGroup" :index="getOptionIndex(i, getItemOptions)">
-                                                <span :class="cx('optionGroupLabel')" v-bind="ptm('optionGroupLabel')">{{ getOptionGroupLabel(option.optionGroup) }}</span>
+                                                <span :class="cx('optionGroupLabel')" v-bind="getPTItemOptions(option, getItemOptions, i, 'optionGroupLabel')">{{ getOptionGroupLabel(option.optionGroup) }}</span>
                                             </slot>
                                         </li>
                                         <li
@@ -151,18 +151,18 @@
                                             v-bind="getPTItemOptions(option, getItemOptions, i, 'option')"
                                         >
                                             <template v-if="checkmark">
-                                                <CheckIcon v-if="isSelected(option)" :class="cx('optionCheckIcon')" v-bind="ptm('optionCheckIcon')" />
-                                                <BlankIcon v-else :class="cx('optionBlankIcon')" v-bind="ptm('optionBlankIcon')" />
+                                                <CheckIcon v-if="isSelected(option)" :class="cx('optionCheckIcon')" v-bind="getPTItemOptions(option, getItemOptions, i, 'optionCheckIcon')" />
+                                                <BlankIcon v-else :class="cx('optionBlankIcon')" v-bind="getPTItemOptions(option, getItemOptions, i, 'optionBlankIcon')" />
                                             </template>
                                             <slot name="option" :option="option" :selected="isSelected(option)" :index="getOptionIndex(i, getItemOptions)">
-                                                <span :class="cx('optionLabel')" v-bind="ptm('optionLabel')">{{ getOptionLabel(option) }}</span>
+                                                <span :class="cx('optionLabel')" v-bind="getPTItemOptions(option, getItemOptions, i, 'optionLabel')">{{ getOptionLabel(option) }}</span>
                                             </slot>
                                         </li>
                                     </template>
-                                    <li v-if="filterValue && (!items || (items && items.length === 0))" :class="cx('emptyMessage')" role="option" v-bind="ptm('emptyMessage')" :data-p-hidden-accessible="true">
+                                    <li v-if="filterValue && (!items || (items && items.length === 0))" :class="cx('emptyMessage')" role="option" v-bind="getPTOptions('emptyMessage')" :data-p-hidden-accessible="true">
                                         <slot name="emptyfilter">{{ emptyFilterMessageText }}</slot>
                                     </li>
-                                    <li v-else-if="!options || (options && options.length === 0)" :class="cx('emptyMessage')" role="option" v-bind="ptm('emptyMessage')" :data-p-hidden-accessible="true">
+                                    <li v-else-if="!options || (options && options.length === 0)" :class="cx('emptyMessage')" role="option" v-bind="getPTOptions('emptyMessage')" :data-p-hidden-accessible="true">
                                         <slot name="empty">{{ emptyMessageText }}</slot>
                                     </li>
                                 </ul>
@@ -173,10 +173,10 @@
                         </VirtualScroller>
                     </div>
                     <slot name="footer" :value="d_value" :options="visibleOptions"></slot>
-                    <span v-if="!options || (options && options.length === 0)" role="status" aria-live="polite" class="p-hidden-accessible" v-bind="ptm('hiddenEmptyMessage')" :data-p-hidden-accessible="true">
+                    <span v-if="!options || (options && options.length === 0)" role="status" aria-live="polite" class="p-hidden-accessible" v-bind="getPTOptions('hiddenEmptyMessage')" :data-p-hidden-accessible="true">
                         {{ emptyMessageText }}
                     </span>
-                    <span role="status" aria-live="polite" class="p-hidden-accessible" v-bind="ptm('hiddenSelectedMessage')" :data-p-hidden-accessible="true">
+                    <span role="status" aria-live="polite" class="p-hidden-accessible" v-bind="getPTOptions('hiddenSelectedMessage')" :data-p-hidden-accessible="true">
                         {{ selectedMessageText }}
                     </span>
                     <span
@@ -186,7 +186,7 @@
                         class="p-hidden-accessible p-hidden-focusable"
                         :tabindex="0"
                         @focus="onLastHiddenFocus"
-                        v-bind="ptm('hiddenLastFocusableEl')"
+                        v-bind="getPTOptions('hiddenLastFocusableEl')"
                         :data-p-hidden-accessible="true"
                         :data-p-hidden-focusable="true"
                     ></span>
@@ -292,6 +292,17 @@ export default {
         },
         getOptionRenderKey(option, index) {
             return (this.dataKey ? resolveFieldData(option, this.dataKey) : this.getOptionLabel(option)) + '_' + index;
+        },
+        getPTOptions(key) {
+            return this.ptm(key, {
+                context: {
+                    option: this.visibleOptions.findIndex((option) => this.isValidSelectedOption(option)),
+                    index: this.findSelectedOptionIndex(),
+                    selected: true,
+                    focused: false,
+                    disabled: false,
+                }
+            });
         },
         getPTItemOptions(option, itemOptions, index, key) {
             return this.ptm(key, {


### PR DESCRIPTION
In Select component, PassThrough property's method expects SelectContext to be available across sections on TypeScript definitions.
However, the context property is actually `undefined` for sections other than option. This causes runtime errors when custom PT methods attempt to access context properties.

This PR serves as a provisional implementation to address the immediate runtime error by introducing a getPTOptions helper method that builds a temporary context for the selected state.

Issue #8606 

## Unclear points

- Context Scope
  Currently, SelectContext seems intrinsically tied to individual options rather than the global component state. Passing option-specific context (like selected or index) to root-level elements or headers may not be semantically correct.

- Type Definitions & Comments
  At the very least, the current type definitions or their internal comments need to be updated to clarify which sections actually receive a context, and what that context contains.


## Fix Details
- Created a temporary getPTOptions(key) method in Select.vue to bridge the gap and inject a basic state context (option, index, selected, focused, disabled) into parent-level sections.

- Replaced standard ptim(...)/ptm(...) bindings with getPTOptions(...) for parent-level sections (e.g., root, label, dropdown, overlay, etc.) to prevent runtime crashes.